### PR TITLE
Add a simple sensiNact provider representing the sensiNact instance

### DIFF
--- a/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/command/impl/GatewayThreadImpl.java
+++ b/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/command/impl/GatewayThreadImpl.java
@@ -1,5 +1,5 @@
 /*********************************************************************
-* Copyright (c) 2022 Contributors to the Eclipse Foundation.
+* Copyright (c) 2023 Contributors to the Eclipse Foundation.
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0
@@ -26,6 +26,7 @@ import org.eclipse.sensinact.prototype.command.AbstractSensinactCommand;
 import org.eclipse.sensinact.prototype.command.GatewayThread;
 import org.eclipse.sensinact.prototype.model.nexus.impl.ModelNexus;
 import org.eclipse.sensinact.prototype.notification.NotificationAccumulator;
+import org.eclipse.sensinact.prototype.notification.impl.ImmediateNotificationAccumulator;
 import org.eclipse.sensinact.prototype.notification.impl.NotificationAccumulatorImpl;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -88,7 +89,8 @@ public class GatewayThreadImpl extends Thread implements GatewayThread {
 
     private NotificationAccumulator getCurrentAccumulator() {
         WorkItem<?> workItem = currentItem.get();
-        return workItem == null ? null : workItem.command.getAccumulator();
+        return workItem == null ? new ImmediateNotificationAccumulator(typedEventBus)
+                : workItem.command.getAccumulator();
     }
 
     @Override

--- a/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/model/nexus/impl/ModelNexus.java
+++ b/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/model/nexus/impl/ModelNexus.java
@@ -1,5 +1,5 @@
 /*********************************************************************
-* Copyright (c) 2022 Contributors to the Eclipse Foundation.
+* Copyright (c) 2023 Contributors to the Eclipse Foundation.
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0
@@ -9,6 +9,7 @@
 *
 * Contributors:
 *   Data In Motion - initial API and implementation
+*   Kentyou - fixes and updates to include a basic sensiNact provider
 **********************************************************************/
 package org.eclipse.sensinact.prototype.model.nexus.impl;
 
@@ -89,6 +90,7 @@ public class ModelNexus {
                 .orElseGet(() -> EMFUtil.createPackage("base", DEFAULT_URI, "sensinactBase", this.resourceSet));
         packageCache.put(DEFAULT_URI_OBJECT, defaultPackage);
         loadInstances();
+        setupSensinactProvider();
     }
 
     private Optional<EPackage> loadDefaultPackage(Path fileName) {
@@ -152,6 +154,14 @@ public class ModelNexus {
             LOG.error("THIS WILL BE A RUNTIME EXCPETION FOR NOW: Error loading provider from Path: {}", path, e);
             throw new RuntimeException(e);
         }
+
+    }
+
+    private void setupSensinactProvider() {
+
+        Instant now = Instant.now();
+        handleDataUpdate("sensinact", "sensiNact", "system", "version", double.class, 0.1D, now);
+        handleDataUpdate("sensinact", "sensiNact", "system", "started", Instant.class, now, now);
 
     }
 

--- a/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/model/nexus/impl/emf/EMFUtil.java
+++ b/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/model/nexus/impl/emf/EMFUtil.java
@@ -1,5 +1,5 @@
 /*********************************************************************
-* Copyright (c) 2022 Contributors to the Eclipse Foundation.
+* Copyright (c) 2023 Contributors to the Eclipse Foundation.
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0
@@ -9,6 +9,7 @@
 *
 * Contributors:
 *   Data In Motion - initial API and implementation
+*   Kentyou - fixes and updates to include a basic sensiNact provider
 **********************************************************************/
 package org.eclipse.sensinact.prototype.model.nexus.impl.emf;
 
@@ -23,6 +24,7 @@ import org.eclipse.emf.ecore.EAnnotation;
 import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EClassifier;
+import org.eclipse.emf.ecore.EDataType;
 import org.eclipse.emf.ecore.EModelElement;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EPackage;
@@ -34,6 +36,7 @@ import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.xmi.impl.XMIResourceImpl;
 import org.eclipse.sensinact.model.core.ModelMetadata;
+import org.eclipse.sensinact.model.core.SensiNactPackage;
 
 /**
  * Some Helper methods to work with Ecores.
@@ -46,6 +49,8 @@ public class EMFUtil {
     private static final Map<Class<?>, EClassifier> typeMap = new HashMap<Class<?>, EClassifier>();
     static {
         EcorePackage.eINSTANCE.getEClassifiers().forEach(ec -> typeMap.put(ec.getInstanceClass(), ec));
+        EDataType eInstant = SensiNactPackage.eINSTANCE.getEInstant();
+        typeMap.put(eInstant.getInstanceClass(), eInstant);
     }
 
     public static Map<String, Object> toEObjectAttributesToMap(EObject eObject) {
@@ -171,4 +176,3 @@ public class EMFUtil {
     }
 
 }
-

--- a/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/notification/impl/AbstractNotificationAccumulatorImpl.java
+++ b/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/notification/impl/AbstractNotificationAccumulatorImpl.java
@@ -1,0 +1,99 @@
+/*********************************************************************
+* Copyright (c) 2023 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Kentyou - initial implementation
+**********************************************************************/
+package org.eclipse.sensinact.prototype.notification.impl;
+
+import java.time.Instant;
+import java.util.Map;
+
+import org.eclipse.sensinact.prototype.notification.LifecycleNotification;
+import org.eclipse.sensinact.prototype.notification.LifecycleNotification.Status;
+import org.eclipse.sensinact.prototype.notification.NotificationAccumulator;
+import org.eclipse.sensinact.prototype.notification.ResourceActionNotification;
+import org.eclipse.sensinact.prototype.notification.ResourceDataNotification;
+import org.eclipse.sensinact.prototype.notification.ResourceMetaDataNotification;
+
+/**
+ * This class is allows some level of implementation sharing between the
+ * different types of {@link NotificationAccumulator}
+ *
+ */
+public abstract class AbstractNotificationAccumulatorImpl implements NotificationAccumulator {
+
+    private boolean complete = false;
+
+    /**
+     * Check whether the accumulator has been completed
+     */
+    protected void check() {
+        if (complete) {
+            throw new IllegalStateException("The accumulator is already complete");
+        }
+    }
+
+    protected LifecycleNotification createLifecycleNotification(Status status, String provider, String service,
+            String resource, Object initialValue, Map<String, Object> initialMetadata) {
+        LifecycleNotification ln = new LifecycleNotification();
+        ln.provider = provider;
+        ln.service = service;
+        ln.resource = resource;
+        ln.status = status;
+        ln.initialValue = initialValue;
+        ln.initialMetadata = initialMetadata;
+        return ln;
+    }
+
+    protected ResourceMetaDataNotification createResourceMetaDataNotification(String provider, String service,
+            String resource, Map<String, Object> oldValues, Map<String, Object> newValues, Instant timestamp) {
+        ResourceMetaDataNotification rn = new ResourceMetaDataNotification();
+        rn.provider = provider;
+        rn.service = service;
+        rn.resource = resource;
+        rn.oldValues = oldValues;
+        rn.newValues = newValues;
+        rn.timestamp = timestamp;
+        return rn;
+    }
+
+    protected ResourceDataNotification createResourceDataNotification(String provider, String service, String resource,
+            Object oldValue, Object newValue, Instant timestamp) {
+        ResourceDataNotification rn = new ResourceDataNotification();
+        rn.provider = provider;
+        rn.service = service;
+        rn.resource = resource;
+        rn.oldValue = oldValue;
+        rn.newValue = newValue;
+        rn.timestamp = timestamp;
+        return rn;
+    }
+
+    protected ResourceActionNotification createResourceActionNotification(String provider, String service,
+            String resource, Instant timestamp) {
+        ResourceActionNotification rn = new ResourceActionNotification();
+        rn.provider = provider;
+        rn.service = service;
+        rn.resource = resource;
+        rn.timestamp = timestamp;
+        return rn;
+    }
+
+    public final void completeAndSend() {
+        check();
+        complete = true;
+        doComplete();
+    }
+
+    /**
+     * Complete the accumulation
+     */
+    protected abstract void doComplete();
+}

--- a/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/notification/impl/ImmediateNotificationAccumulator.java
+++ b/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/notification/impl/ImmediateNotificationAccumulator.java
@@ -1,0 +1,192 @@
+/*********************************************************************
+* Copyright (c) 2023 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Kentyou - initial implementation
+**********************************************************************/
+package org.eclipse.sensinact.prototype.notification.impl;
+
+import static java.util.Collections.emptyMap;
+import static org.eclipse.sensinact.prototype.notification.LifecycleNotification.Status.PROVIDER_CREATED;
+import static org.eclipse.sensinact.prototype.notification.LifecycleNotification.Status.PROVIDER_DELETED;
+import static org.eclipse.sensinact.prototype.notification.LifecycleNotification.Status.RESOURCE_CREATED;
+import static org.eclipse.sensinact.prototype.notification.LifecycleNotification.Status.RESOURCE_DELETED;
+import static org.eclipse.sensinact.prototype.notification.LifecycleNotification.Status.SERVICE_CREATED;
+import static org.eclipse.sensinact.prototype.notification.LifecycleNotification.Status.SERVICE_DELETED;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+
+import org.eclipse.sensinact.prototype.notification.LifecycleNotification;
+import org.eclipse.sensinact.prototype.notification.NotificationAccumulator;
+import org.eclipse.sensinact.prototype.notification.ResourceActionNotification;
+import org.eclipse.sensinact.prototype.notification.ResourceDataNotification;
+import org.eclipse.sensinact.prototype.notification.ResourceMetaDataNotification;
+import org.osgi.service.typedevent.TypedEventBus;
+
+/**
+ * This class is used when no batching should occur. Events are immediately sent
+ * with no duplication. Its use is rare, for internal actions happening on the
+ * gateway thread with no command
+ *
+ * This type is not thread safe and must not be used concurrently.
+ */
+public class ImmediateNotificationAccumulator extends AbstractNotificationAccumulatorImpl
+        implements NotificationAccumulator {
+
+    private final TypedEventBus eventBus;
+
+    public ImmediateNotificationAccumulator(TypedEventBus eventBus) {
+        this.eventBus = eventBus;
+    }
+
+    /**
+     * Called to add a provider. The event is sent immediately
+     *
+     * @param name the provider name
+     */
+    @Override
+    public void addProvider(String name) {
+        LifecycleNotification ln = createLifecycleNotification(PROVIDER_CREATED, name, null, null, null, null);
+        eventBus.deliver(ln.getTopic(), ln);
+    }
+
+    /**
+     * Called to remove a provider. The event is sent immediately.
+     *
+     * @param name the provider name
+     */
+    @Override
+    public void removeProvider(String name) {
+        LifecycleNotification ln = createLifecycleNotification(PROVIDER_DELETED, name, null, null, null, null);
+        eventBus.deliver(ln.getTopic(), ln);
+    }
+
+    /**
+     * Called to add a service. The event is sent immediately.
+     *
+     * @param provider the provider name
+     * @param name     the service name
+     */
+    @Override
+    public void addService(String provider, String name) {
+        LifecycleNotification ln = createLifecycleNotification(SERVICE_CREATED, provider, name, null, null, null);
+        eventBus.deliver(ln.getTopic(), ln);
+    }
+
+    /**
+     * Called to remove a service. The event is sent immediately.
+     *
+     * @param provider the provider name
+     * @param name     the service name
+     */
+    @Override
+    public void removeService(String provider, String name) {
+        LifecycleNotification ln = createLifecycleNotification(SERVICE_DELETED, provider, name, null, null, null);
+        eventBus.deliver(ln.getTopic(), ln);
+    }
+
+    /**
+     * Called to add a resource. The event is sent immediately.
+     *
+     * @param provider the provider name
+     * @param service  the service name
+     * @param name     the resource name
+     */
+    @Override
+    public void addResource(String provider, String service, String name) {
+        LifecycleNotification ln = createLifecycleNotification(RESOURCE_CREATED, provider, service, name, null, null);
+        eventBus.deliver(ln.getTopic(), ln);
+    }
+
+    /**
+     * Called to remove a resource. The event is sent immediately.
+     *
+     * @param provider the provider name
+     * @param service  the service name
+     * @param name     the resource name
+     */
+    @Override
+    public void removeResource(String provider, String service, String name) {
+        LifecycleNotification ln = createLifecycleNotification(RESOURCE_DELETED, provider, service, name, null, null);
+        eventBus.deliver(ln.getTopic(), ln);
+    }
+
+    /**
+     * Called to update metadata - provides the complete snapshot of metadata before
+     * and after. The event is sent immediately
+     *
+     * @param provider  the provider name
+     * @param service   the service name
+     * @param resource  the resource name
+     * @param oldValues the metadata values before the update
+     * @param newValues the metadata values after the update
+     * @param timestamp the latest timestamp of the metadata after the update
+     *
+     * @throws NullPointerException if the timestamp is null
+     */
+    @Override
+    public void metadataValueUpdate(String provider, String service, String resource, Map<String, Object> oldValues,
+            Map<String, Object> newValues, Instant timestamp) {
+
+        Map<String, Object> nonNullOldValues = oldValues == null ? emptyMap() : oldValues;
+        Map<String, Object> nonNullNewValues = newValues == null ? emptyMap() : newValues;
+        Objects.requireNonNull(timestamp);
+
+        ResourceMetaDataNotification rmn = createResourceMetaDataNotification(provider, service, resource,
+                nonNullOldValues, nonNullNewValues, timestamp);
+
+        eventBus.deliver(rmn.getTopic(), rmn);
+    }
+
+    /**
+     * Called to update a resource value. The event is sent immediately.
+     *
+     * @param provider  the provider name
+     * @param service   the service name
+     * @param resource  the resource name
+     * @param oldValue  the value before the update
+     * @param newValue  the value after the update
+     * @param timestamp the latest timestamp of the value after the update
+     *
+     * @throws NullPointerException if the timestamp is null
+     */
+    @Override
+    public void resourceValueUpdate(String provider, String service, String resource, Object oldValue, Object newValue,
+            Instant timestamp) {
+        Objects.requireNonNull(timestamp);
+
+        ResourceDataNotification rdn = createResourceDataNotification(provider, service, resource, oldValue, newValue,
+                timestamp);
+        eventBus.deliver(rdn.getTopic(), rdn);
+    }
+
+    /**
+     * Called to notify of a resource action - The event is sent immediately.
+     *
+     * @param provider  the provider name
+     * @param service   the service name
+     * @param resource  the resource name
+     * @param oldValue  the value before the update
+     * @param newValue  the value after the update
+     * @param timestamp the latest timestamp of the value after the update
+     */
+    @Override
+    public void resourceAction(String provider, String service, String resource, Instant timestamp) {
+        Objects.requireNonNull(timestamp);
+
+        ResourceActionNotification ran = createResourceActionNotification(provider, service, resource, timestamp);
+        eventBus.deliver(ran.getTopic(), ran);
+    }
+
+    protected void doComplete() {
+        // No op by default
+    }
+}

--- a/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/notification/impl/NotificationAccumulatorImpl.java
+++ b/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/notification/impl/NotificationAccumulatorImpl.java
@@ -1,5 +1,5 @@
 /*********************************************************************
-* Copyright (c) 2022 Contributors to the Eclipse Foundation.
+* Copyright (c) 2023 Contributors to the Eclipse Foundation.
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0
@@ -8,7 +8,7 @@
 * SPDX-License-Identifier: EPL-2.0
 *
 * Contributors:
-*   Kentyou - initial implementation 
+*   Kentyou - initial implementation
 **********************************************************************/
 package org.eclipse.sensinact.prototype.notification.impl;
 
@@ -41,19 +41,18 @@ import org.osgi.service.typedevent.TypedEventBus;
 /**
  * This class is responsible for managing batches of update notifications. No
  * notifications are sent until the batch is completed
- * 
+ *
  * If multiple events occur for the same target then the events will be
  * collapsed to "debounce" the notifications
- * 
+ *
  * This type is not thread safe and must not be used concurrently.
  */
-public class NotificationAccumulatorImpl implements NotificationAccumulator {
+public class NotificationAccumulatorImpl extends AbstractNotificationAccumulatorImpl
+        implements NotificationAccumulator {
 
     private final TypedEventBus eventBus;
 
     private final SortedMap<NotificationKey, List<AbstractResourceNotification>> notifications = new TreeMap<>();
-
-    private boolean complete = false;
 
     public NotificationAccumulatorImpl(TypedEventBus eventBus) {
         this.eventBus = eventBus;
@@ -65,7 +64,7 @@ public class NotificationAccumulatorImpl implements NotificationAccumulator {
      * <li>CREATED: then the events are collapsed</li>
      * <li>DELETED: then an added event is added next</li>
      * </ul>
-     * 
+     *
      * @param name the provider name
      * @throws IllegalStateException if this accumulator has been completed with
      *                               {@link #completeAndSend()}
@@ -81,7 +80,7 @@ public class NotificationAccumulatorImpl implements NotificationAccumulator {
      * <li>CREATED: then the created event is removed and no new event added</li>
      * <li>DELETED: then the events are collapsed</li>
      * </ul>
-     * 
+     *
      * @param name the provider name
      * @throws IllegalStateException if this accumulator has been completed with
      *                               {@link #completeAndSend()}
@@ -97,7 +96,7 @@ public class NotificationAccumulatorImpl implements NotificationAccumulator {
      * <li>CREATED: then the events are collapsed</li>
      * <li>DELETED: then an added event is added next</li>
      * </ul>
-     * 
+     *
      * @param provider the provider name
      * @param name     the service name
      * @throws IllegalStateException if this accumulator has been completed with
@@ -114,7 +113,7 @@ public class NotificationAccumulatorImpl implements NotificationAccumulator {
      * <li>CREATED: then the created event is removed and no new event added</li>
      * <li>DELETED: then the events are collapsed</li>
      * </ul>
-     * 
+     *
      * @param provider the provider name
      * @param name     the service name
      * @throws IllegalStateException if this accumulator has been completed with
@@ -131,7 +130,7 @@ public class NotificationAccumulatorImpl implements NotificationAccumulator {
      * <li>CREATED: then the events are collapsed</li>
      * <li>DELETED: then an added event is added next</li>
      * </ul>
-     * 
+     *
      * @param provider the provider name
      * @param service  the service name
      * @param name     the resource name
@@ -149,7 +148,7 @@ public class NotificationAccumulatorImpl implements NotificationAccumulator {
      * <li>CREATED: then the created event is removed and no new event added</li>
      * <li>DELETED: then the events are collapsed</li>
      * </ul>
-     * 
+     *
      * @param provider the provider name
      * @param service  the service name
      * @param name     the resource name
@@ -185,29 +184,17 @@ public class NotificationAccumulatorImpl implements NotificationAccumulator {
         });
     }
 
-    private LifecycleNotification createLifecycleNotification(Status status, String provider, String service,
-            String resource, Object initialValue, Map<String, Object> initialMetadata) {
-        LifecycleNotification ln = new LifecycleNotification();
-        ln.provider = provider;
-        ln.service = service;
-        ln.resource = resource;
-        ln.status = status;
-        ln.initialValue = initialValue;
-        ln.initialMetadata = initialMetadata;
-        return ln;
-    }
-
     /**
      * Called to update metadata - provides the complete snapshot of metadata before
      * and after
-     * 
+     *
      * @param provider  the provider name
      * @param service   the service name
      * @param resource  the resource name
      * @param oldValues the metadata values before the update
      * @param newValues the metadata values after the update
      * @param timestamp the latest timestamp of the metadata after the update
-     * 
+     *
      * @throws IllegalArgumentException if the timestamp is older than the latest
      *                                  known metadata update
      * @throws IllegalStateException    if this accumulator has been completed with
@@ -246,29 +233,17 @@ public class NotificationAccumulatorImpl implements NotificationAccumulator {
                 });
     }
 
-    private ResourceMetaDataNotification createResourceMetaDataNotification(String provider, String service,
-            String resource, Map<String, Object> oldValues, Map<String, Object> newValues, Instant timestamp) {
-        ResourceMetaDataNotification rn = new ResourceMetaDataNotification();
-        rn.provider = provider;
-        rn.service = service;
-        rn.resource = resource;
-        rn.oldValues = oldValues;
-        rn.newValues = newValues;
-        rn.timestamp = timestamp;
-        return rn;
-    }
-
     /**
      * Called to update a resource value. If multiple updates occur they will be
      * collapsed into single events
-     * 
+     *
      * @param provider  the provider name
      * @param service   the service name
      * @param resource  the resource name
      * @param oldValue  the value before the update
      * @param newValue  the value after the update
      * @param timestamp the latest timestamp of the value after the update
-     * 
+     *
      * @throws IllegalArgumentException if the timestamp is older than the latest
      *                                  known metadata update
      * @throws IllegalStateException    if this accumulator has been completed with
@@ -296,29 +271,17 @@ public class NotificationAccumulatorImpl implements NotificationAccumulator {
                 });
     }
 
-    private ResourceDataNotification createResourceDataNotification(String provider, String service, String resource,
-            Object oldValue, Object newValue, Instant timestamp) {
-        ResourceDataNotification rn = new ResourceDataNotification();
-        rn.provider = provider;
-        rn.service = service;
-        rn.resource = resource;
-        rn.oldValue = oldValue;
-        rn.newValue = newValue;
-        rn.timestamp = timestamp;
-        return rn;
-    }
-
     /**
      * Called to notify of a resource action - if multiple actions occur they will
      * be sorted into timestamp order
-     * 
+     *
      * @param provider  the provider name
      * @param service   the service name
      * @param resource  the resource name
      * @param oldValue  the value before the update
      * @param newValue  the value after the update
      * @param timestamp the latest timestamp of the value after the update
-     * 
+     *
      * @throws IllegalStateException if this accumulator has been completed with
      *                               {@link #completeAndSend()}
      */
@@ -338,27 +301,8 @@ public class NotificationAccumulatorImpl implements NotificationAccumulator {
                 });
     }
 
-    private ResourceActionNotification createResourceActionNotification(String provider, String service,
-            String resource, Instant timestamp) {
-        ResourceActionNotification rn = new ResourceActionNotification();
-        rn.provider = provider;
-        rn.service = service;
-        rn.resource = resource;
-        rn.timestamp = timestamp;
-        return rn;
-    }
-
     @Override
-    public void completeAndSend() {
-        check();
-        complete = true;
-
+    protected void doComplete() {
         notifications.values().stream().flatMap(List::stream).forEach(n -> eventBus.deliver(n.getTopic(), n));
-    }
-
-    private void check() {
-        if (complete) {
-            throw new IllegalStateException("The accumulator is already complete");
-        }
     }
 }

--- a/prototype/core/impl/src/test/java/org/eclipse/sensinact/prototype/model/nexus/impl/NexusTest.java
+++ b/prototype/core/impl/src/test/java/org/eclipse/sensinact/prototype/model/nexus/impl/NexusTest.java
@@ -1,5 +1,5 @@
 /*********************************************************************
-* Copyright (c) 2022 Contributors to the Eclipse Foundation.
+* Copyright (c) 2023 Contributors to the Eclipse Foundation.
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0
@@ -13,6 +13,7 @@
 **********************************************************************/
 package org.eclipse.sensinact.prototype.model.nexus.impl;
 
+import static java.time.temporal.ChronoUnit.DAYS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -27,6 +28,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.time.Instant;
+import java.util.List;
 
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EStructuralFeature;
@@ -135,6 +137,46 @@ public class NexusTest {
 
             Object value = service.eGet(valueFeature);
             assertEquals("test", value);
+        }
+
+        @Test
+        void sensiNactProvider() {
+
+            ModelNexus nexus = new ModelNexus(resourceSet, SensiNactPackage.eINSTANCE, () -> accumulator);
+
+            List<Provider> providers = nexus.getProviders();
+
+            assertEquals(1, providers.size());
+            Provider provider = providers.get(0);
+
+            assertNotNull(provider.getAdmin());
+            assertEquals("sensiNact", provider.getAdmin().getFriendlyName());
+
+            EStructuralFeature serviceFeature = provider.eClass().getEStructuralFeature("system");
+            assertNotNull(serviceFeature);
+            assertEquals("system", serviceFeature.getName());
+            EClass eClass = (EClass) serviceFeature.getEType();
+
+            Service service = (Service) provider.eGet(serviceFeature);
+
+            assertNotNull(service);
+
+            EStructuralFeature versionFeature = eClass.getEStructuralFeature("version");
+
+            assertNotNull(versionFeature);
+            assertEquals(EcorePackage.Literals.EDOUBLE, versionFeature.getEType());
+
+            Object value = service.eGet(versionFeature);
+            assertEquals(0.1D, value);
+
+            EStructuralFeature startedFeature = eClass.getEStructuralFeature("started");
+
+            assertNotNull(startedFeature);
+            assertEquals(startedFeature.getEType(), SensiNactPackage.eINSTANCE.getEInstant());
+
+            Instant started = (Instant) service.eGet(startedFeature);
+            assertNotNull(started);
+            assertEquals(Instant.now().truncatedTo(DAYS), started.truncatedTo(DAYS));
         }
 
         @Test

--- a/prototype/core/impl/src/test/java/org/eclipse/sensinact/prototype/model/nexus/impl/SubscriptionTest.java
+++ b/prototype/core/impl/src/test/java/org/eclipse/sensinact/prototype/model/nexus/impl/SubscriptionTest.java
@@ -1,5 +1,5 @@
 /*********************************************************************
-* Copyright (c) 2022 Contributors to the Eclipse Foundation.
+* Copyright (c) 2023 Contributors to the Eclipse Foundation.
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0
@@ -62,6 +62,8 @@ public class SubscriptionTest {
         void basicTest() {
 
             ModelNexus nexus = new ModelNexus(resourceSet, SensiNactPackage.eINSTANCE, () -> accumulator);
+            // Ignore the setup of the sensiNact provider
+            Mockito.clearInvocations(accumulator);
 
             Instant now = Instant.now();
             nexus.handleDataUpdate("TestModel", TEST_PROVIDER, TEST_SERVICE, TEST_RESOURCE, String.class, TEST_VALUE,
@@ -85,6 +87,8 @@ public class SubscriptionTest {
         void basicServiceExtensionTest() {
 
             ModelNexus nexus = new ModelNexus(resourceSet, SensiNactPackage.eINSTANCE, () -> accumulator);
+            // Ignore the setup of the sensiNact provider
+            Mockito.clearInvocations(accumulator);
 
             Instant now = Instant.now();
             Instant before = now.minus(Duration.ofHours(1));
@@ -116,6 +120,8 @@ public class SubscriptionTest {
         void basicSecondServiceTest() {
 
             ModelNexus nexus = new ModelNexus(resourceSet, SensiNactPackage.eINSTANCE, () -> accumulator);
+            // Ignore the setup of the sensiNact provider
+            Mockito.clearInvocations(accumulator);
 
             Instant now = Instant.now();
             Instant before = now.minus(Duration.ofHours(1));
@@ -145,4 +151,3 @@ public class SubscriptionTest {
         }
     }
 }
-

--- a/prototype/northbound/rest/src/test/java/org/eclipse/sensinact/northbound/rest/integration/DescriptionsTest.java
+++ b/prototype/northbound/rest/src/test/java/org/eclipse/sensinact/northbound/rest/integration/DescriptionsTest.java
@@ -1,5 +1,5 @@
 /*********************************************************************
-* Copyright (c) 2022 Contributors to the Eclipse Foundation.
+* Copyright (c) 2023 Contributors to the Eclipse Foundation.
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0
@@ -146,7 +146,7 @@ public class DescriptionsTest {
         // Check the list of providers
         ResultProvidersListDTO result = utils.queryJson("/providers", ResultProvidersListDTO.class);
         utils.assertResultSuccess(result, "PROVIDERS_LIST");
-        assertEquals(result.providers, List.of(PROVIDER));
+        assertEquals(Set.of("sensiNact", PROVIDER), Set.copyOf(result.providers));
 
         // Add another provider
         dto.provider = PROVIDER_2;
@@ -157,7 +157,7 @@ public class DescriptionsTest {
         // Check the new list
         result = utils.queryJson("/providers", ResultProvidersListDTO.class);
         utils.assertResultSuccess(result, "PROVIDERS_LIST");
-        assertEquals(Set.of(PROVIDER, PROVIDER_2), Set.copyOf(result.providers));
+        assertEquals(Set.of("sensiNact", PROVIDER, PROVIDER_2), Set.copyOf(result.providers));
     }
 
     /**

--- a/prototype/northbound/sensorthings/rest.gateway/src/test/java/org/eclipse/sensinact/sensorthings/sensing/rest/integration/FiltersTest.java
+++ b/prototype/northbound/sensorthings/rest.gateway/src/test/java/org/eclipse/sensinact/sensorthings/sensing/rest/integration/FiltersTest.java
@@ -1,5 +1,5 @@
 /*********************************************************************
-* Copyright (c) 2022 Contributors to the Eclipse Foundation.
+* Copyright (c) 2023 Contributors to the Eclipse Foundation.
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0
@@ -30,6 +30,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import org.eclipse.sensinact.prototype.SensiNactSession;
 import org.eclipse.sensinact.prototype.SensiNactSessionManager;
@@ -128,14 +129,17 @@ public class FiltersTest {
     @Test
     void testOrderBy() throws IOException, InterruptedException {
         final String prefix = "orderTester_";
-        final List<String> sortedProviderIds = List.copyOf(IntStream.rangeClosed(0, 9).boxed().map(id -> prefix + id)
-                .sorted(Comparator.naturalOrder()).collect(Collectors.toList()));
+        final List<String> sortedProviderIds = Stream
+                .concat(IntStream.rangeClosed(0, 9).boxed().map(id -> prefix + id), Stream.of("sensiNact"))
+                .sorted(Comparator.naturalOrder()).collect(Collectors.toList());
         final int nbProviders = sortedProviderIds.size();
 
         final List<String> reversedProviderIds = new ArrayList<>(sortedProviderIds);
         Collections.reverse(reversedProviderIds);
 
-        sortedProviderIds.stream().forEach(id -> {
+        sortedProviderIds.stream()
+        .filter(id -> id.startsWith(prefix))
+        .forEach(id -> {
             session.setResourceValue(id, "svcA", "rcA", id);
             session.setResourceValue(id, "svcB", "rcA", id + 256);
             session.setResourceValue(id, "svcA", "rcB", id);


### PR DESCRIPTION
Note that this commit also:

* Fixes the set of supported types to include Instant via the SensinactPackage EInstant
* Adds a non-accumulating NotificationAccumulator instance for use when no command is running

Signed-off-by: Tim Ward <timothyjward@apache.org>