### PR TITLE
Fixes on SensorThings

### DIFF
--- a/prototype/northbound/sensorthings/dto/pom.xml
+++ b/prototype/northbound/sensorthings/dto/pom.xml
@@ -21,6 +21,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.eclipse.sensinact.gateway.core</groupId>
+      <artifactId>geo-json</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>osgi.annotation</artifactId>
     </dependency>
@@ -31,10 +35,6 @@
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>de.grundid.opendatalab</groupId>
-      <artifactId>geojson-jackson</artifactId>
     </dependency>
   </dependencies>
 

--- a/prototype/northbound/sensorthings/dto/src/main/java/org/eclipse/sensinact/sensorthings/sensing/dto/Datastream.java
+++ b/prototype/northbound/sensorthings/dto/src/main/java/org/eclipse/sensinact/sensorthings/sensing/dto/Datastream.java
@@ -17,7 +17,7 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 import java.time.Instant;
 import java.util.Map;
 
-import org.geojson.Polygon;
+import org.eclipse.sensinact.gateway.geojson.Polygon;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/prototype/northbound/sensorthings/dto/src/main/java/org/eclipse/sensinact/sensorthings/sensing/dto/FeatureOfInterest.java
+++ b/prototype/northbound/sensorthings/dto/src/main/java/org/eclipse/sensinact/sensorthings/sensing/dto/FeatureOfInterest.java
@@ -12,7 +12,7 @@
 **********************************************************************/
 package org.eclipse.sensinact.sensorthings.sensing.dto;
 
-import org.geojson.GeoJsonObject;
+import org.eclipse.sensinact.gateway.geojson.GeoJsonObject;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 

--- a/prototype/northbound/sensorthings/dto/src/main/java/org/eclipse/sensinact/sensorthings/sensing/dto/Location.java
+++ b/prototype/northbound/sensorthings/dto/src/main/java/org/eclipse/sensinact/sensorthings/sensing/dto/Location.java
@@ -12,7 +12,7 @@
 **********************************************************************/
 package org.eclipse.sensinact.sensorthings.sensing.dto;
 
-import org.geojson.GeoJsonObject;
+import org.eclipse.sensinact.gateway.geojson.GeoJsonObject;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 

--- a/prototype/northbound/sensorthings/dto/src/test/java/org/eclipse/sensinact/sensorthings/sensing/dto/JsonMappingTest.java
+++ b/prototype/northbound/sensorthings/dto/src/test/java/org/eclipse/sensinact/sensorthings/sensing/dto/JsonMappingTest.java
@@ -23,9 +23,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.sensinact.gateway.geojson.Coordinates;
+import org.eclipse.sensinact.gateway.geojson.Point;
 import org.eclipse.sensinact.sensorthings.sensing.dto.RootResponse.NameUrl;
-import org.geojson.LngLatAlt;
-import org.geojson.Point;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -141,8 +141,8 @@ class JsonMappingTest {
             assertEquals(name, location.name);
             assertEquals("application/vnd.geo+json", location.encodingType);
             assertInstanceOf(Point.class, location.location);
-            assertEquals(longitude, ((Point)location.location).getCoordinates().getLongitude());
-            assertEquals(latitude, ((Point)location.location).getCoordinates().getLatitude());
+            assertEquals(longitude, ((Point)location.location).coordinates.longitude);
+            assertEquals(latitude, ((Point)location.location).coordinates.latitude);
             assertEquals(things, location.thingsLink);
             assertEquals(historicalLocations, location.historicalLocationsLink);
         }
@@ -359,8 +359,8 @@ class JsonMappingTest {
             assertEquals(description, featureOfInterest.description);
             assertEquals("application/vnd.geo+json", featureOfInterest.encodingType);
             assertInstanceOf(Point.class, featureOfInterest.feature);
-            assertEquals(longitude, ((Point)featureOfInterest.feature).getCoordinates().getLongitude());
-            assertEquals(latitude, ((Point)featureOfInterest.feature).getCoordinates().getLatitude());
+            assertEquals(longitude, ((Point)featureOfInterest.feature).coordinates.longitude);
+            assertEquals(latitude, ((Point)featureOfInterest.feature).coordinates.latitude);
             assertEquals(observations, featureOfInterest.observationsLink);
         }
     }
@@ -397,7 +397,9 @@ class JsonMappingTest {
             location.historicalLocationsLink = "https://toronto-bike-snapshot.sensorup.com/v1.0/Locations(206048)/HistoricalLocations";
 
             Point point = new Point();
-            point.setCoordinates(new LngLatAlt(-79.407224, 43.665876));
+            point.coordinates = new Coordinates();
+            point.coordinates.longitude = -79.407224;
+            point.coordinates.latitude = 43.665876;
 
             location.location = point;
 
@@ -499,7 +501,9 @@ class JsonMappingTest {
             featureOfInterest.observationsLink = "https://toronto-bike-snapshot.sensorup.com/v1.0/FeaturesOfInterest(1514)/Observations";
 
             Point point = new Point();
-            point.setCoordinates(new LngLatAlt(-79.424557, 43.650978));
+            point.coordinates = new Coordinates();
+            point.coordinates.longitude = -79.424557;
+            point.coordinates.latitude = 43.650978;
 
             featureOfInterest.feature = point;
 

--- a/prototype/northbound/sensorthings/pom.xml
+++ b/prototype/northbound/sensorthings/pom.xml
@@ -30,7 +30,6 @@
 
   <properties>
     <sensinact.core.version>0.0.1-SNAPSHOT</sensinact.core.version>
-    <jackson.version>2.13.4</jackson.version>
   </properties>
 
   <dependencyManagement>
@@ -38,6 +37,11 @@
       <dependency>
         <groupId>org.eclipse.sensinact.gateway.core</groupId>
         <artifactId>api</artifactId>
+        <version>${sensinact.core.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.sensinact.gateway.core</groupId>
+        <artifactId>geo-json</artifactId>
         <version>${sensinact.core.version}</version>
       </dependency>
       <dependency>
@@ -69,11 +73,6 @@
         <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
         <artifactId>jackson-jakarta-rs-json-provider</artifactId>
         <version>${jackson.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>de.grundid.opendatalab</groupId>
-        <artifactId>geojson-jackson</artifactId>
-        <version>1.14</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/prototype/northbound/sensorthings/rest.api/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/annotation/PropFilter.java
+++ b/prototype/northbound/sensorthings/rest.api/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/annotation/PropFilter.java
@@ -12,6 +12,9 @@
 **********************************************************************/
 package org.eclipse.sensinact.sensorthings.sensing.rest.annotation;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
 import jakarta.ws.rs.NameBinding;
 
 /**
@@ -20,6 +23,7 @@ import jakarta.ws.rs.NameBinding;
  * output to contain only the named property
  */
 @NameBinding
+@Retention(RetentionPolicy.RUNTIME)
 public @interface PropFilter {
 
 }

--- a/prototype/northbound/sensorthings/rest.api/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/annotation/RefFilter.java
+++ b/prototype/northbound/sensorthings/rest.api/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/annotation/RefFilter.java
@@ -12,6 +12,9 @@
 **********************************************************************/
 package org.eclipse.sensinact.sensorthings.sensing.rest.annotation;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
 import jakarta.ws.rs.NameBinding;
 
 /**
@@ -19,6 +22,7 @@ import jakarta.ws.rs.NameBinding;
  * should be filtered to contain only the self link
  */
 @NameBinding
+@Retention(RetentionPolicy.RUNTIME)
 public @interface RefFilter {
 
 }

--- a/prototype/northbound/sensorthings/rest.api/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/filters/CountFilter.java
+++ b/prototype/northbound/sensorthings/rest.api/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/filters/CountFilter.java
@@ -40,7 +40,7 @@ public class CountFilter implements ContainerRequestFilter, ContainerResponseFil
             throws IOException {
         Boolean addCount = (Boolean) requestContext.getProperty(COUNT_PROP);
 
-        if(addCount) {
+        if(addCount != null && addCount) {
             Object entity = responseContext.getEntity();
             if(entity instanceof ResultList) {
                 ResultList<?> resultList = (ResultList<?>) entity;
@@ -53,7 +53,7 @@ public class CountFilter implements ContainerRequestFilter, ContainerResponseFil
     public void filter(ContainerRequestContext requestContext) throws IOException {
         boolean addCount = false;
 
-        List<String> list = requestContext.getUriInfo().getQueryParameters().get("$count");
+        List<String> list = requestContext.getUriInfo().getQueryParameters().getOrDefault("$count", List.of());
         if(list.size() > 1) {
             requestContext.abortWith(Response
                     .status(Status.BAD_REQUEST)

--- a/prototype/northbound/sensorthings/rest.api/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/filters/ExpandFilter.java
+++ b/prototype/northbound/sensorthings/rest.api/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/filters/ExpandFilter.java
@@ -40,7 +40,7 @@ public class ExpandFilter implements ContainerRequestFilter, ContainerResponseFi
     @Override
     public void filter(ContainerRequestContext requestContext) throws IOException {
 
-        List<String> list = requestContext.getUriInfo().getQueryParameters().get("$expand");
+        List<String> list = requestContext.getUriInfo().getQueryParameters().getOrDefault("$expand", List.of());
         if (!list.isEmpty()) {
             requestContext.abortWith(Response
                     .status(Status.NOT_IMPLEMENTED)

--- a/prototype/northbound/sensorthings/rest.api/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/filters/FilterFilter.java
+++ b/prototype/northbound/sensorthings/rest.api/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/filters/FilterFilter.java
@@ -40,7 +40,7 @@ public class FilterFilter implements ContainerRequestFilter, ContainerResponseFi
     @Override
     public void filter(ContainerRequestContext requestContext) throws IOException {
 
-        List<String> list = requestContext.getUriInfo().getQueryParameters().get("$filter");
+        List<String> list = requestContext.getUriInfo().getQueryParameters().getOrDefault("$filter", List.of());
         if (!list.isEmpty()) {
             requestContext.abortWith(Response
                     .status(Status.NOT_IMPLEMENTED)

--- a/prototype/northbound/sensorthings/rest.api/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/filters/OrderByFilter.java
+++ b/prototype/northbound/sensorthings/rest.api/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/filters/OrderByFilter.java
@@ -61,10 +61,7 @@ public class OrderByFilter implements ContainerRequestFilter, ContainerResponseF
 
     @Override
     public void filter(ContainerRequestContext requestContext) throws IOException {
-        List<String> list = requestContext.getUriInfo().getQueryParameters().get("$orderby");
-        if (list == null) {
-            return;
-        }
+        List<String> list = requestContext.getUriInfo().getQueryParameters().getOrDefault("$orderby", List.of());
 
         try {
             Comparator<Object> comparator = list.stream()

--- a/prototype/northbound/sensorthings/rest.api/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/filters/PropFilterImpl.java
+++ b/prototype/northbound/sensorthings/rest.api/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/filters/PropFilterImpl.java
@@ -38,10 +38,8 @@ public class PropFilterImpl implements WriterInterceptor {
         Object entity = context.getEntity();
 
         String propName = uriInfo.getPathParameters().getFirst("prop");
-        if(propName == null) {
-            // No property filter
-            context.proceed();
-            return;
+        if(propName == null || propName.isEmpty()) {
+            throw new BadRequestException("Invalid property filter");
         }
 
         boolean rawValue = uriInfo.getPath().endsWith("/$value");

--- a/prototype/northbound/sensorthings/rest.api/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/filters/PropFilterImpl.java
+++ b/prototype/northbound/sensorthings/rest.api/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/filters/PropFilterImpl.java
@@ -38,6 +38,12 @@ public class PropFilterImpl implements WriterInterceptor {
         Object entity = context.getEntity();
 
         String propName = uriInfo.getPathParameters().getFirst("prop");
+        if(propName == null) {
+            // No property filter
+            context.proceed();
+            return;
+        }
+
         boolean rawValue = uriInfo.getPath().endsWith("/$value");
 
         try {

--- a/prototype/northbound/sensorthings/rest.api/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/filters/RefFilterImpl.java
+++ b/prototype/northbound/sensorthings/rest.api/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/filters/RefFilterImpl.java
@@ -20,6 +20,10 @@ import org.eclipse.sensinact.sensorthings.sensing.dto.ResultList;
 import org.eclipse.sensinact.sensorthings.sensing.dto.Self;
 import org.eclipse.sensinact.sensorthings.sensing.rest.annotation.RefFilter;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.ext.WriterInterceptor;
@@ -50,6 +54,17 @@ public class RefFilterImpl implements WriterInterceptor {
             Self newEntity = new Self();
             newEntity.selfLink = self.selfLink;
             context.setEntity(newEntity);
+        } else if(entity instanceof ObjectNode) {
+            ObjectNode node = (ObjectNode) entity;
+            if(!node.isArray()) {
+                node.retain("@iot.selfLink");
+            } else {
+                ArrayNode array = (ArrayNode) entity;
+                for(int i = 0 ; i < array.size() ; i++) {
+                    final JsonNode jsonNode = array.get(i);
+                    array.set(i, ((ObjectNode) jsonNode).get("@iot.selfLink"));
+                }
+            }
         } else if (entity != null) {
             throw new InternalServerErrorException("The entity " + entity + " does not have a reference");
         }

--- a/prototype/northbound/sensorthings/rest.api/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/filters/SkipFilter.java
+++ b/prototype/northbound/sensorthings/rest.api/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/filters/SkipFilter.java
@@ -41,6 +41,9 @@ public class SkipFilter implements ContainerRequestFilter, ContainerResponseFilt
     public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
             throws IOException {
         Integer skip = (Integer) requestContext.getProperty(SKIP_PROP);
+        if (skip == null) {
+            return;
+        }
 
         Object entity = responseContext.getEntity();
         if(entity instanceof ResultList) {
@@ -55,6 +58,10 @@ public class SkipFilter implements ContainerRequestFilter, ContainerResponseFilt
         int skip = 0;
 
         List<String> list = requestContext.getUriInfo().getQueryParameters().get("$skip");
+        if (list == null) {
+            return;
+        }
+
         if(list.size() > 1) {
             requestContext.abortWith(Response
                     .status(Status.BAD_REQUEST)

--- a/prototype/northbound/sensorthings/rest.api/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/filters/TopFilter.java
+++ b/prototype/northbound/sensorthings/rest.api/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/filters/TopFilter.java
@@ -41,6 +41,9 @@ public class TopFilter implements ContainerRequestFilter, ContainerResponseFilte
     public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
             throws IOException {
         Integer top = (Integer) requestContext.getProperty(TOP_PROP);
+        if(top == null) {
+            return;
+        }
 
         Object entity = responseContext.getEntity();
         if(entity instanceof ResultList) {
@@ -55,7 +58,9 @@ public class TopFilter implements ContainerRequestFilter, ContainerResponseFilte
         int top = 0;
 
         List<String> list = requestContext.getUriInfo().getQueryParameters().get("$top");
-        if(list.size() > 1) {
+        if (list == null) {
+            return;
+        } else if (list.size() > 1) {
             requestContext.abortWith(Response
                     .status(Status.BAD_REQUEST)
                     .entity("Only one $top parameter may be provided")

--- a/prototype/northbound/sensorthings/rest.gateway/pom.xml
+++ b/prototype/northbound/sensorthings/rest.gateway/pom.xml
@@ -19,11 +19,22 @@
   </parent>
   <artifactId>rest.gateway</artifactId>
 
+  <properties>
+    <gecko.jersey.version>6.0.0-SNAPSHOT</gecko.jersey.version>
+    <hk2.version>3.0.3</hk2.version>
+    <jersey.version>3.0.8</jersey.version>
+    <jetty.version>11.0.12</jetty.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.eclipse.sensinact.gateway.northbound.sensorthings</groupId>
       <artifactId>rest.api</artifactId>
       <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.sensinact.gateway.core</groupId>
+      <artifactId>geo-json</artifactId>
     </dependency>
     <dependency>
       <groupId>org.eclipse.sensinact.gateway.core</groupId>
@@ -44,6 +55,23 @@
       <plugin>
         <groupId>biz.aQute.bnd</groupId>
         <artifactId>bnd-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-testing-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-resolver-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-run-maven-plugin</artifactId>
+        <version>${bnd.version}</version>
+        <configuration>
+          <includeDependencyManagement>true</includeDependencyManagement>
+          <bndrun>integration-test.bndrun</bndrun>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/prototype/northbound/sensorthings/rest.gateway/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/impl/DatastreamsAccessImpl.java
+++ b/prototype/northbound/sensorthings/rest.gateway/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/impl/DatastreamsAccessImpl.java
@@ -34,29 +34,38 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.UriInfo;
+import jakarta.ws.rs.ext.Providers;
 
 public class DatastreamsAccessImpl implements DatastreamsAccess {
-
-    @Context
-    SensiNactSession userSession;
 
     @Context
     UriInfo uriInfo;
 
     @Context
-    ObjectMapper mapper;
+    Providers providers;
+
+    private ObjectMapper getMapper() {
+        return providers.getContextResolver(ObjectMapper.class, MediaType.WILDCARD_TYPE).getContext(null);
+    }
+
+    private SensiNactSession getSession() {
+        return providers.getContextResolver(SensiNactSession.class, MediaType.WILDCARD_TYPE).getContext(null);
+    }
 
     @Override
     public Datastream getDatastream(String id) {
+        SensiNactSession userSession = getSession();
         String provider = extractFirstIdSegment(id);
         String service = extractFirstIdSegment(id.substring(provider.length() + 1));
         String resource = extractFirstIdSegment(id.substring(provider.length() + service.length() + 2));
-        return DtoMapper.toDatastream(userSession, uriInfo, userSession.describeResource(provider, service, resource));
+        return DtoMapper.toDatastream(userSession, getMapper(), uriInfo, userSession.describeResource(provider, service, resource));
     }
 
     @Override
     public ResultList<Observation> getDatastreamObservations(String id) {
+        SensiNactSession userSession = getSession();
         String provider = extractFirstIdSegment(id);
         String service = extractFirstIdSegment(id.substring(provider.length() + 1));
         String resource = extractFirstIdSegment(id.substring(provider.length() + service.length() + 2));
@@ -69,6 +78,7 @@ public class DatastreamsAccessImpl implements DatastreamsAccess {
 
     @Override
     public Observation getDatastreamObservation(String id, String id2) {
+        SensiNactSession userSession = getSession();
         String provider = extractFirstIdSegment(id);
         String service = extractFirstIdSegment(id.substring(provider.length() + 1));
         String resource = extractFirstIdSegment(id.substring(provider.length() + service.length() + 2));
@@ -88,12 +98,14 @@ public class DatastreamsAccessImpl implements DatastreamsAccess {
 
     @Override
     public FeatureOfInterest getDatastreamObservationFeatureOfInterest(String id, String id2) {
+        SensiNactSession userSession = getSession();
         String provider = extractFirstIdSegment(id);
-        return DtoMapper.toFeatureOfInterest(userSession, uriInfo, mapper, provider);
+        return DtoMapper.toFeatureOfInterest(userSession, uriInfo, getMapper(), provider);
     }
 
     @Override
     public ObservedProperty getDatastreamObservedProperty(String id) {
+        SensiNactSession userSession = getSession();
         String provider = extractFirstIdSegment(id);
         String service = extractFirstIdSegment(id.substring(provider.length() + 1));
         String resource = extractFirstIdSegment(id.substring(provider.length() + service.length() + 2));
@@ -116,6 +128,7 @@ public class DatastreamsAccessImpl implements DatastreamsAccess {
 
     @Override
     public Sensor getDatastreamSensor(String id) {
+        SensiNactSession userSession = getSession();
         String provider = extractFirstIdSegment(id);
         String service = extractFirstIdSegment(id.substring(provider.length() + 1));
         String resource = extractFirstIdSegment(id.substring(provider.length() + service.length() + 2));
@@ -135,12 +148,14 @@ public class DatastreamsAccessImpl implements DatastreamsAccess {
 
     @Override
     public Thing getDatastreamThing(String id) {
+        SensiNactSession userSession = getSession();
         String provider = extractFirstIdSegment(id);
         return DtoMapper.toThing(userSession, uriInfo, provider);
     }
 
     @Override
     public ResultList<Datastream> getDatastreamThingDatastreams(String id) {
+        SensiNactSession userSession = getSession();
         String provider = extractFirstIdSegment(id);
 
         ResultList<Datastream> list = new ResultList<>();
@@ -148,19 +163,20 @@ public class DatastreamsAccessImpl implements DatastreamsAccess {
         list.value = userSession.describeProvider(provider).services.stream()
                 .map(s -> userSession.describeService(provider, s))
                 .flatMap(s -> s.resources.stream().map(r -> userSession.describeResource(s.provider, s.service, r)))
-                .map(r -> DtoMapper.toDatastream(userSession, uriInfo, r)).collect(toList());
+                .map(r -> DtoMapper.toDatastream(userSession, getMapper(), uriInfo, r)).collect(toList());
 
         return list;
     }
 
     @Override
     public ResultList<HistoricalLocation> getDatastreamThingHistoricalLocations(String id) {
+        SensiNactSession userSession = getSession();
         String provider = extractFirstIdSegment(id);
         getTimestampFromId(id);
 
         HistoricalLocation hl;
         try {
-            hl = DtoMapper.toHistoricalLocation(userSession, uriInfo, provider);
+            hl = DtoMapper.toHistoricalLocation(userSession, getMapper(), uriInfo, provider);
         } catch (IllegalArgumentException iae) {
             throw new NotFoundException();
         }
@@ -172,12 +188,13 @@ public class DatastreamsAccessImpl implements DatastreamsAccess {
 
     @Override
     public ResultList<Location> getDatastreamThingLocations(String id) {
+        SensiNactSession userSession = getSession();
         String provider = extractFirstIdSegment(id);
         getTimestampFromId(id);
 
         Location hl;
         try {
-            hl = DtoMapper.toLocation(userSession, uriInfo, mapper, provider);
+            hl = DtoMapper.toLocation(userSession, uriInfo, getMapper(), provider);
         } catch (IllegalArgumentException iae) {
             throw new NotFoundException();
         }

--- a/prototype/northbound/sensorthings/rest.gateway/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/impl/DtoMapper.java
+++ b/prototype/northbound/sensorthings/rest.gateway/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/impl/DtoMapper.java
@@ -16,8 +16,15 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.Objects;
 
+import org.eclipse.sensinact.gateway.geojson.Coordinates;
+import org.eclipse.sensinact.gateway.geojson.Feature;
+import org.eclipse.sensinact.gateway.geojson.FeatureCollection;
+import org.eclipse.sensinact.gateway.geojson.GeoJsonObject;
+import org.eclipse.sensinact.gateway.geojson.Point;
+import org.eclipse.sensinact.gateway.geojson.Polygon;
 import org.eclipse.sensinact.prototype.ResourceDescription;
 import org.eclipse.sensinact.prototype.SensiNactSession;
+import org.eclipse.sensinact.prototype.command.TimedValue;
 import org.eclipse.sensinact.sensorthings.sensing.dto.Datastream;
 import org.eclipse.sensinact.sensorthings.sensing.dto.FeatureOfInterest;
 import org.eclipse.sensinact.sensorthings.sensing.dto.HistoricalLocation;
@@ -26,12 +33,8 @@ import org.eclipse.sensinact.sensorthings.sensing.dto.Observation;
 import org.eclipse.sensinact.sensorthings.sensing.dto.ObservedProperty;
 import org.eclipse.sensinact.sensorthings.sensing.dto.Sensor;
 import org.eclipse.sensinact.sensorthings.sensing.dto.Thing;
-import org.geojson.Feature;
-import org.geojson.FeatureCollection;
-import org.geojson.GeoJsonObject;
-import org.geojson.Point;
-import org.geojson.Polygon;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import jakarta.ws.rs.BadRequestException;
@@ -73,10 +76,10 @@ public class DtoMapper {
     private static String getProperty(GeoJsonObject location, String propName) {
         if (location instanceof Feature) {
             Feature f = (Feature) location;
-            return toString(f.getProperty(propName));
+            return toString(f.properties.get(propName));
         } else if (location instanceof FeatureCollection) {
             FeatureCollection fc = (FeatureCollection) location;
-            return fc.getFeatures().stream().map(f -> toString(f.getProperty(propName))).filter(p -> p != null)
+            return fc.features.stream().map(f -> toString(f.properties.get(propName))).filter(p -> p != null)
                     .findFirst().orElse(null);
         }
         return null;
@@ -86,18 +89,9 @@ public class DtoMapper {
             String providerName) {
         Location location = new Location();
 
-        ResourceDescription locationResource = getProviderAdminField(userSession, providerName, "location");
-
-        Instant time;
-        GeoJsonObject object;
-        if (locationResource.value == null) {
-            object = new Point(0, 0);
-            time = Instant.EPOCH;
-        } else {
-            object = GeoJsonObject.class.isInstance(locationResource.value) ? (GeoJsonObject) locationResource.value
-                    : mapper.convertValue(locationResource.value, GeoJsonObject.class);
-            time = locationResource.timestamp;
-        }
+        final TimedValue<GeoJsonObject> rcLocation = getLocation(userSession, mapper, providerName, false);
+        final Instant time = rcLocation.getTimestamp();
+        final GeoJsonObject object = rcLocation.getValue();
 
         location.id = String.format("%s~%s", providerName, Long.toString(time.toEpochMilli(), 16));
 
@@ -119,17 +113,16 @@ public class DtoMapper {
         return location;
     }
 
-    public static HistoricalLocation toHistoricalLocation(SensiNactSession userSession, UriInfo uriInfo,
-            String providerName) {
+    public static HistoricalLocation toHistoricalLocation(SensiNactSession userSession, ObjectMapper mapper,
+            UriInfo uriInfo, String providerName) {
         HistoricalLocation historicalLocation = new HistoricalLocation();
 
-        ResourceDescription locationResource = getProviderAdminField(userSession, providerName, "location");
-
-        Instant time;
-        if (locationResource.value == null) {
+        TimedValue<GeoJsonObject> location = getLocation(userSession, mapper, providerName, true);
+        final Instant time;
+        if(location == null) {
             time = Instant.EPOCH;
         } else {
-            time = locationResource.timestamp;
+            time = location.getTimestamp();
         }
 
         historicalLocation.id = String.format("%s~%s", providerName, Long.toString(time.toEpochMilli(), 16));
@@ -147,16 +140,17 @@ public class DtoMapper {
     private static Polygon getObservedArea(GeoJsonObject object) {
 
         if (object instanceof Feature) {
-            object = ((Feature) object).getGeometry();
+            object = ((Feature) object).geometry;
         } else if (object instanceof FeatureCollection) {
             // TODO is there a better mapping?
-            object = ((FeatureCollection) object).getFeatures().stream().map(Feature::getGeometry)
+            object = ((FeatureCollection) object).features.stream().map((f) -> f.geometry)
                     .filter(Polygon.class::isInstance).map(Polygon.class::cast).findFirst().orElse(null);
         }
         return object instanceof Polygon ? (Polygon) object : null;
     }
 
-    public static Datastream toDatastream(SensiNactSession userSession, UriInfo uriInfo, ResourceDescription resource) {
+    public static Datastream toDatastream(SensiNactSession userSession, ObjectMapper mapper, UriInfo uriInfo,
+            ResourceDescription resource) {
         Datastream datastream = new Datastream();
 
         datastream.id = String.format("%s~%s~%s", resource.provider, resource.service, resource.resource);
@@ -167,15 +161,16 @@ public class DtoMapper {
         // TODO can we make this more fine-grained
         datastream.observationType = "http://www.opengis.net/def/observationType/OGC-OM/2.0/OM_Observation";
 
-        datastream.unitOfMeasurement = Map.of("symbol", resource.metadata.get("unit"), "name",
-                resource.metadata.get("sensorthings.unit.name"), "definition",
-                resource.metadata.get("sensorthings.unit.definition"));
+        datastream.unitOfMeasurement = Map.of(
+                "symbol", String.valueOf(resource.metadata.get("unit")),
+                "name", String.valueOf(resource.metadata.get("sensorthings.unit.name")),
+                "definition", String.valueOf(resource.metadata.get("sensorthings.unit.definition")));
 
         datastream.observedArea = getObservedArea(
-                (GeoJsonObject) getProviderAdminField(userSession, resource.provider, "location").value);
+                getLocation(userSession, mapper, resource.provider, true).getValue());
         datastream.properties = resource.metadata;
 
-        datastream.selfLink = uriInfo.getBaseUriBuilder().path("v1.1").path("Sensors({id})")
+        datastream.selfLink = uriInfo.getBaseUriBuilder().path("v1.1").path("Datastreams({id})")
                 .resolveTemplate("id", datastream.id).build().toString();
         datastream.observationsLink = uriInfo.getBaseUriBuilder().uri(datastream.selfLink).path("Observations").build()
                 .toString();
@@ -211,7 +206,7 @@ public class DtoMapper {
     public static Observation toObservation(UriInfo uriInfo, ResourceDescription resource) {
         Observation observation = new Observation();
 
-        observation.id = String.format("%s~%s~%s~s", resource.provider, resource.service, resource.resource,
+        observation.id = String.format("%s~%s~%s~%s", resource.provider, resource.service, resource.resource,
                 Long.toString(resource.timestamp.toEpochMilli(), 16));
 
         observation.resultTime = resource.timestamp;
@@ -249,22 +244,60 @@ public class DtoMapper {
         return observedProperty;
     }
 
+    private static TimedValue<GeoJsonObject> getLocation(SensiNactSession userSession, ObjectMapper mapper,
+            String providerName, boolean allowNull) {
+        ResourceDescription locationResource = getProviderAdminField(userSession, providerName, "location");
+
+        final GeoJsonObject parsedLocation;
+        final Instant time;
+        if (locationResource.value == null) {
+            if (allowNull) {
+                return null;
+            }
+
+            Point point = new Point();
+            point.coordinates = new Coordinates();
+            parsedLocation = point;
+            time = Instant.EPOCH;
+        } else {
+            final Object rawValue = locationResource.value;
+            if (rawValue instanceof GeoJsonObject) {
+                parsedLocation = (GeoJsonObject) rawValue;
+            } else if (rawValue instanceof String) {
+                try {
+                    parsedLocation = mapper.readValue((String) rawValue, GeoJsonObject.class);
+                } catch (JsonProcessingException ex) {
+                    if (allowNull) {
+                        return null;
+                    }
+                    throw new RuntimeException("Invalid resource location content", ex);
+                }
+            } else {
+                parsedLocation = mapper.convertValue(locationResource.value, GeoJsonObject.class);
+            }
+            time = locationResource.timestamp;
+        }
+
+        return new TimedValue<GeoJsonObject>() {
+            @Override
+            public Instant getTimestamp() {
+                return time;
+            }
+
+            @Override
+            public GeoJsonObject getValue() {
+                return parsedLocation;
+            }
+        };
+    }
+
     public static FeatureOfInterest toFeatureOfInterest(SensiNactSession userSession, UriInfo uriInfo,
             ObjectMapper mapper, String providerName) {
         FeatureOfInterest featureOfInterest = new FeatureOfInterest();
 
-        ResourceDescription locationResource = getProviderAdminField(userSession, providerName, "location");
-
-        Instant time;
-        GeoJsonObject object;
-        if (locationResource.value == null) {
-            object = new Point(0, 0);
-            time = Instant.EPOCH;
-        } else {
-            object = GeoJsonObject.class.isInstance(locationResource.value) ? (GeoJsonObject) locationResource.value
-                    : mapper.convertValue(locationResource.value, GeoJsonObject.class);
-            time = locationResource.timestamp;
-        }
+        final TimedValue<GeoJsonObject> location = getLocation(userSession, mapper, providerName, false);
+        final Instant time = location.getTimestamp();
+        final GeoJsonObject object = location.getValue();
 
         featureOfInterest.id = String.format("%s~%s", providerName, Long.toString(time.toEpochMilli(), 16));
 
@@ -286,8 +319,15 @@ public class DtoMapper {
     }
 
     public static String extractFirstIdSegment(String id) {
+        if(id.isEmpty()) {
+            throw new BadRequestException("Invalid id");
+        }
+
         int idx = id.indexOf('~');
-        if(idx < 1 || idx == id.length() - 1) {
+        if (idx == -1) {
+            // No segment found, return the whole ID
+            return id;
+        } else if (idx == 0 || idx == id.length() - 1) {
             throw new BadRequestException("Invalid id");
         }
         return id.substring(0, idx);
@@ -304,4 +344,14 @@ public class DtoMapper {
             throw new BadRequestException("Invalid id");
         }
     }
+
+    /**
+     * Ensure the given ID contains a single segment
+     */
+    public static void validatedProviderId(String id) {
+        if (id.contains("~")) {
+            throw new BadRequestException("Multi-segments ID found");
+        }
+    }
+
 }

--- a/prototype/northbound/sensorthings/rest.gateway/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/impl/DtoMapper.java
+++ b/prototype/northbound/sensorthings/rest.gateway/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/impl/DtoMapper.java
@@ -117,9 +117,9 @@ public class DtoMapper {
             UriInfo uriInfo, String providerName) {
         HistoricalLocation historicalLocation = new HistoricalLocation();
 
-        TimedValue<GeoJsonObject> location = getLocation(userSession, mapper, providerName, true);
+        final TimedValue<GeoJsonObject> location = getLocation(userSession, mapper, providerName, true);
         final Instant time;
-        if(location == null) {
+        if(location.getTimestamp() == null) {
             time = Instant.EPOCH;
         } else {
             time = location.getTimestamp();
@@ -167,7 +167,7 @@ public class DtoMapper {
                 "definition", String.valueOf(resource.metadata.get("sensorthings.unit.definition")));
 
         datastream.observedArea = getObservedArea(
-                getLocation(userSession, mapper, resource.provider, true).getValue());
+                getLocation(userSession, mapper, resource.provider, false).getValue());
         datastream.properties = resource.metadata;
 
         datastream.selfLink = uriInfo.getBaseUriBuilder().path("v1.1").path("Datastreams({id})")
@@ -252,13 +252,14 @@ public class DtoMapper {
         final Instant time;
         if (locationResource.value == null) {
             if (allowNull) {
-                return null;
+                parsedLocation = null;
+                time = null;
+            } else {
+                Point point = new Point();
+                point.coordinates = new Coordinates();
+                parsedLocation = point;
+                time = Instant.EPOCH;
             }
-
-            Point point = new Point();
-            point.coordinates = new Coordinates();
-            parsedLocation = point;
-            time = Instant.EPOCH;
         } else {
             final Object rawValue = locationResource.value;
             if (rawValue instanceof GeoJsonObject) {

--- a/prototype/northbound/sensorthings/rest.gateway/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/impl/SensinactSensorthingsApplication.java
+++ b/prototype/northbound/sensorthings/rest.gateway/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/impl/SensinactSensorthingsApplication.java
@@ -12,18 +12,21 @@
 **********************************************************************/
 package org.eclipse.sensinact.sensorthings.sensing.rest.impl;
 
+import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.sensinact.prototype.SensiNactSessionManager;
 import org.eclipse.sensinact.sensorthings.sensing.rest.SensorThingsFeature;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.jakartars.whiteboard.propertytypes.JakartarsApplicationBase;
 import org.osgi.service.jakartars.whiteboard.propertytypes.JakartarsName;
 
 import jakarta.ws.rs.core.Application;
 
-@Component
+@Component(service = Application.class)
 @JakartarsName("sensorthings")
+@JakartarsApplicationBase("/")
 public class SensinactSensorthingsApplication extends Application {
 
     @Reference
@@ -53,4 +56,8 @@ public class SensinactSensorthingsApplication extends Application {
         return sessionManager;
     }
 
+    @Override
+    public Map<String, Object> getProperties() {
+        return Map.of("session.manager", sessionManager);
+    }
 }

--- a/prototype/northbound/sensorthings/rest.gateway/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/impl/SensinactSessionProvider.java
+++ b/prototype/northbound/sensorthings/rest.gateway/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/impl/SensinactSessionProvider.java
@@ -13,7 +13,9 @@
 package org.eclipse.sensinact.sensorthings.sensing.rest.impl;
 
 import org.eclipse.sensinact.prototype.SensiNactSession;
+import org.eclipse.sensinact.prototype.SensiNactSessionManager;
 
+import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.ext.ContextResolver;
 
@@ -23,12 +25,13 @@ import jakarta.ws.rs.ext.ContextResolver;
 public class SensinactSessionProvider implements ContextResolver<SensiNactSession> {
 
     @Context
-    SensinactSensorthingsApplication application;
+    Application application;
 
     @Override
     public SensiNactSession getContext(Class<?> type) {
         // TODO proper user and session mapping
-        return application.getSessionManager().getDefaultSession(null);
+        SensiNactSessionManager manager = (SensiNactSessionManager) application.getProperties().get("session.manager");
+        return manager.getDefaultSession(null);
     }
 
 }


### PR DESCRIPTION
* Use internal GeoJSON library
* Fixed filters behaviour when related argument is missing
* Don't use `@Context` to find the registered `ObjectMapper` and `SensinactSession` providers
* Normalized conversion of `admin/location` to a `GeoJsonObject`
