### PR TITLE
[HTTP Device Factory] Avoid directly implementing ManagedServiceFactory

### DIFF
--- a/platform/southbound/http/http-device-factory/src/test/java/org/eclipse/sensinact/gateway/sthbnd/http/factory/test/HttpDeviceFactoryTest.java
+++ b/platform/southbound/http/http-device-factory/src/test/java/org/eclipse/sensinact/gateway/sthbnd/http/factory/test/HttpDeviceFactoryTest.java
@@ -138,7 +138,7 @@ public class HttpDeviceFactoryTest {
 	private Session expectNServiceProviders(int targetSize) {
 		Session session = core.getAnonymousSession();
 		
-		for(int i = 0; i < 10; i++) {
+		for(int i = 0; i < 20; i++) {
 			if(session.serviceProviders().size() == targetSize) {
 				break;
 			}

--- a/platform/southbound/http/http-device/src/main/java/org/eclipse/sensinact/gateway/sthbnd/http/smpl/SimpleHttpProtocolStackEndpoint.java
+++ b/platform/southbound/http/http-device/src/main/java/org/eclipse/sensinact/gateway/sthbnd/http/smpl/SimpleHttpProtocolStackEndpoint.java
@@ -10,6 +10,7 @@
 package org.eclipse.sensinact.gateway.sthbnd.http.smpl;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -103,7 +104,7 @@ public class SimpleHttpProtocolStackEndpoint extends HttpProtocolStackEndpoint {
         this.recurrences = new LinkedList<>();
         this.adapters = new HashMap<>();
         this.builders = new HashMap<>();
-        this.recurrenceTasks = new HashSet<>();
+        this.recurrenceTasks = Collections.synchronizedSet(new HashSet<>());
         this.worker = Executors.newScheduledThreadPool(3);
         
         //Mediator classloader because we don't need to retrieve
@@ -545,6 +546,11 @@ public class SimpleHttpProtocolStackEndpoint extends HttpProtocolStackEndpoint {
 			Thread.currentThread().interrupt();
 		}
         worker.shutdownNow();
+        try {
+        	worker.awaitTermination(1000, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+        	Thread.currentThread().interrupt();
+        }
         super.stop();
     }
 }


### PR DESCRIPTION
We can rely upon Declarative Services to correctly manage the lifecycle of our configurations

Also improve thread safety in the Http Device, and relax the timings in the unit tests

Signed-off-by: Tim Ward <timothyjward@apache.org>