### PR TITLE
Avoid using the bnd v7 launcher which needs Java 17

### DIFF
--- a/prototype/distribution/launcher/pom.xml
+++ b/prototype/distribution/launcher/pom.xml
@@ -77,7 +77,8 @@
       <plugin>
         <groupId>biz.aQute.bnd</groupId>
         <artifactId>bnd-export-maven-plugin</artifactId>
-        <version>${bnd.version}</version>
+        <!-- Use 6.4.0 to avoid requiring Java 17 to run -->
+        <version>6.4.0</version>
         <executions>
           <execution>
             <id>export</id>
@@ -94,7 +95,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>3.3.0</version>
         <executions>
           <execution>
             <id>generate-repo</id>


### PR DESCRIPTION
The bnd-export-maven-plugin provides a launcher, but as of 7.0.0 this requires Java 17. We therefore use 6.4.0 for this plugin to maintain compatibility with Java 11

Signed-off-by: Tim Ward <timothyjward@apache.org>