### PR TITLE
Avoid scanning snapshot artifacts

### DIFF
--- a/.github/workflows/eclipse_ip.yml
+++ b/.github/workflows/eclipse_ip.yml
@@ -20,4 +20,6 @@ jobs:
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven
-      run: mvn -B org.eclipse.dash:license-tool-plugin:license-check -Dlicenses-check -Ddash.fail=true -Ddash.summary=DEPENDENCIES -P eclipse-licenses-check --file prototype/pom.xml
+      run: mvn -B org.eclipse.dash:license-tool-plugin:license-check -Dlicenses-check -Ddash.fail=true -Ddash.summary=DEPENDENCIES -DexcludeArtifactIds=$EXCLUDED_ARTIFACTS -P eclipse-licenses-check --file prototype/pom.xml
+      env:
+        EXCLUDED_ARTIFACTS: 'org.osgi.service.jakartars'


### PR DESCRIPTION
Prevent Dash Errors for snapshot artifacts that we know to be safe.

Signed-off-by: Tim Ward <timothyjward@apache.org>