### PR TITLE
Ensure compatibility with old style parameter objects in SET/ACT

### DIFF
--- a/prototype/northbound/query-handler/src/main/java/org/eclipse/sensinact/northbound/query/dto/query/WrappedAccessMethodCallParametersDTO.java
+++ b/prototype/northbound/query-handler/src/main/java/org/eclipse/sensinact/northbound/query/dto/query/WrappedAccessMethodCallParametersDTO.java
@@ -12,26 +12,14 @@
 **********************************************************************/
 package org.eclipse.sensinact.northbound.query.dto.query;
 
-import java.util.Map;
+import java.util.List;
 
-import org.eclipse.sensinact.northbound.query.api.AbstractQueryDTO;
-import org.eclipse.sensinact.northbound.query.api.EQueryType;
-import org.eclipse.sensinact.northbound.query.dto.query.jackson.ActParametersDeserializer;
+import org.eclipse.sensinact.northbound.query.dto.query.jackson.WrappedAccessMethodCallParametersDeserializer;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
-/**
- *
- */
-public class QueryActDTO extends AbstractQueryDTO {
+@JsonDeserialize(using = WrappedAccessMethodCallParametersDeserializer.class)
+public class WrappedAccessMethodCallParametersDTO {
 
-    /**
-     * Named parameters
-     */
-    @JsonDeserialize(using=ActParametersDeserializer.class)
-    public Map<String, Object> parameters;
-
-    public QueryActDTO() {
-        super(EQueryType.ACT);
-    }
+    public List<AccessMethodCallParameterDTO> parameters;
 }

--- a/prototype/northbound/query-handler/src/main/java/org/eclipse/sensinact/northbound/query/dto/query/jackson/ActParametersDeserializer.java
+++ b/prototype/northbound/query-handler/src/main/java/org/eclipse/sensinact/northbound/query/dto/query/jackson/ActParametersDeserializer.java
@@ -10,12 +10,14 @@
 * Contributors:
 *   Kentyou - initial implementation
 **********************************************************************/
-package org.eclipse.sensinact.northbound.query.dto.query;
+package org.eclipse.sensinact.northbound.query.dto.query.jackson;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+
+import org.eclipse.sensinact.northbound.query.dto.query.AccessMethodCallParameterDTO;
 
 import com.fasterxml.jackson.core.JacksonException;
 import com.fasterxml.jackson.core.JsonParser;

--- a/prototype/northbound/query-handler/src/main/java/org/eclipse/sensinact/northbound/query/dto/query/jackson/WrappedAccessMethodCallParametersDeserializer.java
+++ b/prototype/northbound/query-handler/src/main/java/org/eclipse/sensinact/northbound/query/dto/query/jackson/WrappedAccessMethodCallParametersDeserializer.java
@@ -1,0 +1,68 @@
+/*********************************************************************
+* Copyright (c) 2023 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Kentyou - initial implementation
+**********************************************************************/
+package org.eclipse.sensinact.northbound.query.dto.query.jackson;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.eclipse.sensinact.northbound.query.dto.query.AccessMethodCallParameterDTO;
+import org.eclipse.sensinact.northbound.query.dto.query.WrappedAccessMethodCallParametersDTO;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+/**
+ * Handles the deserialization of method parameters
+ */
+public class WrappedAccessMethodCallParametersDeserializer
+        extends StdDeserializer<WrappedAccessMethodCallParametersDTO> {
+
+    private static final long serialVersionUID = 1L;
+
+    public WrappedAccessMethodCallParametersDeserializer() {
+        this(null);
+    }
+
+    protected WrappedAccessMethodCallParametersDeserializer(final Class<?> vc) {
+        super(vc);
+    }
+
+    @Override
+    public WrappedAccessMethodCallParametersDTO deserialize(final JsonParser parser, final DeserializationContext ctxt)
+            throws IOException, JacksonException {
+
+        WrappedAccessMethodCallParametersDTO dto = new WrappedAccessMethodCallParametersDTO();
+        if (parser.currentToken() == JsonToken.START_OBJECT) {
+            if ("parameters".equals(parser.nextFieldName())) {
+                // Look for the array
+                parser.nextToken();
+            } else {
+                throw new JsonMappingException(parser, "Expected the field name to be \"parameters\"",
+                        parser.currentTokenLocation());
+            }
+        }
+        if (parser.currentToken() == JsonToken.START_ARRAY) {
+            dto.parameters = parser.readValueAs(new TypeReference<List<AccessMethodCallParameterDTO>>() {
+            });
+        } else {
+            throw new JsonMappingException(parser, "Invalid token " + parser.currentToken() + " expected ARRAY_START",
+                    parser.currentTokenLocation());
+        }
+        return dto;
+    }
+}

--- a/prototype/northbound/query-handler/src/test/java/org/eclipse/sensinact/northbound/query/test/integration/SerializationTest.java
+++ b/prototype/northbound/query-handler/src/test/java/org/eclipse/sensinact/northbound/query/test/integration/SerializationTest.java
@@ -32,6 +32,7 @@ import org.eclipse.sensinact.northbound.query.dto.query.QueryActDTO;
 import org.eclipse.sensinact.northbound.query.dto.query.QueryDescribeDTO;
 import org.eclipse.sensinact.northbound.query.dto.query.QueryGetDTO;
 import org.eclipse.sensinact.northbound.query.dto.query.QuerySetDTO;
+import org.eclipse.sensinact.northbound.query.dto.query.WrappedAccessMethodCallParametersDTO;
 import org.eclipse.sensinact.northbound.query.dto.result.AccessMethodDTO;
 import org.eclipse.sensinact.northbound.query.dto.result.AccessMethodParameterDTO;
 import org.eclipse.sensinact.northbound.query.dto.result.CompleteProviderDescriptionDTO;
@@ -47,6 +48,7 @@ import org.eclipse.sensinact.northbound.query.dto.result.TypedResponse;
 import org.eclipse.sensinact.prototype.model.ResourceType;
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
@@ -439,5 +441,34 @@ public class SerializationTest {
         assertEquals(setRc.response.timestamp, parsedResult.response.timestamp);
         assertEquals(setRc.response.type, parsedResult.response.type);
         assertEquals(setRc.response.value, parsedResult.response.value);
+    }
+
+    @Test
+    void testWrappedAccessMethodCallParametesrDTO() throws JsonProcessingException {
+
+        final AccessMethodCallParameterDTO arg1 = new AccessMethodCallParameterDTO();
+        arg1.name = "arg1";
+        arg1.type = Integer.class.getName();
+        arg1.value = 42;
+        final AccessMethodCallParameterDTO arg2 = new AccessMethodCallParameterDTO();
+        arg2.name = "arg2";
+        arg2.type = String.class.getName();
+        arg2.value = "abc";
+
+        List<AccessMethodCallParameterDTO> parameters = List.of(arg1, arg2);
+
+        final WrappedAccessMethodCallParametersDTO dto = new WrappedAccessMethodCallParametersDTO();
+        dto.parameters = parameters;
+
+        String s = mapper.writeValueAsString(dto);
+
+        WrappedAccessMethodCallParametersDTO read = mapper.readValue(s, WrappedAccessMethodCallParametersDTO.class);
+
+        assertEquals(dto.parameters.get(0).name, read.parameters.get(0).name);
+
+        s = mapper.writeValueAsString(parameters);
+        WrappedAccessMethodCallParametersDTO read2 = mapper.readValue(s, WrappedAccessMethodCallParametersDTO.class);
+        assertEquals(dto.parameters.get(0).name, read2.parameters.get(0).name);
+
     }
 }

--- a/prototype/northbound/rest/src/main/java/org/eclipse/sensinact/northbound/rest/api/IRestNorthbound.java
+++ b/prototype/northbound/rest/src/main/java/org/eclipse/sensinact/northbound/rest/api/IRestNorthbound.java
@@ -14,10 +14,8 @@ package org.eclipse.sensinact.northbound.rest.api;
 
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 
-import java.util.List;
-
 import org.eclipse.sensinact.northbound.query.api.AbstractResultDTO;
-import org.eclipse.sensinact.northbound.query.dto.query.AccessMethodCallParameterDTO;
+import org.eclipse.sensinact.northbound.query.dto.query.WrappedAccessMethodCallParametersDTO;
 
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
@@ -72,13 +70,13 @@ public interface IRestNorthbound {
     @POST
     AbstractResultDTO resourceSet(@PathParam("providerId") String providerId,
             @PathParam("serviceName") String serviceName, @PathParam("rcName") String rcName,
-            List<AccessMethodCallParameterDTO> parameters);
+            WrappedAccessMethodCallParametersDTO parameters);
 
     @Path("providers/{providerId}/services/{serviceName}/resources/{rcName}/ACT")
     @POST
     AbstractResultDTO resourceAct(@PathParam("providerId") String providerId,
             @PathParam("serviceName") String serviceName, @PathParam("rcName") String rcName,
-            List<AccessMethodCallParameterDTO> parameters);
+            WrappedAccessMethodCallParametersDTO parameters);
 
     @Path("providers/{providerId}/services/{serviceName}/resources/{rcName}/SUBSCRIBE")
     @GET

--- a/prototype/northbound/rest/src/main/java/org/eclipse/sensinact/northbound/rest/impl/RestNorthbound.java
+++ b/prototype/northbound/rest/src/main/java/org/eclipse/sensinact/northbound/rest/impl/RestNorthbound.java
@@ -30,6 +30,7 @@ import org.eclipse.sensinact.northbound.query.dto.query.QueryDescribeDTO;
 import org.eclipse.sensinact.northbound.query.dto.query.QueryGetDTO;
 import org.eclipse.sensinact.northbound.query.dto.query.QueryListDTO;
 import org.eclipse.sensinact.northbound.query.dto.query.QuerySetDTO;
+import org.eclipse.sensinact.northbound.query.dto.query.WrappedAccessMethodCallParametersDTO;
 import org.eclipse.sensinact.northbound.rest.api.IRestNorthbound;
 import org.eclipse.sensinact.prototype.SensiNactSession;
 import org.eclipse.sensinact.prototype.notification.ClientDataListener;
@@ -222,11 +223,11 @@ public class RestNorthbound implements IRestNorthbound {
 
     @Override
     public AbstractResultDTO resourceSet(final String providerId, final String serviceName, final String rcName,
-            final List<AccessMethodCallParameterDTO> parameters) {
+            final WrappedAccessMethodCallParametersDTO parameters) {
 
         final QuerySetDTO query = new QuerySetDTO();
         query.uri = new SensinactPath(providerId, serviceName, rcName);
-        query.value = extractSetValue(parameters);
+        query.value = extractSetValue(parameters.parameters);
         return handleQuery(query);
     }
 
@@ -267,14 +268,14 @@ public class RestNorthbound implements IRestNorthbound {
 
     @Override
     public AbstractResultDTO resourceAct(final String providerId, final String serviceName, final String rcName,
-            final List<AccessMethodCallParameterDTO> parameters) {
+            final WrappedAccessMethodCallParametersDTO parameters) {
 
         final List<Entry<String, Class<?>>> actMethodArgumentsTypes = getSession().describeResourceShort(providerId,
                 serviceName, rcName).actMethodArgumentsTypes;
 
         final QueryActDTO query = new QueryActDTO();
         query.uri = new SensinactPath(providerId, serviceName, rcName);
-        query.parameters = extractActParams(actMethodArgumentsTypes, parameters);
+        query.parameters = extractActParams(actMethodArgumentsTypes, parameters.parameters);
         return handleQuery(query);
     }
 

--- a/prototype/northbound/rest/src/test/java/org/eclipse/sensinact/northbound/rest/integration/SecureAccessTest.java
+++ b/prototype/northbound/rest/src/test/java/org/eclipse/sensinact/northbound/rest/integration/SecureAccessTest.java
@@ -18,7 +18,6 @@ import static jakarta.ws.rs.core.Response.Status.UNAUTHORIZED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
-import java.io.IOException;
 import java.net.http.HttpResponse;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;


### PR DESCRIPTION
The legacy sensiNact northbound REST provider expected parameters to be encapsulated in a JSON object, not a raw array. This should continue to work.