### PR TITLE
Allow changing admin resource values with the same timestamp as they are

### DIFF
--- a/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/model/nexus/impl/ModelNexus.java
+++ b/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/model/nexus/impl/ModelNexus.java
@@ -237,7 +237,7 @@ public class ModelNexus {
             accumulator.addResource(providerName, serviceFeature.getName(), resourceFeature.getName());
         }
 
-        if (metadata == null || metadata.getTimestamp().isBefore(timestamp)) {
+        if (metadata == null || !metadata.getTimestamp().isAfter(timestamp)) {
             service.eSet(resourceFeature, data);
             accumulator.resourceValueUpdate(providerName, serviceFeature.getName(), resourceFeature.getName(), oldValue,
                     data, timestamp);


### PR DESCRIPTION
Without that change, we cannot reuse the provider creation timestamp to update admin values.