### PR TITLE
Avoid errors when converting between data types

### DIFF
--- a/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/model/nexus/impl/emf/EMFUtil.java
+++ b/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/model/nexus/impl/emf/EMFUtil.java
@@ -46,11 +46,15 @@ import org.eclipse.sensinact.model.core.ResourceAttribute;
 import org.eclipse.sensinact.model.core.SensiNactFactory;
 import org.eclipse.sensinact.model.core.SensiNactPackage;
 import org.eclipse.sensinact.model.core.ServiceReference;
+import org.osgi.util.converter.ConversionException;
 import org.osgi.util.converter.Converter;
 import org.osgi.util.converter.ConverterFunction;
 import org.osgi.util.converter.Converters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 
 /**
  * Some Helper methods to work with Ecores.
@@ -63,6 +67,7 @@ public class EMFUtil {
     private static final Logger LOG = LoggerFactory.getLogger(EMFUtil.class);
 
     private static final Converter converter;
+    private static final ObjectMapper mapper = JsonMapper.builder().build();
     private static final Map<Class<?>, EClassifier> typeMap = new HashMap<Class<?>, EClassifier>();
     static {
         converter = Converters.newConverterBuilder().errorHandler(EMFUtil::fallbackConversion).build();
@@ -72,7 +77,8 @@ public class EMFUtil {
 
     private static Object fallbackConversion(Object o, Type t) {
         try {
-            return converter.convert(o.toString()).to(t);
+            // Avoid infinite recursion when the input is a String
+            return o instanceof String ? ConverterFunction.CANNOT_HANDLE : converter.convert(o.toString()).to(t);
         } catch (Exception e) {
             return ConverterFunction.CANNOT_HANDLE;
         }
@@ -218,21 +224,36 @@ public class EMFUtil {
     }
 
     public static Object convertToTargetType(EClassifier targetType, Object o) {
-        return convertToTargetType(targetType.getInstanceClass(), o);
+        return convertToTargetType((EDataType) targetType, targetType.getInstanceClass(), o);
     }
 
     public static Object convertToTargetType(Class<?> targetType, Object o) {
+        return convertToTargetType((EDataType) typeMap.get(targetType), targetType, o);
+    }
+
+    private static Object convertToTargetType(EDataType targetEType, Class<?> targetType, Object o) {
         Object converted;
         if (o == null) {
             converted = o;
         } else {
             EClassifier type = typeMap.get(o.getClass());
-            EClassifier target = typeMap.get(targetType);
-            if (type == null || target == null) {
-                converted = converter.convert(o).to(targetType);
+            if (type == null || targetEType == null) {
+                try {
+                    converted = converter.convert(o).to(targetType);
+                } catch (ConversionException ce) {
+                    if (targetEType != null) {
+                        try {
+                            converted = convertToTargetType(targetEType, targetType, mapper.writeValueAsString(o));
+                        } catch (Exception e) {
+                            throw ce;
+                        }
+                    } else {
+                        throw ce;
+                    }
+                }
             } else {
                 String string = type.getEPackage().getEFactoryInstance().convertToString((EDataType) type, o);
-                converted = target.getEPackage().getEFactoryInstance().createFromString((EDataType) target, string);
+                converted = targetEType.getEPackage().getEFactoryInstance().createFromString(targetEType, string);
             }
         }
         return converted;

--- a/prototype/core/impl/src/test/java/org/eclipse/sensinact/prototype/emf/util/EMFUtilTest.java
+++ b/prototype/core/impl/src/test/java/org/eclipse/sensinact/prototype/emf/util/EMFUtilTest.java
@@ -1,0 +1,76 @@
+/*********************************************************************
+* Copyright (c) 2023 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Kentyou - initial API and implementation
+**********************************************************************/
+package org.eclipse.sensinact.prototype.emf.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+
+import org.eclipse.emf.ecore.EcorePackage;
+import org.eclipse.sensinact.gateway.geojson.GeoJsonObject;
+import org.eclipse.sensinact.gateway.geojson.GeoJsonType;
+import org.eclipse.sensinact.gateway.geojson.Point;
+import org.eclipse.sensinact.model.core.SensiNactPackage;
+import org.eclipse.sensinact.prototype.model.nexus.impl.emf.EMFUtil;
+import org.junit.jupiter.api.Test;
+
+public class EMFUtilTest {
+
+    @Test
+    void testConvertStringToGeoJson() {
+
+        String point = "{\"type\": \"Point\", \"coordinates\": [12.3,45.6]}";
+        Point o = (Point) EMFUtil.convertToTargetType(GeoJsonObject.class, point);
+
+        assertEquals(GeoJsonType.Point, o.type);
+        assertEquals(12.3d, o.coordinates.longitude);
+        assertEquals(45.6d, o.coordinates.latitude);
+
+        o = (Point) EMFUtil.convertToTargetType(SensiNactPackage.eINSTANCE.getEGeoJsonObject(), point);
+
+        assertEquals(GeoJsonType.Point, o.type);
+        assertEquals(12.3d, o.coordinates.longitude);
+        assertEquals(45.6d, o.coordinates.latitude);
+    }
+
+    @Test
+    void testConvertMapToGeoJson() {
+
+        Map<String, Object> point = Map.of("type", "Point", "coordinates", new double[] { 12.3, 45.6 });
+        Point o = (Point) EMFUtil.convertToTargetType(GeoJsonObject.class, point);
+
+        assertEquals(GeoJsonType.Point, o.type);
+        assertEquals(12.3d, o.coordinates.longitude);
+        assertEquals(45.6d, o.coordinates.latitude);
+
+        o = (Point) EMFUtil.convertToTargetType(SensiNactPackage.eINSTANCE.getEGeoJsonObject(), point);
+
+        assertEquals(GeoJsonType.Point, o.type);
+        assertEquals(12.3d, o.coordinates.longitude);
+        assertEquals(45.6d, o.coordinates.latitude);
+    }
+
+    @Test
+    void testConvertStringToNumber() {
+
+        String num = "12";
+        Number o = (Number) EMFUtil.convertToTargetType(Integer.class, num);
+
+        assertEquals(12, o);
+
+        o = (Number) EMFUtil.convertToTargetType(EcorePackage.eINSTANCE.getEIntegerObject(), num);
+
+        assertEquals(12, o);
+    }
+
+}

--- a/prototype/northbound/rest/src/test/java/org/eclipse/sensinact/northbound/rest/integration/TestUtils.java
+++ b/prototype/northbound/rest/src/test/java/org/eclipse/sensinact/northbound/rest/integration/TestUtils.java
@@ -127,7 +127,11 @@ public class TestUtils {
      * Converts the content of the parsed response
      */
     public <T> T convert(final TypedResponse<?> dto, Class<T> type) {
-        return mapper.convertValue(dto.response, type);
+        return convert(dto.response, type);
+    }
+
+    public <T> T convert(final Object o, Class<T> type) {
+        return mapper.convertValue(o, type);
     }
 
     /**


### PR DESCRIPTION
In some cases we saw infinite recursion when converting data. Also the converter is not suitable for some JSON types, so we should attempt to use those where possible.