### PR TITLE
add org.eclipse.dash plugin

### DIFF
--- a/prototype/pom.xml
+++ b/prototype/pom.xml
@@ -177,6 +177,13 @@
         <enabled>true</enabled>
       </snapshots>
     </pluginRepository>
+    <pluginRepository>
+		<id>dash-licenses-snapshots</id>
+		<url>https://repo.eclipse.org/content/repositories/dash-licenses-snapshots/</url>
+		<snapshots>
+			<enabled>true</enabled>
+		</snapshots>
+	</pluginRepository>
   </pluginRepositories>
 
   <dependencyManagement>
@@ -488,5 +495,21 @@
         </plugin>
       </plugins>
     </pluginManagement>
+    <plugins>
+		<!-- https://github.com/eclipse/dash-licenses/blob/master/README.md#maven-plugin-options -->
+		<plugin>
+			<groupId>org.eclipse.dash</groupId>
+			<artifactId>license-tool-plugin</artifactId>
+			<version>0.0.1-SNAPSHOT</version>
+			<executions>
+				<execution>
+					<id>license-check</id>
+					<goals>
+						<goal>license-check</goal>
+					</goals>
+				</execution>
+			</executions>
+		</plugin>
+	</plugins>
   </build>
 </project>


### PR DESCRIPTION
adds org.eclipse.dash plugin.
```
The Eclipse Dash License Tool identifies the licenses of content. It is intended primarily for use by Eclipse committers to vet third party content used by their Eclipse open source project.
```

docs:
`https://github.com/eclipse/dash-licenses/blob/master/README.md#maven-plugin-options`

command:
`mvn org.eclipse.dash:license-tool-plugin:license-check -Ddash.summary=DEPENDENCIES`

out:
```
[INFO] --- license-tool-plugin:0.0.1-SNAPSHOT:license-check (default-cli) @ sensinact-parent ---
[INFO] Querying Eclipse Foundation for license data for 67 items.
[INFO] Found 33 items.
[INFO] Querying ClearlyDefined for license data for 34 items.
[INFO] Found 34 items.
[INFO] License information could not be automatically verified for the following content:
[INFO] 
[INFO] maven/mavencentral/org.geckoprojects.emf/org.gecko.emf.osgi.api/4.2.0-20221010.204304-9
[INFO] maven/mavencentral/org.geckoprojects.emf/org.gecko.emf.osgi.bnd.library.project/4.2.0-20221010.204312-9
[INFO] maven/mavencentral/org.geckoprojects.emf/org.gecko.emf.osgi.bnd.templates.project/4.2.0-20221010.204331-9
[INFO] maven/mavencentral/org.geckoprojects.emf/org.gecko.emf.osgi.bom/4.2.0-20221010.204337-9
[INFO] maven/mavencentral/org.geckoprojects.emf/org.gecko.emf.osgi.codegen/4.2.0-20221010.204343-9
[INFO] maven/mavencentral/org.geckoprojects.emf/org.gecko.emf.osgi.component/4.2.0-20221010.204307-9
[INFO] maven/mavencentral/org.geckoprojects.emf/org.gecko.emf.osgi.doc.mermaid/4.2.0-20221010.204350-9
[INFO] maven/mavencentral/org.geckoprojects.emf/org.gecko.emf.osgi.doc.plantuml/4.2.0-20221010.204403-9
[INFO] maven/mavencentral/org.geckoprojects.emf/org.gecko.emf.osgi.model.info/4.2.0-20221010.204444-6
[INFO] maven/mavencentral/org.osgi/org.osgi.service.typedevent/1.0.0
[INFO] 
[INFO] This content is either not correctly mapped by the system, or requires review.
[INFO] Summary file was written to: /home/stbischof/dev/git/org.eclipse.sensinact.gateway/prototype/DEPENDENCIES

```


Discussion:

Would we also add this into out ci build?
```
# This workflow will check for Maven projects if the licenses of all (transitive) dependencies are vetted.
name: License vetting status check
on:
  push:
    branches: 
      - 'master'
  pull_request:
    branches: 
     - 'master'
  issue_comment:
    types: [created]
jobs:
  call-license-check:
    uses: eclipse/dash-licenses/.github/workflows/mavenLicenseCheck.yml@master
    with:
      projectId: <PROJECT-ID>
    secrets:
      gitlabAPIToken: ${{ secrets.<PROJECT-NAME>_GITLAB_API_TOKEN }}
```


Complete Result:
```
maven/mavencentral/biz.aQute.bnd/aQute.libg/6.1.0, Apache-2.0 OR EPL-2.0, approved, clearlydefined
maven/mavencentral/biz.aQute.bnd/biz.aQute.bnd.util/6.1.0, Apache-2.0 OR EPL-2.0, approved, clearlydefined
maven/mavencentral/biz.aQute.bnd/biz.aQute.bndlib/6.1.0, Apache-2.0 OR EPL-2.0, approved, clearlydefined
maven/mavencentral/org.apache.felix/org.apache.felix.configadmin/1.9.22, Apache-2.0, approved, clearlydefined
maven/mavencentral/org.eclipse.emf/org.eclipse.emf.codegen.ecore/2.28.0, EPL-2.0, approved, modeling.emf.emf
maven/mavencentral/org.eclipse.emf/org.eclipse.emf.codegen/2.22.0, EPL-2.0, approved, modeling.emf.emf
maven/mavencentral/org.eclipse.emf/org.eclipse.emf.common/2.23.0, EPL-2.0, approved, modeling.emf.emf
maven/mavencentral/org.eclipse.emf/org.eclipse.emf.ecore.xmi/2.16.0, EPL-2.0, approved, modeling.emf.emf
maven/mavencentral/org.eclipse.emf/org.eclipse.emf.ecore/2.25.0, EPL-2.0, approved, modeling.emf.emf
maven/mavencentral/org.eclipse.jdt/org.eclipse.jdt.core/3.31.0, EPL-2.0, approved, eclipse.jdt
maven/mavencentral/org.eclipse.jdt/org.eclipse.jdt.debug/3.19.300, EPL-2.0, approved, eclipse.jdt
maven/mavencentral/org.eclipse.jdt/org.eclipse.jdt.launching/3.19.700, EPL-2.0, approved, eclipse.jdt
maven/mavencentral/org.eclipse.platform/org.eclipse.core.commands/3.10.200, EPL-2.0, approved, eclipse.platform
maven/mavencentral/org.eclipse.platform/org.eclipse.core.contenttype/3.8.200, EPL-2.0, approved, eclipse.platform
maven/mavencentral/org.eclipse.platform/org.eclipse.core.expressions/3.7.100, EPL-2.0, approved, eclipse.platform
maven/mavencentral/org.eclipse.platform/org.eclipse.core.filesystem/1.9.0, EPL-2.0, approved, eclipse.platform
maven/mavencentral/org.eclipse.platform/org.eclipse.core.jobs/3.13.100, EPL-2.0, approved, eclipse.platform
maven/mavencentral/org.eclipse.platform/org.eclipse.core.resources/3.18.0, EPL-2.0, approved, eclipse.platform
maven/mavencentral/org.eclipse.platform/org.eclipse.core.runtime/3.26.0, EPL-2.0, approved, eclipse.platform
maven/mavencentral/org.eclipse.platform/org.eclipse.core.variables/3.5.100, EPL-2.0, approved, eclipse.platform
maven/mavencentral/org.eclipse.platform/org.eclipse.debug.core/3.20.0, EPL-2.0, approved, eclipse.platform
maven/mavencentral/org.eclipse.platform/org.eclipse.equinox.app/1.6.200, EPL-2.0, approved, eclipse.platform
maven/mavencentral/org.eclipse.platform/org.eclipse.equinox.common/3.16.200, EPL-2.0, approved, eclipse.platform
maven/mavencentral/org.eclipse.platform/org.eclipse.equinox.preferences/3.10.100, EPL-2.0, approved, eclipse.platform
maven/mavencentral/org.eclipse.platform/org.eclipse.equinox.registry/3.11.200, EPL-2.0, approved, eclipse.platform
maven/mavencentral/org.eclipse.platform/org.eclipse.osgi/3.18.100, EPL-2.0, approved, eclipse.platform
maven/mavencentral/org.eclipse.platform/org.eclipse.text/3.11.0, EPL-2.0, approved, eclipse.platform
maven/mavencentral/org.eclipse.sensinact.gateway.core/annotation/0.0.1-20221025.184540-7, EPL-1.0, approved, technology.sensinact
maven/mavencentral/org.eclipse.sensinact.gateway.core/api/0.0.1-20221025.184540-7, EPL-1.0, approved, technology.sensinact
maven/mavencentral/org.eclipse.sensinact.gateway.core/models/0.0.1-20221026.124845-8, EPL-1.0, approved, technology.sensinact
maven/mavencentral/org.freemarker/freemarker/2.3.31, Apache-2.0, approved, CQ24213
maven/mavencentral/org.geckoprojects.emf/org.gecko.emf.osgi.api/4.2.0-20221010.204304-9, , restricted, clearlydefined
maven/mavencentral/org.geckoprojects.emf/org.gecko.emf.osgi.bnd.library.project/4.2.0-20221010.204312-9, , restricted, clearlydefined
maven/mavencentral/org.geckoprojects.emf/org.gecko.emf.osgi.bnd.templates.project/4.2.0-20221010.204331-9, , restricted, clearlydefined
maven/mavencentral/org.geckoprojects.emf/org.gecko.emf.osgi.bom/4.2.0-20221010.204337-9, , restricted, clearlydefined
maven/mavencentral/org.geckoprojects.emf/org.gecko.emf.osgi.codegen/4.2.0-20221010.204343-9, , restricted, clearlydefined
maven/mavencentral/org.geckoprojects.emf/org.gecko.emf.osgi.component/4.2.0-20221010.204307-9, , restricted, clearlydefined
maven/mavencentral/org.geckoprojects.emf/org.gecko.emf.osgi.doc.mermaid/4.2.0-20221010.204350-9, , restricted, clearlydefined
maven/mavencentral/org.geckoprojects.emf/org.gecko.emf.osgi.doc.plantuml/4.2.0-20221010.204403-9, , restricted, clearlydefined
maven/mavencentral/org.geckoprojects.emf/org.gecko.emf.osgi.model.info/4.2.0-20221010.204444-6, , restricted, clearlydefined
maven/mavencentral/org.osgi/org.osgi.annotation.bundle/1.0.0, Apache-2.0, approved, clearlydefined
maven/mavencentral/org.osgi/org.osgi.annotation.versioning/1.0.0, Apache-2.0, approved, #1762
maven/mavencentral/org.osgi/org.osgi.dto/1.0.0, Apache-2.0, approved, clearlydefined
maven/mavencentral/org.osgi/org.osgi.framework/1.9.0, Apache-2.0, approved, clearlydefined
maven/mavencentral/org.osgi/org.osgi.namespace.extender/1.0.1, Apache-2.0, approved, clearlydefined
maven/mavencentral/org.osgi/org.osgi.namespace.implementation/1.0.0, Apache-2.0, approved, clearlydefined
maven/mavencentral/org.osgi/org.osgi.namespace.service/1.0.0, Apache-2.0, approved, clearlydefined
maven/mavencentral/org.osgi/org.osgi.resource/1.0.0, Apache-2.0, approved, #258
maven/mavencentral/org.osgi/org.osgi.service.cm/1.6.0, Apache-2.0, approved, clearlydefined
maven/mavencentral/org.osgi/org.osgi.service.component.annotations/1.5.0, Apache-2.0, approved, clearlydefined
maven/mavencentral/org.osgi/org.osgi.service.component/1.5.0, Apache-2.0, approved, clearlydefined
maven/mavencentral/org.osgi/org.osgi.service.condition/1.0.0, Apache-2.0, approved, clearlydefined
maven/mavencentral/org.osgi/org.osgi.service.log/1.3.0, Apache-2.0, approved, clearlydefined
maven/mavencentral/org.osgi/org.osgi.service.metatype.annotations/1.4.0, Apache-2.0, approved, clearlydefined
maven/mavencentral/org.osgi/org.osgi.service.prefs/1.1.2, Apache-2.0, approved, #2451
maven/mavencentral/org.osgi/org.osgi.service.repository/1.1.0, Apache-2.0, approved, clearlydefined
maven/mavencentral/org.osgi/org.osgi.service.typedevent/1.0.0, Apache-2.0, restricted, clearlydefined
maven/mavencentral/org.osgi/org.osgi.util.converter/1.0.1, Apache-2.0, approved, clearlydefined
maven/mavencentral/org.osgi/org.osgi.util.function/1.0.0, Apache-2.0, approved, clearlydefined
maven/mavencentral/org.osgi/org.osgi.util.function/1.1.0, Apache-2.0, approved, clearlydefined
maven/mavencentral/org.osgi/org.osgi.util.promise/1.2.0, Apache-2.0, approved, clearlydefined
maven/mavencentral/org.osgi/org.osgi.util.pushstream/1.0.1, Apache-2.0, approved, #2441
maven/mavencentral/org.osgi/org.osgi.util.tracker/1.5.4, Apache-2.0, approved, clearlydefined
maven/mavencentral/org.osgi/osgi.annotation/7.0.0, Apache-2.0, approved, clearlydefined
maven/mavencentral/org.osgi/osgi.core/7.0.0, Apache-2.0, approved, clearlydefined
maven/mavencentral/org.slf4j/slf4j-api/1.7.25, MIT, approved, CQ13368
maven/mavencentral/org.slf4j/slf4j-simple/1.7.25, MIT, approved, CQ7952

```

