### PR TITLE
Add more testing for the ConfigurationManager

### DIFF
--- a/prototype/distribution/launcher/export.bndrun
+++ b/prototype/distribution/launcher/export.bndrun
@@ -14,7 +14,6 @@
 	org.apache.aries.spifly.dynamic.framework.extension;version='[1.3.5,1.3.6)', \
 	org.apache.felix.cm.json;version='[1.0.6,1.0.7)', \
 	org.apache.felix.configadmin;version='[1.9.24,1.9.25)', \
-	org.apache.felix.converter;version='[1.0.14,1.0.15)', \
 	org.apache.felix.feature;version='[1.0.0,1.0.1)', \
 	org.apache.felix.scr;version='[2.2.2,2.2.3)', \
 	org.apache.geronimo.specs.geronimo-json_1.1_spec;version='[1.5.0,1.5.1)', \
@@ -22,6 +21,7 @@
 	org.eclipse.sensinact.gateway.distribution.launcher;version='[0.0.1,0.0.2)', \
 	org.osgi.service.component;version='[1.5.0,1.5.1)', \
 	org.osgi.service.feature;version='[1.0.0,1.0.1)', \
+	org.osgi.util.converter;version='[1.0.9,1.0.10)', \
 	org.osgi.util.function;version='[1.1.0,1.1.1)', \
 	org.osgi.util.promise;version='[1.3.0,1.3.1)', \
 	slf4j.api;version='[1.7.36,1.7.37)', \

--- a/prototype/distribution/launcher/pom.xml
+++ b/prototype/distribution/launcher/pom.xml
@@ -51,6 +51,10 @@
       <artifactId>johnzon-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.util.converter</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.geronimo.specs</groupId>
       <artifactId>geronimo-json_1.1_spec</artifactId>
       <scope>compile</scope>

--- a/prototype/distribution/launcher/src/main/java/org/eclipse/sensinact/gateway/launcher/ConfigurationManager.java
+++ b/prototype/distribution/launcher/src/main/java/org/eclipse/sensinact/gateway/launcher/ConfigurationManager.java
@@ -123,7 +123,7 @@ public class ConfigurationManager {
                     // there has been a change, so assume there has
                     executor.submit(this::reloadConfigFile);
                     break;
-                } else if (Files.isSameFile(configFile, (Path) watchEvent.context())) {
+                } else if (Files.isSameFile(configFile.getFileName(), (Path) watchEvent.context())) {
                     // There has been a change to the config file
                     executor.submit(this::reloadConfigFile);
                     break;

--- a/prototype/distribution/launcher/src/test/java/org/eclipse/sensinact/gateway/launcher/ConfigurationManagerTest.java
+++ b/prototype/distribution/launcher/src/test/java/org/eclipse/sensinact/gateway/launcher/ConfigurationManagerTest.java
@@ -1,0 +1,182 @@
+/*********************************************************************
+* Copyright (c) 2022 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Kentyou - initial implementation
+**********************************************************************/
+package org.eclipse.sensinact.gateway.launcher;
+
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import static java.util.Map.of;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Dictionary;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Semaphore;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatcher;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+
+@ExtendWith(MockitoExtension.class)
+class ConfigurationManagerTest {
+
+    @Mock
+    ConfigurationAdmin configAdmin;
+
+    @InjectMocks
+    ConfigurationManager manager;
+
+    private final Map<String, Configuration> configs = new HashMap<>();
+
+    private final Semaphore semaphore = new Semaphore(0);
+
+    @BeforeEach
+    void start() throws Exception {
+
+        Mockito.lenient().when(configAdmin.getConfiguration(anyString(), anyString())).thenAnswer(i -> {
+            String pid = i.getArgument(0, String.class);
+            Configuration mock = Mockito.mock(Configuration.class, pid);
+            Mockito.when(mock.getPid()).thenReturn(pid);
+            configs.put(pid, mock);
+            semaphore.release();
+            return mock;
+        });
+        Mockito.lenient().when(configAdmin.getFactoryConfiguration(anyString(), anyString(), anyString()))
+                .thenAnswer(i -> {
+                    String factoryPid = i.getArgument(0, String.class);
+                    String pid = factoryPid + "~" + i.getArgument(1, String.class);
+                    Configuration mock = Mockito.mock(Configuration.class, pid);
+                    Mockito.when(mock.getFactoryPid()).thenReturn(factoryPid);
+                    Mockito.when(mock.getPid()).thenReturn(pid);
+                    configs.put(pid, mock);
+                    semaphore.release();
+                    return mock;
+                });
+        Mockito.lenient().when(configAdmin.listConfigurations(eq("(.sensinact.config=true)"))).then(i -> {
+            return configs.values().toArray(Configuration[]::new);
+        });
+    }
+
+    @AfterEach
+    void stop() {
+        configs.clear();
+        if (manager != null)
+            manager.stop();
+    }
+
+    @Nested
+    class ConfigFileWatching {
+
+        @Test
+        void testSimpleConfig() throws Exception {
+            System.setProperty("sensinact.config.dir", "target/test-classes/configs/a");
+            manager.start();
+
+            assertTrue(semaphore.tryAcquire(2, 1, SECONDS));
+
+            Mockito.verify(configAdmin).getConfiguration(eq("test.pid"), anyString());
+            Mockito.verify(configAdmin).getFactoryConfiguration(eq("test.factory.pid"), eq("boo"), anyString());
+
+            Mockito.verify(configs.get("test.pid"), Mockito.timeout(500))
+                    .update(argThat(isConfig(of("foo", "bar", "fizzbuzz", 42L, ".sensinact.config", true))));
+            Mockito.verify(configs.get("test.factory.pid~boo"), Mockito.timeout(500))
+                    .update(argThat(isConfig(of("fizz", "buzz", "foobar", 24L, ".sensinact.config", true))));
+        }
+
+        @Test
+        void testSimpleUpdate() throws Exception {
+            Path path = Paths.get("target/test-classes/configs/b");
+            System.setProperty("sensinact.config.dir", path.toString());
+
+            Path configFile = path.resolve("configuration.json");
+
+            if (Files.exists(configFile)) {
+                Files.delete(configFile);
+            }
+
+            manager.start();
+
+            Thread.sleep(500);
+
+            Mockito.verify(configAdmin).listConfigurations(anyString());
+
+            Mockito.verifyNoMoreInteractions(configAdmin);
+
+            Files.copy(path.resolve("configuration-initial.json"), configFile);
+
+            assertTrue(semaphore.tryAcquire(3, 15, SECONDS));
+
+            Mockito.verify(configAdmin).getConfiguration(eq("test.pid"), anyString());
+            Mockito.verify(configAdmin).getConfiguration(eq("test.pid.temp"), anyString());
+            Mockito.verify(configAdmin).getFactoryConfiguration(eq("test.factory.pid"), eq("boo"), anyString());
+
+            Mockito.verify(configs.get("test.pid"), Mockito.timeout(500))
+                    .update(argThat(isConfig(of("foo", "bar", "fizzbuzz", 42L, ".sensinact.config", true))));
+            Mockito.verify(configs.get("test.pid.temp"), Mockito.timeout(500))
+                    .update(argThat(isConfig(of("ttl", 1L, ".sensinact.config", true))));
+            Mockito.verify(configs.get("test.factory.pid~boo"), Mockito.timeout(500))
+                    .update(argThat(isConfig(of("fizz", "buzz", "foobar", 24L, ".sensinact.config", true))));
+
+            Files.copy(path.resolve("configuration-update.json"), configFile, REPLACE_EXISTING);
+
+            // Mockito timeout as there is no creation of configurations
+            Mockito.verify(configs.get("test.pid"), Mockito.timeout(20000))
+                    .updateIfDifferent(argThat(isConfig(of("bar", "foo", "fizzbuzz", 84L, ".sensinact.config", true))));
+            Mockito.verify(configs.get("test.pid.temp"), Mockito.timeout(500)).delete();
+            Mockito.verify(configs.get("test.factory.pid~boo"), Mockito.timeout(500))
+                    .updateIfDifferent(argThat(isConfig(of("buzz", "fizz", "foobar", 48L, ".sensinact.config", true))));
+        }
+
+    }
+
+    ArgumentMatcher<Dictionary<String, Object>> isConfig(Map<String, Object> config) {
+        return new ArgumentMatcher<Dictionary<String, Object>>() {
+
+            @Override
+            public boolean matches(Dictionary<String, Object> arg) {
+                Set<String> keySet = new HashSet<>();
+                Enumeration<String> keys = arg.keys();
+                while (keys.hasMoreElements()) {
+                    keySet.add(keys.nextElement());
+                }
+                if (config.keySet().equals(keySet)) {
+                    return keySet.stream().allMatch(s -> arg.get(s).equals(config.get(s)));
+                }
+
+                return false;
+            }
+
+            @Override
+            public String toString() {
+                return "Expected config " + config;
+            }
+        };
+    }
+}

--- a/prototype/distribution/launcher/src/test/resources/configs/a/configuration.json
+++ b/prototype/distribution/launcher/src/test/resources/configs/a/configuration.json
@@ -1,0 +1,13 @@
+{
+  ":configurator:resource-version": 1,
+  ":configurator:symbolic-name": "org.eclipse.sensinact.gateway.feature.gogo.test",
+  ":configurator:version": "0.0.1",
+  "test.pid": {
+    "foo": "bar",
+    "fizzbuzz": 42
+  },
+  "test.factory.pid~boo": {
+    "fizz": "buzz",
+    "foobar": 24
+  }
+}

--- a/prototype/distribution/launcher/src/test/resources/configs/b/configuration-initial.json
+++ b/prototype/distribution/launcher/src/test/resources/configs/b/configuration-initial.json
@@ -1,0 +1,16 @@
+{
+  ":configurator:resource-version": 1,
+  ":configurator:symbolic-name": "org.eclipse.sensinact.gateway.feature.gogo.test",
+  ":configurator:version": "0.0.1",
+  "test.pid": {
+    "foo": "bar",
+    "fizzbuzz": 42
+  },
+  "test.pid.temp": {
+    "ttl": 1
+  },
+  "test.factory.pid~boo": {
+    "fizz": "buzz",
+    "foobar": 24
+  }
+}

--- a/prototype/distribution/launcher/src/test/resources/configs/b/configuration-update.json
+++ b/prototype/distribution/launcher/src/test/resources/configs/b/configuration-update.json
@@ -1,0 +1,13 @@
+{
+  ":configurator:resource-version": 1,
+  ":configurator:symbolic-name": "org.eclipse.sensinact.gateway.feature.gogo.test",
+  ":configurator:version": "0.0.1",
+  "test.pid": {
+    "bar": "foo",
+    "fizzbuzz": 84
+  },
+  "test.factory.pid~boo": {
+    "buzz": "fizz",
+    "foobar": 48
+  }
+}

--- a/prototype/pom.xml
+++ b/prototype/pom.xml
@@ -117,6 +117,7 @@
     <osgi.pushstream.version>1.0.2</osgi.pushstream.version>
     <osgi.typedevent.version>1.0.0</osgi.typedevent.version>
     <osgi.feature.version>1.0.0</osgi.feature.version>
+    <osgi.converter.version>1.0.9</osgi.converter.version>
     <gecko.emf.version>4.4.0</gecko.emf.version>
     <emf.common.version>2.23.0</emf.common.version>
     <emf.ecore.version>2.25.0</emf.ecore.version>
@@ -353,6 +354,12 @@
         <groupId>org.apache.johnzon</groupId>
         <artifactId>johnzon-core</artifactId>
         <version>${johnzon.version}</version>
+        <scope>runtime</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.osgi</groupId>
+        <artifactId>org.osgi.util.converter</artifactId>
+        <version>${osgi.converter.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
Fixes a bug in the configuration watcher. Tests are slow on MacOS due to the lack of a native implementation in the JDK

Signed-off-by: Tim Ward <timothyjward@apache.org>