### PR TITLE
Catch and log MQTT message listener exceptions

### DIFF
--- a/prototype/southbound/mqtt/mqtt-client/src/main/java/org/eclipse/sensinact/gateway/southbound/mqtt/impl/MqttClientHandler.java
+++ b/prototype/southbound/mqtt/mqtt-client/src/main/java/org/eclipse/sensinact/gateway/southbound/mqtt/impl/MqttClientHandler.java
@@ -220,7 +220,12 @@ public class MqttClientHandler implements MqttCallback {
 
         for (Entry<IMqttMessageListener, Predicate<String>> entry : workListeners.entrySet()) {
             if (entry.getValue().test(topic)) {
-                entry.getKey().onMqttMessage(handlerId, topic, snMessage);
+                try {
+                    entry.getKey().onMqttMessage(handlerId, topic, snMessage);
+                } catch (Throwable t) {
+                    logger.error("Error handling MQTT message. Client={}, topic={}, error={}", handlerId, topic,
+                            t.getMessage(), t);
+                }
             }
         }
     }


### PR DESCRIPTION
This avoids to propagate the exception to Paho, which will disconnect on error