### PR TITLE
Require that admin/location is a GeoJsonObject

### DIFF
--- a/prototype/core/impl/integration-test.bndrun
+++ b/prototype/core/impl/integration-test.bndrun
@@ -13,6 +13,9 @@
 	order=sortbynameversion,\
 	begin=-1
 -runbundles: \
+	com.fasterxml.jackson.core.jackson-annotations;version='[2.14.0,2.14.1)',\
+	com.fasterxml.jackson.core.jackson-core;version='[2.14.0,2.14.1)',\
+	com.fasterxml.jackson.core.jackson-databind;version='[2.14.0,2.14.1)',\
 	junit-jupiter-api;version='[5.9.0,5.9.1)',\
 	junit-jupiter-engine;version='[5.9.0,5.9.1)',\
 	junit-jupiter-params;version='[5.9.0,5.9.1)',\
@@ -31,6 +34,7 @@
 	org.eclipse.emf.ecore.xmi;version='[2.16.0,2.16.1)',\
 	org.eclipse.sensinact.gateway.core.annotation;version='[0.0.1,0.0.2)',\
 	org.eclipse.sensinact.gateway.core.api;version='[0.0.1,0.0.2)',\
+	org.eclipse.sensinact.gateway.core.geo-json;version='[0.0.1,0.0.2)',\
 	org.eclipse.sensinact.gateway.core.impl;version='[0.0.1,0.0.2)',\
 	org.eclipse.sensinact.gateway.core.impl-tests;version='[0.0.1,0.0.2)',\
 	org.eclipse.sensinact.gateway.core.models;version='[0.0.1,0.0.2)',\

--- a/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/model/nexus/impl/ModelNexus.java
+++ b/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/model/nexus/impl/ModelNexus.java
@@ -34,6 +34,8 @@ import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EAnnotation;
 import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EClassifier;
+import org.eclipse.emf.ecore.EDataType;
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.resource.Resource;
@@ -309,10 +311,14 @@ public class ModelNexus {
         // Allow an update if the resource didn't exist or if the update timestamp is
         // equal to or after the one of the current value
         if (metadata == null || !metadata.getTimestamp().isAfter(timestamp)) {
-            service.eSet(resourceFeature, data);
+            EClassifier resourceType = resourceFeature.getEType();
+            if (data == null || resourceType.isInstance(data)) {
+                service.eSet(resourceFeature, data);
+            } else {
+                service.eSet(resourceFeature, EMFUtil.convertToTargetType(resourceType, data));
+            }
             accumulator.resourceValueUpdate(modelName, providerName, serviceFeature.getName(),
-                    resourceFeature.getName(), resourceFeature.getEType().getInstanceClass(), oldValue, data,
-                    timestamp);
+                    resourceFeature.getName(), resourceType.getInstanceClass(), oldValue, data, timestamp);
         } else {
             return;
         }

--- a/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/model/nexus/impl/emf/EMFUtil.java
+++ b/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/model/nexus/impl/emf/EMFUtil.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 
 import org.eclipse.emf.common.util.URI;
@@ -51,6 +52,8 @@ public class EMFUtil {
         EcorePackage.eINSTANCE.getEClassifiers().forEach(ec -> typeMap.put(ec.getInstanceClass(), ec));
         EDataType eInstant = SensiNactPackage.eINSTANCE.getEInstant();
         typeMap.put(eInstant.getInstanceClass(), eInstant);
+        EDataType eGeoJsonObject = SensiNactPackage.eINSTANCE.getEGeoJsonObject();
+        typeMap.put(eGeoJsonObject.getInstanceClass(), eGeoJsonObject);
     }
 
     public static Map<String, Object> toEObjectAttributesToMap(EObject eObject) {
@@ -175,4 +178,17 @@ public class EMFUtil {
         return getVersion((EClass) feature.eContainer());
     }
 
+    public static Object convertToTargetType(EClassifier targetType, Object o) {
+
+        if (o == null) {
+            return targetType.getInstanceClass().isPrimitive() ? targetType.getDefaultValue() : o;
+        } else {
+            EClassifier type = typeMap.get(o.getClass());
+            if (type == null) {
+                throw new IllegalArgumentException("Unknown data type " + o.getClass());
+            }
+            String string = type.getEPackage().getEFactoryInstance().convertToString((EDataType) type, o);
+            return targetType.getEPackage().getEFactoryInstance().createFromString((EDataType) targetType, string);
+        }
+    }
 }

--- a/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/model/nexus/impl/emf/EMFUtil.java
+++ b/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/model/nexus/impl/emf/EMFUtil.java
@@ -17,7 +17,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Function;
 
 import org.eclipse.emf.common.util.URI;

--- a/prototype/core/impl/src/test/java/org/eclipse/sensinact/prototype/integration/session/AdminServiceTest.java
+++ b/prototype/core/impl/src/test/java/org/eclipse/sensinact/prototype/integration/session/AdminServiceTest.java
@@ -16,6 +16,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.time.Instant;
+import java.util.List;
+import java.util.Map;
 
 import org.eclipse.sensinact.prototype.ResourceDescription;
 import org.eclipse.sensinact.prototype.SensiNactSession;
@@ -26,6 +28,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.osgi.test.common.annotation.InjectService;
 import org.osgi.test.junit5.service.ServiceExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Tests the behavior around the admin service
@@ -87,7 +91,8 @@ public class AdminServiceTest {
         assertEquals(timestamp, descr.timestamp);
 
         // Reject earlier values
-        session.setResourceValue(PROVIDER, "admin", "location", "bar", timestamp.minusSeconds(1));
+        session.setResourceValue(PROVIDER, "admin", "location",
+                "{\"type\":\"Point\",\"coordinates\":[-0.119700, 51.503300]}", timestamp.minusSeconds(1));
         descr = session.describeResource(PROVIDER, "admin", "location");
         assertNull(descr.value);
         assertEquals(timestamp, descr.timestamp);
@@ -98,9 +103,11 @@ public class AdminServiceTest {
         assertEquals("foo", descr.value);
         assertEquals(timestamp, descr.timestamp);
 
-        session.setResourceValue(PROVIDER, "admin", "location", "bar", timestamp);
+        session.setResourceValue(PROVIDER, "admin", "location",
+                "{\"type\":\"Point\",\"coordinates\":[-0.119700, 51.503300]}", timestamp);
         descr = session.describeResource(PROVIDER, "admin", "location");
-        assertEquals("bar", descr.value);
+        assertEquals(Map.of("type", "Point", "coordinates", List.of(-0.119700d, 51.503300d)),
+                new ObjectMapper().convertValue(descr.value, Map.class));
         assertEquals(timestamp, descr.timestamp);
 
         // Set the value with a future timestamp
@@ -109,10 +116,11 @@ public class AdminServiceTest {
         descr = session.describeResource(PROVIDER, "admin", "friendlyName");
         assertEquals("eclipse", descr.value);
         assertEquals(future, descr.timestamp);
-
-        session.setResourceValue(PROVIDER, "admin", "location", "sensiNact", future);
+        session.setResourceValue(PROVIDER, "admin", "location",
+                "{\"type\":\"Point\",\"coordinates\":[2.295049, 48.873785]}", future);
         descr = session.describeResource(PROVIDER, "admin", "location");
-        assertEquals("sensiNact", descr.value);
+        assertEquals(Map.of("type", "Point", "coordinates", List.of(2.295049d, 48.873785d)),
+                new ObjectMapper().convertValue(descr.value, Map.class));
         assertEquals(future, descr.timestamp);
     }
 }

--- a/prototype/core/models/pom.xml
+++ b/prototype/core/models/pom.xml
@@ -36,6 +36,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>geo-json</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.geckoprojects.emf</groupId>
       <artifactId>org.gecko.emf.osgi.api</artifactId>
     </dependency>

--- a/prototype/core/models/src/main/resources/model/sensinact.ecore
+++ b/prototype/core/models/src/main/resources/model/sensinact.ecore
@@ -12,9 +12,10 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="linkedProviders" upperBound="-1"
         eType="#//Provider"/>
   </eClassifiers>
+  <eClassifiers xsi:type="ecore:EDataType" name="EGeoJsonObject" instanceClassName="org.eclipse.sensinact.gateway.geojson.GeoJsonObject"/>
   <eClassifiers xsi:type="ecore:EClass" name="Admin" eSuperTypes="#//Service">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="friendlyName" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="location" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="location" eType="#//EGeoJsonObject"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Service">
     <eStructuralFeatures xsi:type="ecore:EReference" name="metadata" upperBound="-1"

--- a/prototype/core/models/src/main/resources/model/sensinact.genmodel
+++ b/prototype/core/models/src/main/resources/model/sensinact.genmodel
@@ -8,6 +8,8 @@
   <foreignModel>sensinact.ecore</foreignModel>
   <genPackages prefix="SensiNact" basePackage="org.eclipse.sensinact.model" resource="XMI"
       disposableProviderFactory="true" literalsInterface="false" ecorePackage="sensinact.ecore#/">
+    <genDataTypes ecoreDataType="sensinact.ecore#//EGeoJsonObject" create="try { return new com.fasterxml.jackson.databind.ObjectMapper().readValue(it, GeoJsonObject.class); } catch (com.fasterxml.jackson.core.JsonProcessingException e) { throw new IllegalArgumentException(e); }"
+        convert="try { return new com.fasterxml.jackson.databind.ObjectMapper().writeValueAsString(it); } catch (com.fasterxml.jackson.core.JsonProcessingException e) { throw new IllegalArgumentException(e); }"/>
     <genDataTypes ecoreDataType="sensinact.ecore#//EInstant" create="return Instant.parse(it);"
         convert="return it.toString();"/>
     <genClasses ecoreClass="sensinact.ecore#//Provider">

--- a/prototype/northbound/rest/integration-test.bndrun
+++ b/prototype/northbound/rest/integration-test.bndrun
@@ -61,6 +61,7 @@
 	org.eclipse.parsson.jakarta.json;version='[1.1.1,1.1.2)',\
 	org.eclipse.sensinact.gateway.core.annotation;version='[0.0.1,0.0.2)',\
 	org.eclipse.sensinact.gateway.core.api;version='[0.0.1,0.0.2)',\
+	org.eclipse.sensinact.gateway.core.geo-json;version='[0.0.1,0.0.2)',\
 	org.eclipse.sensinact.gateway.core.impl;version='[0.0.1,0.0.2)',\
 	org.eclipse.sensinact.gateway.core.models;version='[0.0.1,0.0.2)',\
 	org.eclipse.sensinact.gateway.northbound.rest;version='[0.0.1,0.0.2)',\

--- a/prototype/northbound/rest/pom.xml
+++ b/prototype/northbound/rest/pom.xml
@@ -27,6 +27,11 @@
       <artifactId>api</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.sensinact.gateway.core</groupId>
+      <artifactId>geo-json</artifactId>
+      <version>${project.version}</version>
+    </dependency>
 
     <!-- SL4J -->
     <dependency>

--- a/prototype/northbound/rest/src/main/java/org/eclipse/sensinact/northbound/rest/dto/CompleteProviderDescriptionDTO.java
+++ b/prototype/northbound/rest/src/main/java/org/eclipse/sensinact/northbound/rest/dto/CompleteProviderDescriptionDTO.java
@@ -16,6 +16,8 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 import java.util.List;
 
+import org.eclipse.sensinact.gateway.geojson.GeoJsonObject;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 public class CompleteProviderDescriptionDTO {
@@ -29,7 +31,7 @@ public class CompleteProviderDescriptionDTO {
      * Provider location, if available
      */
     @JsonInclude(NON_NULL)
-    public String location;
+    public GeoJsonObject location;
 
     /**
      * Provider icon, if available

--- a/prototype/northbound/rest/src/main/java/org/eclipse/sensinact/northbound/rest/impl/RestNorthbound.java
+++ b/prototype/northbound/rest/src/main/java/org/eclipse/sensinact/northbound/rest/impl/RestNorthbound.java
@@ -22,6 +22,7 @@ import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
+import org.eclipse.sensinact.gateway.geojson.GeoJsonObject;
 import org.eclipse.sensinact.northbound.rest.api.IRestNorthbound;
 import org.eclipse.sensinact.northbound.rest.dto.AccessMethodCallParameterDTO;
 import org.eclipse.sensinact.northbound.rest.dto.AccessMethodDTO;
@@ -130,7 +131,8 @@ public class RestNorthbound implements IRestNorthbound {
                 providerDto.name = provider;
                 providerDto.services = new ArrayList<>(providerDescription.services.size());
 
-                final String location = userSession.getResourceValue(provider, "admin", "location", String.class);
+                final GeoJsonObject location = userSession.getResourceValue(provider, "admin", "location",
+                        GeoJsonObject.class);
                 if (location != null) {
                     providerDto.location = location;
                 }

--- a/prototype/northbound/rest/src/test/java/org/eclipse/sensinact/northbound/rest/integration/ResourceAccessTest.java
+++ b/prototype/northbound/rest/src/test/java/org/eclipse/sensinact/northbound/rest/integration/ResourceAccessTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.sensinact.gateway.geojson.GeoJsonObject;
 import org.eclipse.sensinact.northbound.rest.dto.AccessMethodCallParameterDTO;
 import org.eclipse.sensinact.northbound.rest.dto.GetResponse;
 import org.eclipse.sensinact.northbound.rest.dto.ResultTypedResponseDTO;
@@ -210,7 +211,7 @@ public class ResourceAccessTest {
                 ResultTypedResponseDTO.class);
         utils.assertResultSuccess(result, "GET_RESPONSE", PROVIDER, "admin", "location");
         response = utils.convert(result, GetResponse.class);
-        assertEquals(String.class.getName(), response.type);
+        assertEquals(GeoJsonObject.class.getName(), response.type);
         assertNull(response.value);
     }
 }

--- a/prototype/southbound/device-factory/parser-csv/src/test/java/org/eclipse/sensinact/gateway/southbound/device/parser/integration/csv/CSVParserTest.java
+++ b/prototype/southbound/device-factory/parser-csv/src/test/java/org/eclipse/sensinact/gateway/southbound/device/parser/integration/csv/CSVParserTest.java
@@ -110,11 +110,10 @@ public class CSVParserTest {
         assertEquals(timestamp2, session.describeResource(provider2, "data", "value").timestamp);
 
         // Ensure location update (and its timestamp)
-        final ObjectMapper mapper = new ObjectMapper();
         ResourceDescription location1 = session.describeResource(provider1, "admin", "location");
         assertEquals(timestamp1, location1.timestamp);
         assertNotNull(location1.value);
-        Point geoPoint = mapper.readValue(String.valueOf(location1.value), Point.class);
+        Point geoPoint = (Point) location1.value;
         assertEquals(1.2, geoPoint.coordinates.latitude, 0.001);
         assertEquals(3.4, geoPoint.coordinates.longitude, 0.001);
         assertTrue(Double.isNaN(geoPoint.coordinates.elevation));
@@ -122,7 +121,7 @@ public class CSVParserTest {
         ResourceDescription location2 = session.describeResource(provider2, "admin", "location");
         assertNotNull(location2.value);
         assertEquals(timestamp2, location2.timestamp);
-        geoPoint = mapper.readValue(String.valueOf(location2.value), Point.class);
+        geoPoint = (Point) location2.value;
         assertEquals(5.6, geoPoint.coordinates.latitude, 0.001);
         assertEquals(7.8, geoPoint.coordinates.longitude, 0.001);
         assertTrue(Double.isNaN(geoPoint.coordinates.elevation));
@@ -162,11 +161,10 @@ public class CSVParserTest {
         assertEquals(timestamp2, session.describeResource(provider2, "data", "value").timestamp);
 
         // Ensure location update (and its timestamp)
-        final ObjectMapper mapper = new ObjectMapper();
         ResourceDescription location1 = session.describeResource(provider1, "admin", "location");
         assertEquals(timestamp1, location1.timestamp);
         assertNotNull(location1.value);
-        Point geoPoint = mapper.readValue(String.valueOf(location1.value), Point.class);
+        Point geoPoint = (Point) location1.value;
         assertEquals(1.2, geoPoint.coordinates.latitude, 0.001);
         assertEquals(3.4, geoPoint.coordinates.longitude, 0.001);
         assertTrue(Double.isNaN(geoPoint.coordinates.elevation));
@@ -174,7 +172,7 @@ public class CSVParserTest {
         ResourceDescription location2 = session.describeResource(provider2, "admin", "location");
         assertNotNull(location2.value);
         assertEquals(timestamp2, location2.timestamp);
-        geoPoint = mapper.readValue(String.valueOf(location2.value), Point.class);
+        geoPoint = (Point) location2.value;
         assertEquals(5.6, geoPoint.coordinates.latitude, 0.001);
         assertEquals(7.8, geoPoint.coordinates.longitude, 0.001);
         assertTrue(Double.isNaN(geoPoint.coordinates.elevation));
@@ -214,11 +212,10 @@ public class CSVParserTest {
         assertEquals(timestamp2, session.describeResource(provider2, "data", "value").timestamp);
 
         // Ensure location update (and its timestamp)
-        final ObjectMapper mapper = new ObjectMapper();
         ResourceDescription location1 = session.describeResource(provider1, "admin", "location");
         assertEquals(timestamp1, location1.timestamp);
         assertNotNull(location1.value);
-        Point geoPoint = mapper.readValue(String.valueOf(location1.value), Point.class);
+        Point geoPoint = (Point) location1.value;
         assertEquals(1.2, geoPoint.coordinates.latitude, 0.001);
         assertEquals(3.4, geoPoint.coordinates.longitude, 0.001);
         assertTrue(Double.isNaN(geoPoint.coordinates.elevation));
@@ -226,7 +223,7 @@ public class CSVParserTest {
         ResourceDescription location2 = session.describeResource(provider2, "admin", "location");
         assertNotNull(location2.value);
         assertEquals(timestamp2, location2.timestamp);
-        geoPoint = mapper.readValue(String.valueOf(location2.value), Point.class);
+        geoPoint = (Point) location2.value;
         assertEquals(5.6, geoPoint.coordinates.latitude, 0.001);
         assertEquals(7.8, geoPoint.coordinates.longitude, 0.001);
         assertTrue(Double.isNaN(geoPoint.coordinates.elevation));

--- a/prototype/southbound/device-factory/parser-json/src/test/java/org/eclipse/sensinact/gateway/southbound/device/parser/integration/json/JSONParserTest.java
+++ b/prototype/southbound/device-factory/parser-json/src/test/java/org/eclipse/sensinact/gateway/southbound/device/parser/integration/json/JSONParserTest.java
@@ -110,11 +110,10 @@ public class JSONParserTest {
         assertEquals(timestamp2, session.describeResource(provider2, "data", "value").timestamp);
 
         // Ensure location update (and its timestamp)
-        final ObjectMapper mapper = new ObjectMapper();
         ResourceDescription location1 = session.describeResource(provider1, "admin", "location");
         assertEquals(timestamp1, location1.timestamp);
         assertNotNull(location1.value);
-        Point geoPoint = mapper.readValue(String.valueOf(location1.value), Point.class);
+        Point geoPoint = (Point) location1.value;
         assertEquals(1.2, geoPoint.coordinates.latitude, 0.001);
         assertEquals(3.4, geoPoint.coordinates.longitude, 0.001);
         assertTrue(Double.isNaN(geoPoint.coordinates.elevation));
@@ -122,7 +121,7 @@ public class JSONParserTest {
         ResourceDescription location2 = session.describeResource(provider2, "admin", "location");
         assertNotNull(location2.value);
         assertEquals(timestamp2, location2.timestamp);
-        geoPoint = mapper.readValue(String.valueOf(location2.value), Point.class);
+        geoPoint = (Point) location2.value;
         assertEquals(5.6, geoPoint.coordinates.latitude, 0.001);
         assertEquals(7.8, geoPoint.coordinates.longitude, 0.001);
         assertEquals(1.5, geoPoint.coordinates.elevation, 0.001);
@@ -164,11 +163,10 @@ public class JSONParserTest {
         assertEquals(timestamp2, session.describeResource(provider2, "data", "value").timestamp);
 
         // Ensure location update (and its timestamp)
-        final ObjectMapper mapper = new ObjectMapper();
         ResourceDescription location1 = session.describeResource(provider1, "admin", "location");
         assertEquals(timestamp1, location1.timestamp);
         assertNotNull(location1.value);
-        Point geoPoint = mapper.readValue(String.valueOf(location1.value), Point.class);
+        Point geoPoint = (Point) location1.value;
         assertEquals(1.2, geoPoint.coordinates.latitude, 0.001);
         assertEquals(3.4, geoPoint.coordinates.longitude, 0.001);
         assertTrue(Double.isNaN(geoPoint.coordinates.elevation));
@@ -176,7 +174,7 @@ public class JSONParserTest {
         ResourceDescription location2 = session.describeResource(provider2, "admin", "location");
         assertNotNull(location2.value);
         assertEquals(timestamp2, location2.timestamp);
-        geoPoint = mapper.readValue(String.valueOf(location2.value), Point.class);
+        geoPoint = (Point) location2.value;
         assertEquals(5.6, geoPoint.coordinates.latitude, 0.001);
         assertEquals(7.8, geoPoint.coordinates.longitude, 0.001);
         assertTrue(Double.isNaN(geoPoint.coordinates.elevation));
@@ -213,11 +211,10 @@ public class JSONParserTest {
         assertEquals(timestamp, session.describeResource(provider, "data", "value").timestamp);
 
         // Ensure location update (and its timestamp)
-        final ObjectMapper mapper = new ObjectMapper();
         ResourceDescription location = session.describeResource(provider, "admin", "location");
         assertEquals(timestamp, location.timestamp);
         assertNotNull(location.value);
-        Point geoPoint = mapper.readValue(String.valueOf(location.value), Point.class);
+        Point geoPoint = (Point) location.value;
         assertEquals(45.199, geoPoint.coordinates.latitude, 0.001);
         assertEquals(5.725, geoPoint.coordinates.longitude, 0.001);
         assertEquals(476, geoPoint.coordinates.elevation);
@@ -278,11 +275,10 @@ public class JSONParserTest {
         assertEquals(timestamp, session.describeResource(provider1, "data", type1 + "_value").timestamp);
 
         // Ensure location update (and its timestamp)
-        final ObjectMapper mapper = new ObjectMapper();
         ResourceDescription location = session.describeResource(provider1, "admin", "location");
         assertEquals(timestamp, location.timestamp);
         assertNotNull(location.value);
-        Point geoPoint = mapper.readValue(String.valueOf(location.value), Point.class);
+        Point geoPoint = (Point) location.value;
         assertEquals(48.849577, geoPoint.coordinates.latitude, 0.001);
         assertEquals(2.350867, geoPoint.coordinates.longitude, 0.001);
         assertTrue(Double.isNaN(geoPoint.coordinates.elevation));
@@ -298,7 +294,7 @@ public class JSONParserTest {
         location = session.describeResource(provider2, "admin", "location");
         assertEquals(timestamp, location.timestamp);
         assertNotNull(location.value);
-        geoPoint = mapper.readValue(String.valueOf(location.value), Point.class);
+        geoPoint = (Point) location.value;
         assertEquals(48.858396, geoPoint.coordinates.latitude, 0.001);
         assertEquals(2.350484, geoPoint.coordinates.longitude, 0.001);
         assertTrue(Double.isNaN(geoPoint.coordinates.elevation));

--- a/prototype/southbound/http/http-device-factory/src/test/java/org/eclipse/sensinact/gateway/southbound/http/factory/integration/HttpDeviceFactoryTest.java
+++ b/prototype/southbound/http/http-device-factory/src/test/java/org/eclipse/sensinact/gateway/southbound/http/factory/integration/HttpDeviceFactoryTest.java
@@ -164,7 +164,7 @@ public class HttpDeviceFactoryTest {
             ResourceDescription location1 = session.describeResource(provider1, "admin", "location");
             assertEquals(timestamp1, location1.timestamp);
             assertNotNull(location1.value);
-            Point geoPoint = mapper.readValue(String.valueOf(location1.value), Point.class);
+            Point geoPoint = (Point) location1.value;
             assertEquals(1.2, geoPoint.coordinates.latitude, 0.001);
             assertEquals(3.4, geoPoint.coordinates.longitude, 0.001);
             assertTrue(Double.isNaN(geoPoint.coordinates.elevation));
@@ -172,7 +172,7 @@ public class HttpDeviceFactoryTest {
             ResourceDescription location2 = session.describeResource(provider2, "admin", "location");
             assertNotNull(location2.value);
             assertEquals(timestamp2, location2.timestamp);
-            geoPoint = mapper.readValue(String.valueOf(location2.value), Point.class);
+            geoPoint = (Point) location2.value;
             assertEquals(5.6, geoPoint.coordinates.latitude, 0.001);
             assertEquals(7.8, geoPoint.coordinates.longitude, 0.001);
             assertTrue(Double.isNaN(geoPoint.coordinates.elevation));
@@ -325,7 +325,7 @@ public class HttpDeviceFactoryTest {
             ResourceDescription location1 = session.describeResource(provider1, "admin", "location");
             final Instant firstLocationTimestamp = location1.timestamp;
             assertNotNull(location1.value);
-            Point geoPoint = mapper.readValue(String.valueOf(location1.value), Point.class);
+            Point geoPoint = (Point) location1.value;
             assertEquals(45.185, geoPoint.coordinates.latitude, 0.001);
             assertEquals(5.735, geoPoint.coordinates.longitude, 0.001);
             assertTrue(Double.isNaN(geoPoint.coordinates.elevation));

--- a/prototype/southbound/mqtt/mqtt-device-factory/src/test/java/org/eclipse/sensinact/gateway/southbound/mqtt/factory/integration/MqttDeviceFactoryTest.java
+++ b/prototype/southbound/mqtt/mqtt-device-factory/src/test/java/org/eclipse/sensinact/gateway/southbound/mqtt/factory/integration/MqttDeviceFactoryTest.java
@@ -165,11 +165,10 @@ public class MqttDeviceFactoryTest {
         assertEquals(timestamp2, session.describeResource(provider2, "data", "value").timestamp);
 
         // Ensure location update (and its timestamp)
-        final ObjectMapper mapper = new ObjectMapper();
         ResourceDescription location1 = session.describeResource(provider1, "admin", "location");
         assertEquals(timestamp1, location1.timestamp);
         assertNotNull(location1.value);
-        Point geoPoint = mapper.readValue(String.valueOf(location1.value), Point.class);
+        Point geoPoint = (Point) location1.value;
         assertEquals(1.2, geoPoint.coordinates.latitude, 0.001);
         assertEquals(3.4, geoPoint.coordinates.longitude, 0.001);
         assertTrue(Double.isNaN(geoPoint.coordinates.elevation));
@@ -177,7 +176,7 @@ public class MqttDeviceFactoryTest {
         ResourceDescription location2 = session.describeResource(provider2, "admin", "location");
         assertNotNull(location2.value);
         assertEquals(timestamp2, location2.timestamp);
-        geoPoint = mapper.readValue(String.valueOf(location2.value), Point.class);
+        geoPoint = (Point) location2.value;
         assertEquals(5.6, geoPoint.coordinates.latitude, 0.001);
         assertEquals(7.8, geoPoint.coordinates.longitude, 0.001);
         assertTrue(Double.isNaN(geoPoint.coordinates.elevation));


### PR DESCRIPTION
The Admin service location resource should always be valid Geo Json. We can require this by using a GeoJsonObject as the type of the resource.

Signed-off-by: Tim Ward <timothyjward@apache.org>