### PR TITLE
Refactor the ModelNexus

### DIFF
--- a/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/model/impl/ModelBuilderImpl.java
+++ b/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/model/impl/ModelBuilderImpl.java
@@ -28,7 +28,7 @@ public class ModelBuilderImpl extends AbstractBuilderImpl<Model> implements Mode
     private final NotificationAccumulator accumulator;
     private final ModelNexus nexusImpl;
     private final String name;
-    private final List<NestableBuilderImpl<?, Model, ?>> nested = new ArrayList<>();
+    private final List<NestableBuilderImpl<?, ModelImpl, ?>> nested = new ArrayList<>();
     private Instant creationTime;
 
     public ModelBuilderImpl(AtomicBoolean active, NotificationAccumulator accumulator, ModelNexus nexusImpl,

--- a/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/model/impl/ModelImpl.java
+++ b/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/model/impl/ModelImpl.java
@@ -12,13 +12,13 @@
 **********************************************************************/
 package org.eclipse.sensinact.prototype.model.impl;
 
+import static java.util.stream.Collectors.toMap;
+
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.eclipse.emf.ecore.EClass;
-import org.eclipse.sensinact.model.core.SensiNactPackage;
+import org.eclipse.emf.ecore.EReference;
 import org.eclipse.sensinact.prototype.command.impl.CommandScopedImpl;
 import org.eclipse.sensinact.prototype.model.Model;
 import org.eclipse.sensinact.prototype.model.Service;
@@ -72,13 +72,13 @@ public class ModelImpl extends CommandScopedImpl implements Model {
     @Override
     public Map<String, ? extends Service> getServices() {
         checkValid();
-        // Remember to add in the provider, which is in the parent type and
-        // therefore doesn't show up in EStructuralFeatures
-        return Stream
-                .concat(Stream.of(SensiNactPackage.eINSTANCE.getProvider_Admin()),
-                        eClass.getEStructuralFeatures().stream())
-                .collect(Collectors.toMap(f -> f.getName(),
-                        f -> new ServiceImpl(active, this, f, nexusImpl, accumulator)));
+        // Use nexusImpl to get services reliably
+        return nexusImpl.getServicesForModel(eClass)
+                .collect(toMap(EReference::getName, r -> new ServiceImpl(active, this, r, nexusImpl, accumulator)));
+    }
+
+    EClass getModelEClass() {
+        return eClass;
     }
 
 }

--- a/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/model/impl/ResourceBuilderImpl.java
+++ b/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/model/impl/ResourceBuilderImpl.java
@@ -21,12 +21,11 @@ import java.util.function.Supplier;
 import org.eclipse.sensinact.prototype.model.Resource;
 import org.eclipse.sensinact.prototype.model.ResourceBuilder;
 import org.eclipse.sensinact.prototype.model.ResourceType;
-import org.eclipse.sensinact.prototype.model.Service;
 import org.eclipse.sensinact.prototype.model.ValueType;
 import org.eclipse.sensinact.prototype.model.nexus.impl.ModelNexus;
 import org.eclipse.sensinact.prototype.notification.NotificationAccumulator;
 
-public class ResourceBuilderImpl<R, T> extends NestableBuilderImpl<R, Service, Resource>
+public class ResourceBuilderImpl<R, T> extends NestableBuilderImpl<R, ServiceImpl, Resource>
         implements ResourceBuilder<R, T> {
 
     private final String name;
@@ -37,8 +36,8 @@ public class ResourceBuilderImpl<R, T> extends NestableBuilderImpl<R, Service, R
     private Instant timestamp;
     private ResourceType resourceType = null;
 
-    public ResourceBuilderImpl(AtomicBoolean active, R parent, Service builtParent, String name, ModelNexus nexusImpl,
-            NotificationAccumulator accumulator) {
+    public ResourceBuilderImpl(AtomicBoolean active, R parent, ServiceImpl builtParent, String name,
+            ModelNexus nexusImpl, NotificationAccumulator accumulator) {
         super(active, parent, builtParent);
         this.name = name;
         this.nexusImpl = nexusImpl;
@@ -134,9 +133,9 @@ public class ResourceBuilderImpl<R, T> extends NestableBuilderImpl<R, Service, R
     }
 
     @Override
-    protected Resource doBuild(Service builtParent) {
-        return new ResourceImpl(active, builtParent, nexusImpl.createResource(builtParent.getModel().getName(),
-                builtParent.getName(), name, type, initialValue, timestamp, accumulator));
+    protected Resource doBuild(ServiceImpl builtParent) {
+        return new ResourceImpl(active, builtParent, nexusImpl.createResource(builtParent.getServiceEClass(), name,
+                type, timestamp, initialValue, accumulator));
     }
 
 }

--- a/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/model/impl/ServiceBuilderImpl.java
+++ b/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/model/impl/ServiceBuilderImpl.java
@@ -17,22 +17,21 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.eclipse.sensinact.prototype.model.Model;
 import org.eclipse.sensinact.prototype.model.ResourceBuilder;
 import org.eclipse.sensinact.prototype.model.Service;
 import org.eclipse.sensinact.prototype.model.ServiceBuilder;
 import org.eclipse.sensinact.prototype.model.nexus.impl.ModelNexus;
 import org.eclipse.sensinact.prototype.notification.NotificationAccumulator;
 
-public class ServiceBuilderImpl<P> extends NestableBuilderImpl<P, Model, Service> implements ServiceBuilder<P> {
+public class ServiceBuilderImpl<P> extends NestableBuilderImpl<P, ModelImpl, Service> implements ServiceBuilder<P> {
 
     private final String name;
     private final ModelNexus nexusImpl;
     private final NotificationAccumulator accumulator;
-    private final List<NestableBuilderImpl<?, Service, ?>> nested = new ArrayList<>();
+    private final List<NestableBuilderImpl<?, ServiceImpl, ?>> nested = new ArrayList<>();
     private Instant creationTimestamp;
 
-    public ServiceBuilderImpl(AtomicBoolean active, P parent, Model built, String name, ModelNexus nexusImpl,
+    public ServiceBuilderImpl(AtomicBoolean active, P parent, ModelImpl built, String name, ModelNexus nexusImpl,
             NotificationAccumulator accumulator) {
         super(active, parent, built);
         this.name = name;
@@ -68,10 +67,10 @@ public class ServiceBuilderImpl<P> extends NestableBuilderImpl<P, Model, Service
         return rb;
     }
 
-    protected Service doBuild(Model builtParent) {
+    protected Service doBuild(ModelImpl builtParent) {
         checkValid();
-        Service s = new ServiceImpl(active, builtParent,
-                nexusImpl.createService(builtParent.getName(), name,
+        ServiceImpl s = new ServiceImpl(active, builtParent,
+                nexusImpl.createService(builtParent.getModelEClass(), name,
                         creationTimestamp == null ? Instant.now() : creationTimestamp, accumulator),
                 nexusImpl, accumulator);
         nested.forEach(n -> n.doBuild(s));

--- a/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/model/impl/ServiceImpl.java
+++ b/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/model/impl/ServiceImpl.java
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import org.eclipse.emf.ecore.EClass;
-import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.ecore.EReference;
 import org.eclipse.sensinact.prototype.command.impl.CommandScopedImpl;
 import org.eclipse.sensinact.prototype.model.Model;
 import org.eclipse.sensinact.prototype.model.Resource;
@@ -29,15 +29,15 @@ import org.eclipse.sensinact.prototype.notification.NotificationAccumulator;
 public class ServiceImpl extends CommandScopedImpl implements Service {
 
     private final Model model;
-    private final EStructuralFeature feature;
+    private final EReference service;
     private final ModelNexus nexusImpl;
     private NotificationAccumulator accumulator;
 
-    public ServiceImpl(AtomicBoolean active, Model model, EStructuralFeature feature, ModelNexus nexusImpl,
+    public ServiceImpl(AtomicBoolean active, Model model, EReference service, ModelNexus nexusImpl,
             NotificationAccumulator accumulator) {
         super(active);
         this.model = model;
-        this.feature = feature;
+        this.service = service;
         this.nexusImpl = nexusImpl;
         this.accumulator = accumulator;
     }
@@ -45,7 +45,7 @@ public class ServiceImpl extends CommandScopedImpl implements Service {
     @Override
     public String getName() {
         checkValid();
-        return feature.getName();
+        return service.getName();
     }
 
     @Override
@@ -69,7 +69,7 @@ public class ServiceImpl extends CommandScopedImpl implements Service {
     @Override
     public Map<String, ? extends Resource> getResources() {
         checkValid();
-        return ((EClass) feature.getEType()).getEStructuralFeatures().stream()
+        return nexusImpl.getResourcesForService(getServiceEClass())
                 .collect(Collectors.toMap(f -> f.getName(), f -> new ResourceImpl(active, this, f)));
     }
 
@@ -79,4 +79,7 @@ public class ServiceImpl extends CommandScopedImpl implements Service {
         return model;
     }
 
+    EClass getServiceEClass() {
+        return service.getEReferenceType();
+    }
 }

--- a/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/twin/impl/SensinactProviderImpl.java
+++ b/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/twin/impl/SensinactProviderImpl.java
@@ -12,86 +12,79 @@
 **********************************************************************/
 package org.eclipse.sensinact.prototype.twin.impl;
 
-import java.util.Collection;
-import java.util.HashMap;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.eclipse.emf.ecore.EReference;
+import org.eclipse.sensinact.model.core.Provider;
 import org.eclipse.sensinact.prototype.command.impl.CommandScopedImpl;
+import org.eclipse.sensinact.prototype.model.nexus.impl.ModelNexus;
 import org.eclipse.sensinact.prototype.twin.SensinactProvider;
 import org.eclipse.sensinact.prototype.twin.SensinactService;
+import org.osgi.util.promise.PromiseFactory;
 
 public class SensinactProviderImpl extends CommandScopedImpl implements SensinactProvider {
 
-    private final String model;
-    private final String name;
+    private final Provider provider;
 
-    /**
-     * Service name -&gt; service bean
-     */
-    private final Map<String, SensinactService> services = new HashMap<>();
+    private final ModelNexus nexus;
 
-    public SensinactProviderImpl(AtomicBoolean active, String model, String name) {
+    private final PromiseFactory promiseFactory;
+
+    public SensinactProviderImpl(AtomicBoolean active, Provider provider, ModelNexus nexus,
+            PromiseFactory promiseFactory) {
         super(active);
-        this.model = model;
-        this.name = name;
+        this.provider = provider;
+        this.nexus = nexus;
+        this.promiseFactory = promiseFactory;
     }
 
     @Override
     public Map<String, SensinactService> getServices() {
-        return Map.copyOf(services);
-    }
-
-    /**
-     * Bundle-private way to populate services
-     */
-    public void setServices(final Map<String, SensinactService> services) {
-        synchronized (this.services) {
-            this.services.clear();
-            this.services.putAll(services);
-        }
-    }
-
-    /**
-     * Bundle-private way to populate services
-     */
-    public void setServices(final Collection<SensinactService> services) {
-        setServices(services.stream().collect(Collectors.toMap(SensinactService::getName, Function.identity())));
+        checkValid();
+        return nexus.getServicesForModel(provider.eClass()).collect(Collectors.toMap(EReference::getName,
+                r -> new SensinactServiceImpl(active, this, provider, r, nexus, promiseFactory)));
     }
 
     @Override
     public String getName() {
-        return name;
+        checkValid();
+        return provider.getId();
     }
 
     @Override
     public String getModelName() {
-        return model;
+        checkValid();
+        return nexus.getModelName(provider.eClass());
     }
 
     @Override
     public String toString() {
-        return String.format("SensiNactProvider(model=%s, name=%s, services=%s)", model, name, services.keySet());
+        checkValid();
+        return String.format("SensiNactProvider(model=%s, name=%s, services=%s)", getModelName(), getName(),
+                getServices().keySet());
     }
 
     @Override
     public List<SensinactProvider> getLinkedProviders() {
-        // TODO Auto-generated method stub
-        return null;
+        checkValid();
+        return provider.getLinkedProviders().stream()
+                .map(p -> new SensinactProviderImpl(active, provider, nexus, promiseFactory))
+                .collect(Collectors.toList());
     }
 
     @Override
     public void addLinkedProvider(SensinactProvider provider) {
-        // TODO Auto-generated method stub
-
+        checkValid();
+        nexus.linkProviders(getName(), provider.getName(), Instant.now());
     }
 
     @Override
     public void removeLinkedProvider(SensinactProvider provider) {
-        // TODO Auto-generated method stub
-
+        checkValid();
+        nexus.unlinkProviders(getName(), provider.getName(), Instant.now());
     }
 }

--- a/prototype/core/impl/src/test/java/org/eclipse/sensinact/prototype/command/impl/GatewayThreadImplTest.java
+++ b/prototype/core/impl/src/test/java/org/eclipse/sensinact/prototype/command/impl/GatewayThreadImplTest.java
@@ -16,6 +16,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
@@ -55,8 +59,17 @@ public class GatewayThreadImplTest {
     GatewayThreadImpl thread = null;
 
     @BeforeEach
-    void setup() {
+    void setup() throws IOException {
 
+        Path path = Paths.get("data", "instances");
+        if (Files.isDirectory(path)) {
+            Files.walk(path, 1).filter(Files::isRegularFile).forEach(t -> {
+                try {
+                    Files.delete(t);
+                } catch (IOException e) {
+                }
+            });
+        }
         resourceSet = EMFTestUtil.createResourceSet();
 
         thread = new GatewayThreadImpl(typedEventBus, resourceSet, sensinactPackage);

--- a/prototype/core/impl/src/test/java/org/eclipse/sensinact/prototype/model/nexus/impl/NexusTest.java
+++ b/prototype/core/impl/src/test/java/org/eclipse/sensinact/prototype/model/nexus/impl/NexusTest.java
@@ -27,9 +27,11 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.time.Instant;
-import java.util.List;
+import java.util.Collection;
 
+import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.EcorePackage;
 import org.eclipse.emf.ecore.resource.ResourceSet;
@@ -110,8 +112,14 @@ public class NexusTest {
 
             ModelNexus nexus = new ModelNexus(resourceSet, SensiNactPackage.eINSTANCE, () -> accumulator);
 
-            nexus.handleDataUpdate("TestModel", "testprovider", "testservice", "testValue", String.class, "test",
-                    Instant.now());
+            Instant now = Instant.now();
+            EClass model = nexus.createModel("TestModel", now, accumulator);
+            EReference service = nexus.createService(model, "testservice", now, accumulator);
+            EAttribute resource = nexus.createResource(service.getEReferenceType(), "testValue", String.class, now,
+                    null, accumulator);
+            Provider p = nexus.createProviderInstance("TestModel", "testprovider", now, accumulator);
+
+            nexus.handleDataUpdate("TestModel", p, service, resource, "test", now);
 
             Provider provider = nexus.getProvider("TestModel", "testprovider");
             assertNotNull(provider);
@@ -125,16 +133,16 @@ public class NexusTest {
             EClass eClass = (EClass) serviceFeature.getEType();
             assertEquals("TestModelTestservice", eClass.getName());
 
-            Service service = (Service) provider.eGet(serviceFeature);
+            Service svc = (Service) provider.eGet(serviceFeature);
 
-            assertNotNull(service);
+            assertNotNull(svc);
 
             EStructuralFeature valueFeature = eClass.getEStructuralFeature("testValue");
 
             assertNotNull(valueFeature);
             assertEquals(valueFeature.getEType(), EcorePackage.Literals.ESTRING);
 
-            Object value = service.eGet(valueFeature);
+            Object value = svc.eGet(valueFeature);
             assertEquals("test", value);
         }
 
@@ -143,10 +151,10 @@ public class NexusTest {
 
             ModelNexus nexus = new ModelNexus(resourceSet, SensiNactPackage.eINSTANCE, () -> accumulator);
 
-            List<Provider> providers = nexus.getProviders();
+            Collection<Provider> providers = nexus.getProviders();
 
             assertEquals(1, providers.size());
-            Provider provider = providers.get(0);
+            Provider provider = providers.iterator().next();
 
             assertNotNull(provider.getAdmin());
             assertEquals("sensiNact", provider.getAdmin().getFriendlyName());
@@ -183,30 +191,37 @@ public class NexusTest {
 
             ModelNexus nexus = new ModelNexus(resourceSet, SensiNactPackage.eINSTANCE, () -> accumulator);
 
-            nexus.handleDataUpdate("TestModel", "testprovider", "testservice", "testValue", String.class, "test",
-                    Instant.now());
+            Instant now = Instant.now();
+            EClass model = nexus.createModel("TestModel", now, accumulator);
+            EReference service = nexus.createService(model, "testservice", now, accumulator);
+            EAttribute resource = nexus.createResource(service.getEReferenceType(), "testValue", String.class, now,
+                    null, accumulator);
+            Provider p = nexus.createProviderInstance("TestModel", "testprovider", now, accumulator);
+
+            nexus.handleDataUpdate("TestModel", p, service, resource, "test", now);
 
             Provider provider = nexus.getProvider("TestModel", "testprovider");
             assertNotNull(provider);
             EStructuralFeature serviceFeature = provider.eClass().getEStructuralFeature("testservice");
-            Service service = (Service) provider.eGet(serviceFeature);
+            Service svc = (Service) provider.eGet(serviceFeature);
 
-            EStructuralFeature valueFeature = service.eClass().getEStructuralFeature("testValue");
+            EStructuralFeature valueFeature = svc.eClass().getEStructuralFeature("testValue");
 
             assertNotNull(valueFeature);
             assertEquals(valueFeature.getEType(), EcorePackage.Literals.ESTRING);
 
-            Object value = service.eGet(valueFeature);
+            Object value = svc.eGet(valueFeature);
             assertEquals("test", value);
 
-            nexus.handleDataUpdate("TestModel", "testprovider", "testservice", "testValue2", String.class, "test",
-                    Instant.now());
+            EAttribute resource2 = nexus.createResource(service.getEReferenceType(), "testValue2", String.class, now,
+                    null, accumulator);
+            nexus.handleDataUpdate("TestModel", p, service, resource2, "test", Instant.now());
 
             Provider updatedProvider = nexus.getProvider("TestModel", "testprovider");
             assertEquals(provider, updatedProvider);
 
             Service updateService = (Service) updatedProvider.eGet(serviceFeature);
-            assertEquals(service, updateService);
+            assertEquals(svc, updateService);
 
             value = updateService.eGet(valueFeature);
             assertEquals("test", value);
@@ -225,47 +240,52 @@ public class NexusTest {
 
             ModelNexus nexus = new ModelNexus(resourceSet, SensiNactPackage.eINSTANCE, () -> accumulator);
 
-            nexus.handleDataUpdate("TestModel", "testprovider", "testservice", "testValue", String.class, "test",
-                    Instant.now());
+            Instant now = Instant.now();
+            EClass model = nexus.createModel("TestModel", now, accumulator);
+            EReference service = nexus.createService(model, "testservice", now, accumulator);
+            EAttribute resource = nexus.createResource(service.getEReferenceType(), "testValue", String.class, now,
+                    null, accumulator);
+            Provider p = nexus.createProviderInstance("TestModel", "testprovider", now, accumulator);
+
+            nexus.handleDataUpdate("TestModel", p, service, resource, "test", now);
 
             Provider provider = nexus.getProvider("TestModel", "testprovider");
             assertNotNull(provider);
 
             EStructuralFeature serviceFeature = provider.eClass().getEStructuralFeature("testservice");
-            Service service = (Service) provider.eGet(serviceFeature);
+            Service svc = (Service) provider.eGet(serviceFeature);
 
-            EStructuralFeature valueFeature = service.eClass().getEStructuralFeature("testValue");
+            EStructuralFeature valueFeature = svc.eClass().getEStructuralFeature("testValue");
 
             assertNotNull(valueFeature);
             assertEquals(valueFeature.getEType(), EcorePackage.Literals.ESTRING);
 
-            Object value = service.eGet(valueFeature);
+            Object value = svc.eGet(valueFeature);
             assertEquals("test", value);
 
-            nexus.handleDataUpdate("TestModel", "testprovider", "testservice2", "testValue", String.class, "test2",
-                    Instant.now());
+            EReference service2 = nexus.createService(model, "testservice2", now, accumulator);
+            EAttribute resource2 = nexus.createResource(service2.getEReferenceType(), "testValue", String.class, now,
+                    null, accumulator);
+            nexus.handleDataUpdate("TestModel", p, service2, resource2, "test2", Instant.now());
 
-            Provider updatedProvider = nexus.getProvider("TestModel", "testprovider");
-            service = (Service) updatedProvider.eGet(serviceFeature);
+            svc = (Service) p.eGet(serviceFeature);
             assertNotNull(valueFeature);
             assertEquals(valueFeature.getEType(), EcorePackage.Literals.ESTRING);
 
-            value = service.eGet(valueFeature);
+            value = svc.eGet(valueFeature);
             assertEquals("test", value);
 
             // now check the new feature
 
-            assertEquals(provider, updatedProvider);
+            EStructuralFeature serviceFeature2 = p.eClass().getEStructuralFeature("testservice2");
+            Service svc2 = (Service) p.eGet(serviceFeature2);
 
-            EStructuralFeature serviceFeature2 = updatedProvider.eClass().getEStructuralFeature("testservice2");
-            Service service2 = (Service) updatedProvider.eGet(serviceFeature2);
-
-            EStructuralFeature valueFeature2 = service2.eClass().getEStructuralFeature("testValue");
+            EStructuralFeature valueFeature2 = svc2.eClass().getEStructuralFeature("testValue");
 
             assertNotNull(valueFeature2);
             assertEquals(valueFeature2.getEType(), EcorePackage.Literals.ESTRING);
 
-            Object value2 = service2.eGet(valueFeature2);
+            Object value2 = svc2.eGet(valueFeature2);
             assertEquals("test2", value2);
         }
 
@@ -273,11 +293,22 @@ public class NexusTest {
         void basicFullProviderTest() {
             ModelNexus nexus = new ModelNexus(resourceSet, SensiNactPackage.eINSTANCE, () -> accumulator);
             for (int modelIdx = 0; modelIdx < 2; modelIdx++) {
+                EClass model = nexus.createModel("model_" + modelIdx, Instant.now(), accumulator);
                 for (int svcIdx = 0; svcIdx < 2; svcIdx++) {
+                    EReference service = nexus.createService(model, "service_" + svcIdx, Instant.now(), accumulator);
+                    EAttribute resource = nexus.createResource(service.getEReferenceType(), "resource", Integer.class,
+                            Instant.now(), null, accumulator);
+                    Provider p;
+                    if (svcIdx == 0) {
+                        p = nexus.createProviderInstance(nexus.getModelName(model), "provider_" + modelIdx,
+                                Instant.now(), accumulator);
+                    } else {
+                        p = nexus.getProvider("provider_" + modelIdx);
+                    }
+
                     System.out.println("Calling update with model_" + modelIdx + ", provider_" + modelIdx + ", service_"
                             + svcIdx + ", resource , 42...");
-                    nexus.handleDataUpdate("model_" + modelIdx, "provider_" + modelIdx, "service_" + svcIdx, "resource",
-                            Integer.class, 42, Instant.now());
+                    nexus.handleDataUpdate("model_" + modelIdx, p, service, resource, 42, Instant.now());
                 }
             }
 
@@ -301,11 +332,19 @@ public class NexusTest {
         void basicPersistanceTest() throws IOException {
 
             ModelNexus nexus = new ModelNexus(resourceSet, SensiNactPackage.eINSTANCE, () -> accumulator);
-            nexus.handleDataUpdate("TestModel", "testprovider", "testservice", "testValue", String.class, "test",
-                    Instant.now());
+            Instant now = Instant.now();
 
-            nexus.handleDataUpdate("TestModel", "testprovider", "testservice2", "testValue", String.class, "test2",
-                    Instant.now());
+            EClass model = nexus.createModel("TestModel", now, accumulator);
+            EReference service = nexus.createService(model, "testservice", now, accumulator);
+            EReference service2 = nexus.createService(model, "testservice2", now, accumulator);
+            EAttribute resource = nexus.createResource(service.getEReferenceType(), "testValue", String.class, now,
+                    null, accumulator);
+            EAttribute resource2 = nexus.createResource(service2.getEReferenceType(), "testValue", String.class, now,
+                    null, accumulator);
+            Provider p = nexus.createProviderInstance("TestModel", "testprovider", now, accumulator);
+
+            nexus.handleDataUpdate("TestModel", p, service, resource, "test", now);
+            nexus.handleDataUpdate("TestModel", p, service2, resource2, "test2", now);
 
             nexus.shutDown();
 
@@ -313,14 +352,14 @@ public class NexusTest {
             Provider provider = nexus.getProvider("TestModel", "testprovider");
             assertNotNull(provider);
             EStructuralFeature serviceFeature = provider.eClass().getEStructuralFeature("testservice2");
-            Service service = (Service) provider.eGet(serviceFeature);
+            Service svc = (Service) provider.eGet(serviceFeature);
 
-            EStructuralFeature valueFeature = service.eClass().getEStructuralFeature("testValue");
+            EStructuralFeature valueFeature = svc.eClass().getEStructuralFeature("testValue");
 
             assertNotNull(valueFeature);
             assertEquals(valueFeature.getEType(), EcorePackage.Literals.ESTRING);
 
-            Object value = service.eGet(valueFeature);
+            Object value = svc.eGet(valueFeature);
             assertEquals("test2", value);
 
         }
@@ -329,14 +368,27 @@ public class NexusTest {
         void basicPersistanceTestMultiple() throws IOException {
 
             ModelNexus nexus = new ModelNexus(resourceSet, SensiNactPackage.eINSTANCE, () -> accumulator);
-            nexus.handleDataUpdate("TestModel", "testprovider", "testservice", "testValue", String.class, "test",
-                    Instant.now());
+            Instant now = Instant.now();
 
-            nexus.handleDataUpdate("TestModelNew", "testproviderNew", "testservice2", "testValue", String.class,
-                    "test2", Instant.now());
+            EClass model = nexus.createModel("TestModel", now, accumulator);
+            EClass model2 = nexus.createModel("TestModelNew", now, accumulator);
+            EReference service = nexus.createService(model, "testservice", now, accumulator);
+            EReference service2 = nexus.createService(model2, "testservice2", now, accumulator);
+            EAttribute resource = nexus.createResource(service.getEReferenceType(), "testValue", String.class, now,
+                    null, accumulator);
+            EAttribute resource2 = nexus.createResource(service2.getEReferenceType(), "testValue", String.class, now,
+                    null, accumulator);
+            EClass model3 = nexus.createModel("something_else", now, accumulator);
+            EReference service3 = nexus.createService(model3, "whatever", now, accumulator);
+            EAttribute resource3 = nexus.createResource(service3.getEReferenceType(), "testValue", String.class, now,
+                    null, accumulator);
+            Provider p = nexus.createProviderInstance("TestModel", "testprovider", now, accumulator);
+            Provider p2 = nexus.createProviderInstance("TestModelNew", "testproviderNew", now, accumulator);
+            Provider p3 = nexus.createProviderInstance("something_else", "something_else", now, accumulator);
 
-            nexus.handleDataUpdate(null, "something_else", "whatever", "testValue", String.class, "test2",
-                    Instant.now());
+            nexus.handleDataUpdate("TestModel", p, service, resource, "test", now);
+            nexus.handleDataUpdate("TestModelNew", p2, service2, resource2, "test2", now);
+            nexus.handleDataUpdate("something_else", p3, service3, resource3, "test2", now);
 
             nexus.shutDown();
 
@@ -367,9 +419,15 @@ public class NexusTest {
         @Test
         void testFindProviderWithoutModel() {
             ModelNexus nexus = new ModelNexus(resourceSet, SensiNactPackage.eINSTANCE, () -> accumulator);
+            Instant now = Instant.now();
 
-            nexus.handleDataUpdate("TestModel", "testprovider", "testservice", "testValue", String.class, "test",
-                    Instant.now());
+            EClass model = nexus.createModel("TestModel", now, accumulator);
+            EReference service = nexus.createService(model, "testservice", now, accumulator);
+            EAttribute resource = nexus.createResource(service.getEReferenceType(), "testValue", String.class, now,
+                    null, accumulator);
+            Provider p = nexus.createProviderInstance("TestModel", "testprovider", now, accumulator);
+
+            nexus.handleDataUpdate("TestModel", p, service, resource, "test", now);
 
             assertEquals("TestModel", nexus.getProviderModel("testprovider"));
 
@@ -381,14 +439,27 @@ public class NexusTest {
         }
 
         @Test
+        void testUnableToCreateProviderNoModel() {
+            ModelNexus nexus = new ModelNexus(resourceSet, SensiNactPackage.eINSTANCE, () -> accumulator);
+
+            Instant now = Instant.now();
+
+            assertThrows(IllegalArgumentException.class,
+                    () -> nexus.createProviderInstance("TestModel", "testprovider", now, accumulator));
+        }
+
+        @Test
         void testUnableToCreateProviderDifferentModelAndClashingId() {
             ModelNexus nexus = new ModelNexus(resourceSet, SensiNactPackage.eINSTANCE, () -> accumulator);
 
-            nexus.handleDataUpdate("TestModel", "testprovider", "testservice", "testValue", String.class, "test",
-                    Instant.now());
+            Instant now = Instant.now();
 
-            assertThrows(IllegalArgumentException.class, () -> nexus.handleDataUpdate("TestModel2", "testprovider",
-                    "testservice", "testValue", String.class, "test", Instant.now()));
+            nexus.createModel("TestModel", now, accumulator);
+            nexus.createModel("TestModel2", now, accumulator);
+            nexus.createProviderInstance("TestModel", "testprovider", now, accumulator);
+
+            assertThrows(IllegalArgumentException.class,
+                    () -> nexus.createProviderInstance("TestModel2", "testprovider", now, accumulator));
         }
     }
 
@@ -399,23 +470,34 @@ public class NexusTest {
         void addLink() {
 
             ModelNexus nexus = new ModelNexus(resourceSet, SensiNactPackage.eINSTANCE, () -> accumulator);
+            Instant now = Instant.now();
 
-            nexus.handleDataUpdate("TestModel", "testprovider", "testservice", "testValue", String.class, "test",
-                    Instant.now());
+            EClass model = nexus.createModel("TestModel", now, accumulator);
+            EReference service = nexus.createService(model, "testservice", now, accumulator);
+            EReference service2 = nexus.createService(model, "testservice2", now, accumulator);
+            EAttribute resource = nexus.createResource(service.getEReferenceType(), "testValue", String.class, now,
+                    null, accumulator);
+            EAttribute resource2 = nexus.createResource(service2.getEReferenceType(), "testValue", String.class, now,
+                    null, accumulator);
+            EClass model2 = nexus.createModel("something_else", now, accumulator);
+            EReference service3 = nexus.createService(model2, "whatever", now, accumulator);
+            EAttribute resource3 = nexus.createResource(service3.getEReferenceType(), "testValue", String.class, now,
+                    null, accumulator);
+            Provider p = nexus.createProviderInstance("TestModel", "testprovider", now, accumulator);
+            Provider p2 = nexus.createProviderInstance("TestModel", "testproviderNew", now, accumulator);
+            Provider p3 = nexus.createProviderInstance("something_else", "something_else", now, accumulator);
 
-            nexus.handleDataUpdate("TestModelNew", "testproviderNew", "testservice2", "testValue", String.class,
-                    "test2", Instant.now());
+            nexus.handleDataUpdate("TestModel", p, service, resource, "test", now);
+            nexus.handleDataUpdate("TestModel", p2, service2, resource2, "test2", now);
+            nexus.handleDataUpdate("TestModel", p3, service3, resource3, "test2", now);
 
-            nexus.handleDataUpdate(null, "something_else", "whatever", "testValue", String.class, "test2",
-                    Instant.now());
-
-            nexus.linkProviders("TestModel", "testprovider", "TestModelNew", "testproviderNew", Instant.now());
+            nexus.linkProviders("testprovider", "testproviderNew", Instant.now());
 
             Provider provider = nexus.getProvider("TestModel", "testprovider");
 
             assertEquals(1, provider.getLinkedProviders().size());
 
-            nexus.linkProviders("TestModel", "testprovider", null, "something_else", Instant.now());
+            nexus.linkProviders("testprovider", "something_else", Instant.now());
 
             assertEquals(2, provider.getLinkedProviders().size());
         }
@@ -425,26 +507,38 @@ public class NexusTest {
 
             ModelNexus nexus = new ModelNexus(resourceSet, SensiNactPackage.eINSTANCE, () -> accumulator);
 
-            nexus.handleDataUpdate("TestModel", "testprovider", "testservice", "testValue", String.class, "test",
-                    Instant.now());
+            Instant now = Instant.now();
 
-            nexus.handleDataUpdate("TestModelNew", "testproviderNew", "testservice2", "testValue", String.class,
-                    "test2", Instant.now());
+            EClass model = nexus.createModel("TestModel", now, accumulator);
+            EReference service = nexus.createService(model, "testservice", now, accumulator);
+            EReference service2 = nexus.createService(model, "testservice2", now, accumulator);
+            EAttribute resource = nexus.createResource(service.getEReferenceType(), "testValue", String.class, now,
+                    null, accumulator);
+            EAttribute resource2 = nexus.createResource(service2.getEReferenceType(), "testValue", String.class, now,
+                    null, accumulator);
+            EClass model2 = nexus.createModel("something_else", now, accumulator);
+            EReference service3 = nexus.createService(model2, "whatever", now, accumulator);
+            EAttribute resource3 = nexus.createResource(service3.getEReferenceType(), "testValue", String.class, now,
+                    null, accumulator);
+            Provider p = nexus.createProviderInstance("TestModel", "testprovider", now, accumulator);
+            Provider p2 = nexus.createProviderInstance("TestModel", "testproviderNew", now, accumulator);
+            Provider p3 = nexus.createProviderInstance("something_else", "something_else", now, accumulator);
 
-            nexus.handleDataUpdate(null, "something_else", "whatever", "testValue", String.class, "test2",
-                    Instant.now());
+            nexus.handleDataUpdate("TestModel", p, service, resource, "test", now);
+            nexus.handleDataUpdate("TestModel", p2, service2, resource2, "test2", now);
+            nexus.handleDataUpdate("TestModel", p3, service3, resource3, "test2", now);
 
-            nexus.linkProviders("TestModel", "testprovider", "TestModelNew", "testproviderNew", Instant.now());
+            nexus.linkProviders("testprovider", "testproviderNew", Instant.now());
 
             Provider provider = nexus.getProvider("TestModel", "testprovider");
 
             assertEquals(1, provider.getLinkedProviders().size());
 
-            nexus.linkProviders("TestModel", "testprovider", null, "something_else", Instant.now());
+            nexus.linkProviders("testprovider", "something_else", Instant.now());
 
             assertEquals(2, provider.getLinkedProviders().size());
 
-            nexus.unlinkProviders("TestModel", "testprovider", "TestModelNew", "testproviderNew", Instant.now());
+            nexus.unlinkProviders("testprovider", "testproviderNew", Instant.now());
             assertEquals(1, provider.getLinkedProviders().size());
         }
     }

--- a/prototype/core/impl/src/test/java/org/eclipse/sensinact/prototype/model/nexus/impl/SubscriptionTest.java
+++ b/prototype/core/impl/src/test/java/org/eclipse/sensinact/prototype/model/nexus/impl/SubscriptionTest.java
@@ -17,7 +17,11 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
 
+import org.eclipse.emf.ecore.EAttribute;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.sensinact.model.core.Provider;
 import org.eclipse.sensinact.model.core.SensiNactPackage;
 import org.eclipse.sensinact.prototype.emf.util.EMFTestUtil;
 import org.eclipse.sensinact.prototype.notification.NotificationAccumulator;
@@ -67,8 +71,13 @@ public class SubscriptionTest {
             Mockito.clearInvocations(accumulator);
 
             Instant now = Instant.now();
-            nexus.handleDataUpdate(TEST_MODEL, TEST_PROVIDER, TEST_SERVICE, TEST_RESOURCE, String.class, TEST_VALUE,
-                    now);
+            EClass model = nexus.createModel(TEST_MODEL, now, accumulator);
+            EReference service = nexus.createService(model, TEST_SERVICE, now, accumulator);
+            EAttribute resource = nexus.createResource(service.getEReferenceType(), TEST_RESOURCE, String.class, now,
+                    null, accumulator);
+            Provider p = nexus.createProviderInstance(TEST_MODEL, TEST_PROVIDER, now, accumulator);
+
+            nexus.handleDataUpdate(TEST_MODEL, p, service, resource, TEST_VALUE, now);
 
             Mockito.verify(accumulator).addProvider(TEST_MODEL, TEST_PROVIDER);
             Mockito.verify(accumulator).addService(TEST_MODEL, TEST_PROVIDER, TEST_SERVICE);
@@ -94,10 +103,16 @@ public class SubscriptionTest {
             Instant now = Instant.now();
             Instant before = now.minus(Duration.ofHours(1));
 
-            nexus.handleDataUpdate(TEST_MODEL, TEST_PROVIDER, TEST_SERVICE, TEST_RESOURCE, String.class, TEST_VALUE,
-                    before);
-            nexus.handleDataUpdate(TEST_MODEL, TEST_PROVIDER, TEST_SERVICE, "testValue2", String.class, TEST_VALUE,
-                    now);
+            EClass model = nexus.createModel(TEST_MODEL, before, accumulator);
+            EReference service = nexus.createService(model, TEST_SERVICE, before, accumulator);
+            EAttribute resource = nexus.createResource(service.getEReferenceType(), TEST_RESOURCE, String.class, before,
+                    null, accumulator);
+            EAttribute resource2 = nexus.createResource(service.getEReferenceType(), TEST_RESOURCE_2, String.class,
+                    before, null, accumulator);
+            Provider p = nexus.createProviderInstance(TEST_MODEL, TEST_PROVIDER, before, accumulator);
+
+            nexus.handleDataUpdate(TEST_MODEL, p, service, resource, TEST_VALUE, before);
+            nexus.handleDataUpdate(TEST_MODEL, p, service, resource2, TEST_VALUE, now);
 
             Mockito.verify(accumulator).addProvider(TEST_MODEL, TEST_PROVIDER);
             Mockito.verify(accumulator).addService(TEST_MODEL, TEST_PROVIDER, TEST_SERVICE);
@@ -127,10 +142,17 @@ public class SubscriptionTest {
             Instant now = Instant.now();
             Instant before = now.minus(Duration.ofHours(1));
 
-            nexus.handleDataUpdate(TEST_MODEL, TEST_PROVIDER, TEST_SERVICE, TEST_RESOURCE, String.class, TEST_VALUE,
-                    before);
-            nexus.handleDataUpdate(TEST_MODEL, TEST_PROVIDER, TEST_SERVICE_2, TEST_RESOURCE_2, String.class,
-                    TEST_VALUE_2, now);
+            EClass model = nexus.createModel(TEST_MODEL, before, accumulator);
+            EReference service = nexus.createService(model, TEST_SERVICE, before, accumulator);
+            EReference service2 = nexus.createService(model, TEST_SERVICE_2, before, accumulator);
+            EAttribute resource = nexus.createResource(service.getEReferenceType(), TEST_RESOURCE, String.class, before,
+                    null, accumulator);
+            EAttribute resource2 = nexus.createResource(service2.getEReferenceType(), TEST_RESOURCE_2, String.class,
+                    before, null, accumulator);
+            Provider p = nexus.createProviderInstance(TEST_MODEL, TEST_PROVIDER, before, accumulator);
+
+            nexus.handleDataUpdate(TEST_MODEL, p, service, resource, TEST_VALUE, before);
+            nexus.handleDataUpdate(TEST_MODEL, p, service2, resource2, TEST_VALUE_2, now);
 
             Mockito.verify(accumulator).addProvider(TEST_MODEL, TEST_PROVIDER);
             Mockito.verify(accumulator).addService(TEST_MODEL, TEST_PROVIDER, TEST_SERVICE);


### PR DESCRIPTION
Now that we have programmatic model manipulation the Nexus should no longer auto-extend the model. We should also take more care about how and when we query the model

Signed-off-by: Tim Ward <timothyjward@apache.org>