### PR TITLE
Add support for feature dependencies to the Feature Manager

### DIFF
--- a/prototype/distribution/features/jakarta-rest-whiteboard-feature/src/main/resources/jakarta-rest-whiteboard-feature.json
+++ b/prototype/distribution/features/jakarta-rest-whiteboard-feature/src/main/resources/jakarta-rest-whiteboard-feature.json
@@ -1,5 +1,5 @@
 {
-  "id":"org.eclipse.sensinact.gateway.distribution.features:gogo-shell:osgifeature:0.0.1-SNAPSHOT",
+  "id":"org.eclipse.sensinact.gateway.distribution.features:jakarta-rest-whiteboard-feature:osgifeature:0.0.1-SNAPSHOT",
   "bundles":[
     { "id": "org.geckoprojects.jakartars:org.gecko.rest.jersey:6.0.0.RC1" },
     { "id": "org.geckoprojects.jakartars:org.gecko.rest.jersey.servlet.whiteboard:6.0.0.RC1" },
@@ -26,5 +26,16 @@
     { "id": "org.glassfish.hk2:hk2-utils:3.0.3" },
     { "id": "org.javassist:javassist:3.29.2-GA" },
     { "id": "org.ow2.asm:asm:9.3" }
-  ]
+  ],
+  "extensions": {
+    "sensinact.feature.depends": {
+      "kind": "mandatory",
+      "type": "artifacts",
+      "artifacts": [
+        {
+          "id": "org.eclipse.sensinact.gateway.distribution.features:jakarta-servlet-whiteboard-feature:osgifeature:0.0.1-SNAPSHOT"
+        }
+      ]
+    }
+  }
 }

--- a/prototype/distribution/features/jakarta-servlet-whiteboard-feature/src/main/resources/jakarta-servlet-whiteboard-feature.json
+++ b/prototype/distribution/features/jakarta-servlet-whiteboard-feature/src/main/resources/jakarta-servlet-whiteboard-feature.json
@@ -1,5 +1,5 @@
 {
-  "id":"org.eclipse.sensinact.gateway.distribution.features:gogo-shell:osgifeature:0.0.1-SNAPSHOT",
+  "id":"org.eclipse.sensinact.gateway.distribution.features:jakarta-servlet-whiteboard-feature:osgifeature:0.0.1-SNAPSHOT",
   "bundles":[
     { "id": "org.apache.felix:org.apache.felix.http.jetty:5.0.0-RC1" },
     { "id": "org.apache.felix:org.apache.felix.http.servlet-api:2.1.0" }

--- a/prototype/distribution/features/northbound-rest-feature/src/main/resources/northbound-rest-feature.json
+++ b/prototype/distribution/features/northbound-rest-feature/src/main/resources/northbound-rest-feature.json
@@ -1,5 +1,5 @@
 {
-  "id":"org.eclipse.sensinact.gateway.distribution.features:northbound-rest:osgifeature:0.0.1-SNAPSHOT",
+  "id":"org.eclipse.sensinact.gateway.distribution.features:northbound-rest-feature:osgifeature:0.0.1-SNAPSHOT",
   "bundles":[
     { "id": "org.eclipse.sensinact.gateway.northbound:rest:0.0.1-SNAPSHOT" },
     { "id": "com.fasterxml.jackson.core:jackson-annotations:2.14.0" },
@@ -7,5 +7,19 @@
     { "id": "com.fasterxml.jackson.core:jackson-databind:2.14.0" },
     { "id": "com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-base:2.14.0" },
     { "id": "com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-json-provider:2.14.0" }
-  ]
+  ],
+  "extensions": {
+    "sensinact.feature.depends": {
+      "kind": "mandatory",
+      "type": "artifacts",
+      "artifacts": [
+        {
+          "id": "org.eclipse.sensinact.gateway.distribution.features:core-feature:osgifeature:0.0.1-SNAPSHOT"
+        },
+        {
+          "id": "org.eclipse.sensinact.gateway.distribution.features:jakarta-rest-whiteboard-feature:osgifeature:0.0.1-SNAPSHOT"
+        }
+      ]
+    }
+  }
 }

--- a/prototype/distribution/launcher/src/test/resources/features/bad_depends_type.json
+++ b/prototype/distribution/launcher/src/test/resources/features/bad_depends_type.json
@@ -1,0 +1,20 @@
+{
+  "feature-resource-version": "1.0",
+  "id": "org.eclipse.sensinact.gateway.launcher.test:need_foo:1.0.0",
+  "bundles": [
+    {
+      "id": "org.eclipse.sensinact.gateway.launcher.test:buzz:1.0.2-SNAPSHOT"
+    }
+  ],
+  "extensions": {
+    "sensinact.feature.depends": {
+      "kind": "mandatory",
+      "type": "text",
+      "text": [
+        "foo",
+        "bar",
+        "foobar"
+      ]
+    }
+  }
+}

--- a/prototype/distribution/launcher/src/test/resources/features/need_fizz.json
+++ b/prototype/distribution/launcher/src/test/resources/features/need_fizz.json
@@ -1,0 +1,20 @@
+{
+  "feature-resource-version": "1.0",
+  "id": "org.eclipse.sensinact.gateway.launcher.test:need_fizz:1.0.0",
+  "bundles": [
+    {
+      "id": "org.eclipse.sensinact.gateway.launcher.test:buzz:1.0.1"
+    }
+  ],
+  "extensions": {
+    "sensinact.feature.depends": {
+      "kind": "mandatory",
+      "type": "artifacts",
+      "artifacts": [
+        {
+          "id": "org.eclipse.sensinact.gateway.launcher.test:fizz:1.0.0"
+        }
+      ]
+    }
+  }
+}

--- a/prototype/distribution/launcher/src/test/resources/features/need_foo.json
+++ b/prototype/distribution/launcher/src/test/resources/features/need_foo.json
@@ -1,0 +1,20 @@
+{
+  "feature-resource-version": "1.0",
+  "id": "org.eclipse.sensinact.gateway.launcher.test:need_foo:1.0.0",
+  "bundles": [
+    {
+      "id": "org.eclipse.sensinact.gateway.launcher.test:buzz:1.0.2-SNAPSHOT"
+    }
+  ],
+  "extensions": {
+    "sensinact.feature.depends": {
+      "kind": "mandatory",
+      "type": "artifacts",
+      "artifacts": [
+        {
+          "id": "org.eclipse.sensinact.gateway.launcher.test:foo:1.0.0"
+        }
+      ]
+    }
+  }
+}

--- a/prototype/distribution/launcher/src/test/resources/features/unknown_extension.json
+++ b/prototype/distribution/launcher/src/test/resources/features/unknown_extension.json
@@ -1,0 +1,20 @@
+{
+  "feature-resource-version": "1.0",
+  "id": "org.eclipse.sensinact.gateway.launcher.test:need_foo:1.0.0",
+  "bundles": [
+    {
+      "id": "org.eclipse.sensinact.gateway.launcher.test:buzz:1.0.0"
+    }
+  ],
+  "extensions": {
+    "some.custom.extension": {
+      "kind": "mandatory",
+      "type": "artifacts",
+      "artifacts": [
+        {
+          "id": "org.eclipse.sensinact.gateway.launcher.test:foo:1.0.0"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Some features depend on other features. These commits make sure that we can express that dependency, and that the runtime requires the dependencies to be installed before the dependent feature is.