### PR TITLE
Core update for SensorThings

### DIFF
--- a/prototype/core/api/src/main/java/org/eclipse/sensinact/prototype/command/SensinactResource.java
+++ b/prototype/core/api/src/main/java/org/eclipse/sensinact/prototype/command/SensinactResource.java
@@ -8,7 +8,7 @@
 * SPDX-License-Identifier: EPL-2.0
 *
 * Contributors:
-*   Kentyou - initial implementation 
+*   Kentyou - initial implementation
 **********************************************************************/
 package org.eclipse.sensinact.prototype.command;
 
@@ -26,7 +26,7 @@ public interface SensinactResource extends CommandScoped, Resource {
 
     Promise<Void> setValue(Object value, Instant timestamp);
 
-    Promise<Object> getValue();
+    Promise<TimedValue<?>> getValue();
 
     Promise<Void> setMetadataValue(String name, Object value, Instant timestamp);
 

--- a/prototype/core/geo-json/src/main/java/org/eclipse/sensinact/gateway/geojson/Coordinates.java
+++ b/prototype/core/geo-json/src/main/java/org/eclipse/sensinact/gateway/geojson/Coordinates.java
@@ -35,5 +35,5 @@ public class Coordinates {
     /**
      * The elevation will be {@link Double#NaN} if not set
      */
-    public double elevation;
+    public double elevation = Double.NaN;
 }

--- a/prototype/core/models/src/main/resources/model/sensinact.ecore
+++ b/prototype/core/models/src/main/resources/model/sensinact.ecore
@@ -22,6 +22,8 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="feature" eType="ecore:EClass http://www.eclipse.org/emf/2002/Ecore#//EStructuralFeature"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="timestamp" eType="#//EInstant"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="source" eType="ecore:EClass http://www.eclipse.org/emf/2002/Ecore#//EObject"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="extra" upperBound="-1"
+        eType="#//FeatureCustomMetadata"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="FeatureMetadata" instanceClassName="java.util.Map$Entry">
     <eStructuralFeatures xsi:type="ecore:EReference" name="key" eType="ecore:EClass http://www.eclipse.org/emf/2002/Ecore#//EStructuralFeature"/>
@@ -32,4 +34,9 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="version" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EInt"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="EInstant" instanceClassName="java.time.Instant"/>
+  <eClassifiers xsi:type="ecore:EClass" name="FeatureCustomMetadata">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="value" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EJavaObject"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="timestamp" eType="#//EInstant"/>
+  </eClassifiers>
 </ecore:EPackage>

--- a/prototype/core/models/src/main/resources/model/sensinact.genmodel
+++ b/prototype/core/models/src/main/resources/model/sensinact.genmodel
@@ -25,6 +25,7 @@
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference sensinact.ecore#//Metadata/feature"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute sensinact.ecore#//Metadata/timestamp"/>
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference sensinact.ecore#//Metadata/source"/>
+      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference sensinact.ecore#//Metadata/extra"/>
     </genClasses>
     <genClasses ecoreClass="sensinact.ecore#//FeatureMetadata">
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference sensinact.ecore#//FeatureMetadata/key"/>
@@ -32,6 +33,11 @@
     </genClasses>
     <genClasses ecoreClass="sensinact.ecore#//ModelMetadata">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute sensinact.ecore#//ModelMetadata/version"/>
+    </genClasses>
+    <genClasses ecoreClass="sensinact.ecore#//FeatureCustomMetadata">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute sensinact.ecore#//FeatureCustomMetadata/name"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute sensinact.ecore#//FeatureCustomMetadata/value"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute sensinact.ecore#//FeatureCustomMetadata/timestamp"/>
     </genClasses>
   </genPackages>
 </genmodel:GenModel>


### PR DESCRIPTION
* Added an `extra` field to `Metadata`, allowing to add timestamped custom metadata to a resource
* `Resource.getValue()` now returns `TimedValue` to include its timestamp
* `SensiNactModelImpl.getResourceValue()` now reject null value type argument. Explicitly use `java.lang.Object` instead.
* GeoJson coordinates elevation is initialized to NaN to respect its documentation