### PR TITLE
ClassCastException occurs when filtering models with actions

### DIFF
--- a/prototype/core/api/src/main/java/org/eclipse/sensinact/prototype/snapshot/ResourceSnapshot.java
+++ b/prototype/core/api/src/main/java/org/eclipse/sensinact/prototype/snapshot/ResourceSnapshot.java
@@ -15,6 +15,7 @@ package org.eclipse.sensinact.prototype.snapshot;
 
 import java.util.Map;
 
+import org.eclipse.sensinact.prototype.model.ResourceType;
 import org.eclipse.sensinact.prototype.twin.TimedValue;
 
 public interface ResourceSnapshot extends Snapshot {
@@ -24,4 +25,6 @@ public interface ResourceSnapshot extends Snapshot {
     TimedValue<?> getValue();
 
     Map<String, Object> getMetadata();
+
+    ResourceType getResourceType();
 }

--- a/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/impl/snapshot/ResourceSnapshotImpl.java
+++ b/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/impl/snapshot/ResourceSnapshotImpl.java
@@ -20,6 +20,8 @@ import java.util.Map;
 import org.eclipse.emf.ecore.ETypedElement;
 import org.eclipse.sensinact.model.core.ResourceMetadata;
 import org.eclipse.sensinact.model.core.Service;
+import org.eclipse.sensinact.prototype.model.ResourceType;
+import org.eclipse.sensinact.prototype.model.impl.ResourceImpl;
 import org.eclipse.sensinact.prototype.model.nexus.impl.emf.EMFUtil;
 import org.eclipse.sensinact.prototype.snapshot.ProviderSnapshot;
 import org.eclipse.sensinact.prototype.snapshot.ResourceSnapshot;
@@ -52,12 +54,15 @@ public class ResourceSnapshotImpl extends AbstractSnapshot implements ResourceSn
      */
     private final Class<?> type;
 
+    private final ResourceType resourceType;
+
     public ResourceSnapshotImpl(final ServiceSnapshotImpl parent, final ETypedElement rcFeature,
             final Instant snapshotInstant) {
         super(rcFeature.getName(), snapshotInstant);
         this.service = parent;
         this.rcFeature = rcFeature;
         this.type = rcFeature.getEType().getInstanceClass();
+        this.resourceType = ResourceImpl.findResourceType(rcFeature);
 
         Service modelService = parent.getModelService();
         final ResourceMetadata rcMetadata = modelService == null ? null : modelService.getMetadata().get(rcFeature);
@@ -100,5 +105,10 @@ public class ResourceSnapshotImpl extends AbstractSnapshot implements ResourceSn
 
     public ETypedElement getFeature() {
         return rcFeature;
+    }
+
+    @Override
+    public ResourceType getResourceType() {
+        return resourceType;
     }
 }

--- a/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/twin/impl/SensinactDigitalTwinImpl.java
+++ b/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/twin/impl/SensinactDigitalTwinImpl.java
@@ -33,6 +33,7 @@ import org.eclipse.sensinact.prototype.command.impl.CommandScopedImpl;
 import org.eclipse.sensinact.prototype.impl.snapshot.ProviderSnapshotImpl;
 import org.eclipse.sensinact.prototype.impl.snapshot.ResourceSnapshotImpl;
 import org.eclipse.sensinact.prototype.impl.snapshot.ServiceSnapshotImpl;
+import org.eclipse.sensinact.prototype.model.ResourceType;
 import org.eclipse.sensinact.prototype.model.nexus.impl.ModelNexus;
 import org.eclipse.sensinact.prototype.notification.NotificationAccumulator;
 import org.eclipse.sensinact.prototype.snapshot.ProviderSnapshot;
@@ -293,10 +294,13 @@ public class SensinactDigitalTwinImpl extends CommandScopedImpl implements Sensi
         providersStream = providersStream.map(p -> {
             p.getServices().stream().forEach(s -> {
                 s.getResources().stream().forEach(rc -> {
+                    if (rc.getResourceType() == ResourceType.ACTION) {
+                        // Skip values for actions
+                        return;
+                    }
                     // Get the resource metadata
                     final Service svc = rc.getService().getModelService();
                     final ETypedElement rcFeature = rc.getFeature();
-
                     final ResourceMetadata metadata = svc == null ? null : svc.getMetadata().get(rcFeature);
                     final Instant timestamp;
                     if (metadata != null) {

--- a/prototype/core/impl/src/test/java/org/eclipse/sensinact/prototype/twin/impl/SensinactTwinTest.java
+++ b/prototype/core/impl/src/test/java/org/eclipse/sensinact/prototype/twin/impl/SensinactTwinTest.java
@@ -15,12 +15,14 @@ package org.eclipse.sensinact.prototype.twin.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Instant;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.eclipse.emf.ecore.resource.ResourceSet;
@@ -31,6 +33,8 @@ import org.eclipse.sensinact.prototype.model.ResourceType;
 import org.eclipse.sensinact.prototype.model.impl.SensinactModelManagerImpl;
 import org.eclipse.sensinact.prototype.model.nexus.impl.ModelNexus;
 import org.eclipse.sensinact.prototype.notification.NotificationAccumulator;
+import org.eclipse.sensinact.prototype.snapshot.ProviderSnapshot;
+import org.eclipse.sensinact.prototype.snapshot.ResourceSnapshot;
 import org.eclipse.sensinact.prototype.twin.SensinactProvider;
 import org.eclipse.sensinact.prototype.twin.TimedValue;
 import org.junit.jupiter.api.BeforeEach;
@@ -147,6 +151,43 @@ public class SensinactTwinTest {
             assertFalse(act.isDone());
             assertEquals(4.2D, act.getValue());
         }
+    }
 
+    @Nested
+    public class FilterTests {
+
+        @Test
+        void simpleEmptyFilter() {
+            List<ProviderSnapshot> list = twinImpl.filteredSnapshot(null, null, null, null);
+            assertEquals(1, list.size());
+
+            twinImpl.createProvider(TEST_MODEL, TEST_PROVIDER);
+            list = twinImpl.filteredSnapshot(null, null, null, null);
+            assertEquals(2, list.size());
+        }
+
+        @Test
+        void simpleProviderNameFilter() {
+            twinImpl.createProvider(TEST_MODEL, TEST_PROVIDER);
+
+            List<ProviderSnapshot> list = twinImpl.filteredSnapshot(null, p -> "foo".equals(p.getName()), null, null);
+            assertTrue(list.isEmpty());
+
+            list = twinImpl.filteredSnapshot(null, p -> TEST_PROVIDER.equals(p.getName()), null, null);
+            assertEquals(1, list.size());
+        }
+
+        @Test
+        void simpleResourceValueFilter() throws Exception {
+            twinImpl.createProvider(TEST_MODEL, TEST_PROVIDER);
+            twinImpl.getResource(TEST_PROVIDER, TEST_SERVICE, TEST_RESOURCE).setValue(5).getValue();
+
+            Predicate<ResourceSnapshot> p = r -> TEST_RESOURCE.equals(r.getName());
+
+            List<ProviderSnapshot> list = twinImpl.filteredSnapshot(null, null, null, p);
+            assertEquals(1, list.size());
+            assertEquals(2, list.get(0).getServices().size());
+            assertEquals(5, list.get(0).getServices().get(1).getResources().get(0).getValue().getValue());
+        }
     }
 }

--- a/prototype/northbound/filters/ldap/src/test/java/org/eclipse/sensinact/northbound/filters/ldap/LdapParserTest.java
+++ b/prototype/northbound/filters/ldap/src/test/java/org/eclipse/sensinact/northbound/filters/ldap/LdapParserTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.sensinact.northbound.filters.ldap.impl.LdapParser;
+import org.eclipse.sensinact.prototype.model.ResourceType;
 import org.eclipse.sensinact.prototype.snapshot.ICriterion;
 import org.eclipse.sensinact.prototype.snapshot.ProviderSnapshot;
 import org.eclipse.sensinact.prototype.snapshot.ResourceSnapshot;
@@ -116,6 +117,11 @@ public class LdapParserTest {
                         };
                     }
                 };
+            }
+
+            @Override
+            public ResourceType getResourceType() {
+                return ResourceType.PROPERTY;
             }
         };
     }

--- a/prototype/northbound/sensorthings/filter/src/test/java/org/eclipse/sensinact/northbound/filters/sensorthings/RcUtils.java
+++ b/prototype/northbound/sensorthings/filter/src/test/java/org/eclipse/sensinact/northbound/filters/sensorthings/RcUtils.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.sensinact.prototype.model.ResourceType;
 import org.eclipse.sensinact.prototype.snapshot.ProviderSnapshot;
 import org.eclipse.sensinact.prototype.snapshot.ResourceSnapshot;
 import org.eclipse.sensinact.prototype.snapshot.ServiceSnapshot;
@@ -145,6 +146,11 @@ public class RcUtils {
             @Override
             public ServiceSnapshot getService() {
                 return svc;
+            }
+
+            @Override
+            public ResourceType getResourceType() {
+                return ResourceType.PROPERTY;
             }
         };
 


### PR DESCRIPTION
The ResourceSnapshot fails with a ClassCastException when we attempt to populate the value for an Action Resource. We should not attempt to do this at all.