### PR TITLE
Device factory enhancements

### DIFF
--- a/prototype/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/Constants.java
+++ b/prototype/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/Constants.java
@@ -1,0 +1,20 @@
+/*********************************************************************
+* Copyright (c) 2023 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Kentyou - initial implementation
+**********************************************************************/
+package org.eclipse.sensinact.gateway.southbound.device.factory;
+
+/**
+ * Constants values to represent value state
+ */
+public enum Constants {
+    IGNORE
+}

--- a/prototype/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/IDeviceMappingParser.java
+++ b/prototype/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/IDeviceMappingParser.java
@@ -30,6 +30,15 @@ public interface IDeviceMappingParser {
      */
     String PARSER_SUPPORTED_TYPES = "sensinact.southbound.mapping.types";
 
-    List<? extends IDeviceMappingRecord> parseRecords(byte[] rawInput, Map<String, Object> parserConfiguration)
-            throws ParserException;
+    /**
+     * Parse the records found in the given payload
+     *
+     * @param rawInput            RAW payload
+     * @param parserConfiguration Parser configuration
+     * @param context             Payload context (MQTT topic, ...)
+     * @return The list of parsed records (can be null)
+     * @throws ParserException Error parsing payload
+     */
+    List<? extends IDeviceMappingRecord> parseRecords(byte[] rawInput, Map<String, Object> parserConfiguration,
+            Map<String, String> context) throws ParserException;
 }

--- a/prototype/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/ResourceLiteralMapping.java
+++ b/prototype/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/ResourceLiteralMapping.java
@@ -14,6 +14,7 @@ package org.eclipse.sensinact.gateway.southbound.device.factory.impl;
 
 import java.util.Map;
 
+import org.eclipse.sensinact.gateway.southbound.device.factory.Constants;
 import org.eclipse.sensinact.gateway.southbound.device.factory.IResourceMapping;
 import org.eclipse.sensinact.gateway.southbound.device.factory.InvalidResourcePathException;
 import org.eclipse.sensinact.gateway.southbound.device.factory.ValueType;
@@ -74,7 +75,11 @@ public class ResourceLiteralMapping extends AbstractResourceMapping {
      * @return Converted literal value
      */
     public Object getTypedValue(final DeviceMappingOptionsDTO options) {
-        return valueType.convert(value, options);
+        if (value != Constants.IGNORE) {
+            return valueType.convert(value, options);
+        } else {
+            return value;
+        }
     }
 
     /**

--- a/prototype/southbound/device-factory/device-factory-core/src/test/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/FakeDeviceMappingParser.java
+++ b/prototype/southbound/device-factory/device-factory-core/src/test/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/FakeDeviceMappingParser.java
@@ -51,7 +51,7 @@ public class FakeDeviceMappingParser implements IDeviceMappingParser {
 
     @Override
     public List<? extends IDeviceMappingRecord> parseRecords(final byte[] rawInput,
-            final Map<String, Object> parserConfiguration) throws ParserException {
+            final Map<String, Object> parserConfiguration, final Map<String, String> context) throws ParserException {
         return records;
     }
 }

--- a/prototype/southbound/device-factory/parser-csv/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/parser/csv/CsvParser.java
+++ b/prototype/southbound/device-factory/parser-csv/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/parser/csv/CsvParser.java
@@ -39,8 +39,8 @@ import org.osgi.service.component.annotations.Component;
 public class CsvParser implements IDeviceMappingParser {
 
     @Override
-    public List<? extends IDeviceMappingRecord> parseRecords(byte[] rawInput, Map<String, Object> parserConfiguration)
-            throws ParserException {
+    public List<? extends IDeviceMappingRecord> parseRecords(byte[] rawInput, Map<String, Object> parserConfiguration,
+            Map<String, String> context) throws ParserException {
 
         // Read CSV file
         final Charset charset;

--- a/prototype/southbound/device-factory/parser-json/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/parser/json/JsonParser.java
+++ b/prototype/southbound/device-factory/parser-json/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/parser/json/JsonParser.java
@@ -44,8 +44,8 @@ public class JsonParser implements IDeviceMappingParser {
     private ObjectMapper objectMapper = new ObjectMapper();
 
     @Override
-    public List<? extends IDeviceMappingRecord> parseRecords(byte[] rawInput, Map<String, Object> parserConfiguration)
-            throws ParserException {
+    public List<? extends IDeviceMappingRecord> parseRecords(byte[] rawInput, Map<String, Object> parserConfiguration,
+            final Map<String, String> context) throws ParserException {
 
         // Configured base entry
         String base = (String) parserConfiguration.get("base");

--- a/prototype/southbound/mqtt/mqtt-device-factory/integration-test.bndrun
+++ b/prototype/southbound/mqtt/mqtt-device-factory/integration-test.bndrun
@@ -77,21 +77,3 @@
 	slf4j.api;version='[1.7.36,1.7.37)',\
 	slf4j.log4j12;version='[1.7.25,1.7.26)',\
 	slf4j.simple;version='[1.7.36,1.7.37)'
-	org.gecko.emf.osgi.api;version='[4.6.0,4.6.1)',\
-	org.gecko.emf.osgi.component;version='[4.6.0,4.6.1)',\
-=======
-	org.gecko.emf.osgi.component;version='[5.0.0,5.0.1)',\
->>>>>>> branch 'model_push' of git@github.com:eclipse/org.eclipse.sensinact.gateway.git
-	org.opentest4j;version='[1.2.0,1.2.1)',\
-	org.osgi.service.component;version='[1.5.0,1.5.1)',\
-	org.osgi.service.typedevent;version='[1.0.0,1.0.1)',\
-	org.osgi.test.common;version='[1.2.1,1.2.2)',\
-	org.osgi.test.junit5;version='[1.2.1,1.2.2)',\
-	org.osgi.test.junit5.cm;version='[1.2.1,1.2.2)',\
-	org.osgi.util.converter;version='[1.0.9,1.0.10)',\
-	org.osgi.util.function;version='[1.1.0,1.1.1)',\
-	org.osgi.util.promise;version='[1.3.0,1.3.1)',\
-	org.osgi.util.pushstream;version='[1.0.2,1.0.3)',\
-	slf4j.api;version='[1.7.36,1.7.37)',\
-	slf4j.log4j12;version='[1.7.25,1.7.26)',\
-	slf4j.simple;version='[1.7.36,1.7.37)'


### PR DESCRIPTION
* Added a `Constants.IGNORE` value that can be returned by records: the value is then ignored by the device factory handler. This avoids having updates with null values if they are missing in the payload.
* Added the `Map<String, String> context` argument to the calls to the device factory parser.
* Protect the device factory handler against parsers returning null for no records
* Allow parsers to return the timestamp as an `Instant`