### PR TITLE
Ensure that the sensinact-system provider is registered

### DIFF
--- a/platform/sensinact-system/src/test/java/org/eclipse/sensinact/gateway/system/test/TestSensiNactResource.java
+++ b/platform/sensinact-system/src/test/java/org/eclipse/sensinact/gateway/system/test/TestSensiNactResource.java
@@ -27,7 +27,7 @@ public class TestSensiNactResource {
 
     @Test
     public void testSensiNactResource(@InjectService(timeout = 500) Core core) throws Throwable {
-    	
+    	Thread.sleep(1000);
     	Session session = core.getAnonymousSession();
     	
     	DescribeResponse<JsonObject> provider = session.getProvider("sensiNact");


### PR DESCRIPTION
This is a quick and dirty workaround for the fact that the sensiNact provider sometimes fails to register properly. The model management code needs a significant overhaul

Signed-off-by: Tim Ward <timothyjward@apache.org>