### PR TITLE
Implementation of pull-based resources

### DIFF
--- a/prototype/core/annotation/src/main/java/org/eclipse/sensinact/core/annotation/verb/GET.java
+++ b/prototype/core/annotation/src/main/java/org/eclipse/sensinact/core/annotation/verb/GET.java
@@ -17,6 +17,8 @@ import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.sensinact.core.annotation.dto.NullAction;
 
@@ -72,6 +74,19 @@ public @interface GET {
      * @return
      */
     Class<?> type() default Object.class;
+
+    /**
+     * Duration of the value cache. If the value is requested using a CACHED get and
+     * the cache duration is exceeded, the annotated method will be called.
+     *
+     * The default duration is in {@link TimeUnit#MILLISECONDS}.
+     */
+    long cacheDuration() default 500;
+
+    /**
+     * Unit of the value cache duration. Defaults to {@link ChronoUnit#MILLIS}.
+     */
+    ChronoUnit cacheDurationUnit() default ChronoUnit.MILLIS;
 
     NullAction onNull() default NullAction.IGNORE;
 

--- a/prototype/core/annotation/src/main/java/org/eclipse/sensinact/core/annotation/verb/GET.java
+++ b/prototype/core/annotation/src/main/java/org/eclipse/sensinact/core/annotation/verb/GET.java
@@ -18,7 +18,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.time.temporal.ChronoUnit;
-import java.util.concurrent.TimeUnit;
 
 import org.eclipse.sensinact.core.annotation.dto.NullAction;
 
@@ -79,7 +78,7 @@ public @interface GET {
      * Duration of the value cache. If the value is requested using a CACHED get and
      * the cache duration is exceeded, the annotated method will be called.
      *
-     * The default duration is in {@link TimeUnit#MILLISECONDS}.
+     * The default duration is in {@link ChronoUnit#MILLIS}.
      */
     long cacheDuration() default 500;
 

--- a/prototype/core/annotation/src/main/java/org/eclipse/sensinact/core/annotation/verb/GetParam.java
+++ b/prototype/core/annotation/src/main/java/org/eclipse/sensinact/core/annotation/verb/GetParam.java
@@ -1,0 +1,46 @@
+/*********************************************************************
+* Copyright (c) 2023 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Kentyou - initial implementation
+**********************************************************************/
+package org.eclipse.sensinact.core.annotation.verb;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A parameter annotation used to define the name of a getter parameter.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface GetParam {
+
+    /**
+     * The kind of the getter parameter
+     */
+    GetSegment value();
+
+    /**
+     * Possible arguments for SET handlers
+     */
+    public enum GetSegment {
+        /**
+         * Current value in the twin (TimedValue)
+         */
+        CACHED_VALUE,
+
+        /**
+         * Expected result type (Class)
+         */
+        RESULT_TYPE,
+    }
+}

--- a/prototype/core/annotation/src/main/java/org/eclipse/sensinact/core/annotation/verb/SetParam.java
+++ b/prototype/core/annotation/src/main/java/org/eclipse/sensinact/core/annotation/verb/SetParam.java
@@ -1,0 +1,51 @@
+/*********************************************************************
+* Copyright (c) 2023 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Kentyou - initial implementation
+**********************************************************************/
+package org.eclipse.sensinact.core.annotation.verb;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A parameter annotation used to define the name of a setter parameter.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface SetParam {
+
+    /**
+     * The kind of the action parameter
+     */
+    SetSegment value();
+
+    /**
+     * Possible arguments for SET handlers
+     */
+    public enum SetSegment {
+        /**
+         * Current value in the twin
+         */
+        CACHED_VALUE,
+
+        /**
+         * New value given to the handler
+         */
+        NEW_VALUE,
+
+        /**
+         * Expected result type (Class)
+         */
+        RESULT_TYPE,
+    }
+}

--- a/prototype/core/api/src/main/java/org/eclipse/sensinact/core/command/GetLevel.java
+++ b/prototype/core/api/src/main/java/org/eclipse/sensinact/core/command/GetLevel.java
@@ -1,0 +1,38 @@
+/*********************************************************************
+* Copyright (c) 2023 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Kentyou - initial implementation
+**********************************************************************/
+package org.eclipse.sensinact.core.command;
+
+/**
+ * Variants of the GET command
+ */
+public enum GetLevel {
+
+    /**
+     * Default level. For pull-based values, if the cached value is older than the
+     * threshold, pull the real value, else return the cached one. For push-based
+     * values, returns the last cached value.
+     */
+    CACHED,
+
+    /**
+     * Weak Get: always return the last value in cache. Don't try to pull a real
+     * value
+     */
+    WEAK,
+
+    /**
+     * Hard Get: always ask for the real value and put it in cache. Acts like
+     * {@link #CACHED} for pushed values.
+     */
+    HARD,
+}

--- a/prototype/core/api/src/main/java/org/eclipse/sensinact/core/command/GetLevel.java
+++ b/prototype/core/api/src/main/java/org/eclipse/sensinact/core/command/GetLevel.java
@@ -13,26 +13,34 @@
 package org.eclipse.sensinact.core.command;
 
 /**
- * Variants of the GET command
+ * Levels of execution of the GET command.
+ * <p>
+ * These levels only have effect on resources with an external getter. GET
+ * commands execution upon other resources will always return the cached value.
  */
 public enum GetLevel {
 
     /**
-     * Default level. For pull-based values, if the cached value is older than the
-     * threshold, pull the real value, else return the cached one. For push-based
-     * values, returns the last cached value.
+     * Default level for the GET command
+     * <p>
+     * For resources with an external getter, the cached value will be returned if
+     * its time stamp is in the cache period. If the value wasn't set or if the
+     * cache expired, the external getter will be called.
      */
-    CACHED,
+    NORMAL,
 
     /**
-     * Weak Get: always return the last value in cache. Don't try to pull a real
-     * value
+     * Weak Get
+     * <p>
+     * Always returns the cached value, never calls the external getter (if defined)
+     * even if the resource has not yet been set.
      */
     WEAK,
 
     /**
-     * Hard Get: always ask for the real value and put it in cache. Acts like
-     * {@link #CACHED} for pushed values.
+     * Strong Get
+     * <p>
+     * Always calls the external getter of the resource, if defined.
      */
-    HARD,
+    STRONG,
 }

--- a/prototype/core/api/src/main/java/org/eclipse/sensinact/core/model/ResourceBuilder.java
+++ b/prototype/core/api/src/main/java/org/eclipse/sensinact/core/model/ResourceBuilder.java
@@ -12,12 +12,12 @@
 **********************************************************************/
 package org.eclipse.sensinact.core.model;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 /**
  * A builder for programmatically registering models
@@ -85,20 +85,21 @@ public interface ResourceBuilder<B, T> {
     ResourceBuilder<B, T> withAction(List<Entry<String, Class<?>>> namedParameterTypes);
 
     /**
-     * Set a getter function to be called
-     *
-     * @param getter
-     * @return
+     * This resource has a dynamic get behavior. Can't work on resource with an action.
      */
-    ResourceBuilder<B, T> withGetter(Supplier<T> getter);
+    ResourceBuilder<B, T> withGetter();
 
     /**
-     * Set a setter function to be called
+     * Sets the cache duration for dynamic get calls
      *
-     * @param setter
-     * @return
+     * @param cacheDuration Duration of the cache
      */
-    ResourceBuilder<B, T> withSetter(Consumer<T> setter);
+    ResourceBuilder<B, T> withGetterCache(Duration cacheDuration);
+
+    /**
+     * This resource has a dynamic set behavior. Can't work on resource with an action.
+     */
+    ResourceBuilder<B, T> withSetter();
 
     /**
      * Build the resource

--- a/prototype/core/api/src/main/java/org/eclipse/sensinact/core/model/ResourceBuilder.java
+++ b/prototype/core/api/src/main/java/org/eclipse/sensinact/core/model/ResourceBuilder.java
@@ -85,9 +85,20 @@ public interface ResourceBuilder<B, T> {
     ResourceBuilder<B, T> withAction(List<Entry<String, Class<?>>> namedParameterTypes);
 
     /**
-     * This resource has a dynamic get behavior. Can't work on resource with an action.
+     * This resource has a dynamic get behavior. This can't be applied on an action
+     * resource.
      */
-    ResourceBuilder<B, T> withGetter();
+    default ResourceBuilder<B, T> withGetter() {
+        return withGetter(true);
+    }
+
+    /**
+     * Indicates if the resource has a dynamic get behavior. Action resources can't
+     * have such a behavior.
+     *
+     * @param hasGetter Flag to indicate if the resource has a dynamic get or not
+     */
+    ResourceBuilder<B, T> withGetter(boolean hasGetter);
 
     /**
      * Sets the cache duration for dynamic get calls
@@ -97,9 +108,20 @@ public interface ResourceBuilder<B, T> {
     ResourceBuilder<B, T> withGetterCache(Duration cacheDuration);
 
     /**
-     * This resource has a dynamic set behavior. Can't work on resource with an action.
+     * This resource has a dynamic set behavior. This can't be applied on an action
+     * resource.
      */
-    ResourceBuilder<B, T> withSetter();
+    default ResourceBuilder<B, T> withSetter() {
+        return withSetter(true);
+    }
+
+    /**
+     * Indicates if the resource has a dynamic set behavior. Action resources can't
+     * have such a behavior.
+     *
+     * @param hasSetter Flag to indicate if the resource has a dynamic set or not
+     */
+    ResourceBuilder<B, T> withSetter(boolean hasSetter);
 
     /**
      * Build the resource

--- a/prototype/core/api/src/main/java/org/eclipse/sensinact/core/session/ResourceDescription.java
+++ b/prototype/core/api/src/main/java/org/eclipse/sensinact/core/session/ResourceDescription.java
@@ -13,20 +13,69 @@
 package org.eclipse.sensinact.core.session;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
+import org.eclipse.sensinact.core.model.ResourceType;
+import org.eclipse.sensinact.core.model.ValueType;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+/**
+ * Description/snapshot of the resource
+ */
 public class ResourceDescription {
 
+    /**
+     * Provider name
+     */
     public String provider;
 
+    /**
+     * Service name
+     */
     public String service;
 
+    /**
+     * Resource name
+     */
     public String resource;
 
+    /**
+     * Metadata
+     */
     public Map<String, Object> metadata;
 
+    /**
+     * Current value
+     */
     public Object value;
 
+    /**
+     * Time stamp of current value
+     */
     public Instant timestamp;
 
+    /**
+     * Value type (fixed, updatable, ...)
+     */
+    public ValueType valueType;
+
+    /**
+     * Resource type (action, ...)
+     */
+    public ResourceType resourceType;
+
+    /**
+     * Resource content type
+     */
+    public Class<?> contentType;
+
+    /**
+     * Parameters of the ACT method if the resource is of type Action
+     */
+    @JsonInclude(Include.NON_NULL)
+    public List<Entry<String, Class<?>>> actMethodArgumentsTypes;
 }

--- a/prototype/core/api/src/main/java/org/eclipse/sensinact/core/session/SensiNactSession.java
+++ b/prototype/core/api/src/main/java/org/eclipse/sensinact/core/session/SensiNactSession.java
@@ -17,6 +17,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.sensinact.core.command.GetLevel;
 import org.eclipse.sensinact.core.notification.ClientActionListener;
 import org.eclipse.sensinact.core.notification.ClientDataListener;
 import org.eclipse.sensinact.core.notification.ClientLifecycleListener;
@@ -86,14 +87,14 @@ public interface SensiNactSession {
     void removeListener(String id);
 
     /**
-     * Get the value of a resource
+     * Get the value of a resource with with a {@link GetLevel#NORMAL} operation.
      *
-     * @param <T>
-     * @param provider
-     * @param service
-     * @param resource
-     * @param clazz
-     * @return
+     * @param <T>      Resource value type
+     * @param provider Provider name
+     * @param service  Service name
+     * @param resource Resource name
+     * @param clazz    Resource value type class
+     * @return The resource value, can be null
      * @throws ClassCastException       if the value cannot be cast to the relevant
      *                                  type
      * @throws IllegalArgumentException if there is no resource at the given
@@ -104,18 +105,54 @@ public interface SensiNactSession {
     /**
      * Get the value of a resource
      *
-     * @param <T>
-     * @param provider
-     * @param service
-     * @param resource
-     * @param clazz
-     * @return
+     * @param <T>      Resource value type
+     * @param provider Provider name
+     * @param service  Service name
+     * @param resource Resource name
+     * @param clazz    Resource value type class
+     * @param getLevel The level of get operation. Only concerns resources with an external getter.
+     * @return The resource value, can be null
+     * @throws ClassCastException       if the value cannot be cast to the relevant
+     *                                  type
+     * @throws IllegalArgumentException if there is no resource at the given
+     *                                  location
+     */
+    <T> T getResourceValue(String provider, String service, String resource, Class<T> clazz, GetLevel getLevel);
+
+    /**
+     * Get the timed value of a resource with a {@link GetLevel#NORMAL} operation.
+     *
+     * @param <T>      Resource value type
+     * @param provider Provider name
+     * @param service  Service name
+     * @param resource Resource name
+     * @param clazz    Resource value type class
+     * @return The timed value of the resource. Can return null.
      * @throws ClassCastException       if the value cannot be cast to the relevant
      *                                  type
      * @throws IllegalArgumentException if there is no resource at the given
      *                                  location
      */
     <T> TimedValue<T> getResourceTimedValue(String provider, String service, String resource, Class<T> clazz);
+
+    /**
+     * Get the timed value of a resource with a {@link GetLevel#NORMAL} operation.
+     *
+     * @param <T>      Resource value type
+     * @param provider Provider name
+     * @param service  Service name
+     * @param resource Resource name
+     * @param clazz    Resource value type class
+     * @param getLevel The level of get operation. Only concerns resources with an
+     *                 external getter.
+     * @return The timed value of the resource. Can return null.
+     * @throws ClassCastException       if the value cannot be cast to the relevant
+     *                                  type
+     * @throws IllegalArgumentException if there is no resource at the given
+     *                                  location
+     */
+    <T> TimedValue<T> getResourceTimedValue(String provider, String service, String resource, Class<T> clazz,
+            GetLevel getLevel);
 
     /**
      * Set the value of a resource with the current time

--- a/prototype/core/api/src/main/java/org/eclipse/sensinact/core/session/SensiNactSession.java
+++ b/prototype/core/api/src/main/java/org/eclipse/sensinact/core/session/SensiNactSession.java
@@ -24,6 +24,7 @@ import org.eclipse.sensinact.core.notification.ClientMetadataListener;
 import org.eclipse.sensinact.core.security.UserInfo;
 import org.eclipse.sensinact.core.snapshot.ICriterion;
 import org.eclipse.sensinact.core.snapshot.ProviderSnapshot;
+import org.eclipse.sensinact.core.twin.TimedValue;
 
 public interface SensiNactSession {
 
@@ -99,6 +100,22 @@ public interface SensiNactSession {
      *                                  location
      */
     <T> T getResourceValue(String provider, String service, String resource, Class<T> clazz);
+
+    /**
+     * Get the value of a resource
+     *
+     * @param <T>
+     * @param provider
+     * @param service
+     * @param resource
+     * @param clazz
+     * @return
+     * @throws ClassCastException       if the value cannot be cast to the relevant
+     *                                  type
+     * @throws IllegalArgumentException if there is no resource at the given
+     *                                  location
+     */
+    <T> TimedValue<T> getResourceTimedValue(String provider, String service, String resource, Class<T> clazz);
 
     /**
      * Set the value of a resource with the current time

--- a/prototype/core/api/src/main/java/org/eclipse/sensinact/core/twin/SensinactResource.java
+++ b/prototype/core/api/src/main/java/org/eclipse/sensinact/core/twin/SensinactResource.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.sensinact.core.command.CommandScoped;
+import org.eclipse.sensinact.core.command.GetLevel;
 import org.eclipse.sensinact.core.model.ResourceType;
 import org.eclipse.sensinact.core.model.ValueType;
 import org.osgi.util.promise.Promise;
@@ -77,14 +78,36 @@ public interface SensinactResource extends CommandScoped {
      * @param timestamp
      * @return
      */
-    Promise<Void> setValue(Object value, Instant timestamp);
+    <T> Promise<Void> setValue(T value, Instant timestamp);
 
     /**
      * Get the value of the resource
-     *
-     * @return
      */
-    Promise<TimedValue<?>> getValue();
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    default Promise<TimedValue<?>> getValue() {
+        return getValue((Class) Object.class, GetLevel.CACHED);
+    }
+
+    /**
+     * Get the typed value of the resource. If the value doesn't match the expected
+     * type, null is returned.
+     *
+     * @param type Expected resource type
+     * @return The timed and typed value of the resource
+     */
+    default <T> Promise<TimedValue<T>> getValue(Class<T> type) {
+        return getValue(type, GetLevel.CACHED);
+    }
+
+    /**
+     * Get the typed value of the resource.
+     * If the value doesn't match the expected type, null is returned.
+     *
+     * @param type Expected resource type
+     * @param getLevel Get command level for pull-based resources
+     * @return The timed and typed value of the resource
+     */
+    <T> Promise<TimedValue<T>> getValue(Class<T> type, GetLevel getLevel);
 
     /**
      * Set a metadata value for the resource

--- a/prototype/core/api/src/main/java/org/eclipse/sensinact/core/twin/SensinactResource.java
+++ b/prototype/core/api/src/main/java/org/eclipse/sensinact/core/twin/SensinactResource.java
@@ -85,7 +85,7 @@ public interface SensinactResource extends CommandScoped {
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
     default Promise<TimedValue<?>> getValue() {
-        return getValue((Class) Object.class, GetLevel.CACHED);
+        return getValue((Class) Object.class, GetLevel.NORMAL);
     }
 
     /**
@@ -96,7 +96,7 @@ public interface SensinactResource extends CommandScoped {
      * @return The timed and typed value of the resource
      */
     default <T> Promise<TimedValue<T>> getValue(Class<T> type) {
-        return getValue(type, GetLevel.CACHED);
+        return getValue(type, GetLevel.NORMAL);
     }
 
     /**

--- a/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/command/impl/ResourcePullHandler.java
+++ b/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/command/impl/ResourcePullHandler.java
@@ -1,0 +1,37 @@
+/*********************************************************************
+* Copyright (c) 2023 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Kentyou - initial implementation
+**********************************************************************/
+package org.eclipse.sensinact.prototype.command.impl;
+
+import org.eclipse.sensinact.core.twin.TimedValue;
+import org.osgi.util.promise.Promise;
+
+/**
+ *
+ */
+public interface ResourcePullHandler {
+
+    /**
+     * Pulls the value
+     *
+     * @param <T>         Expected resource value type
+     * @param model       Model name
+     * @param provider    Provider name
+     * @param service     Service name
+     * @param resource    Resource name
+     * @param clazz       Expected resource value type
+     * @param cachedValue Current cached value (value and timestamp can be null)
+     * @return The promise of a new value (can't be null)
+     */
+    <T> Promise<TimedValue<T>> pullValue(String model, String provider, String service, String resource, Class<T> clazz,
+            TimedValue<T> cachedValue);
+}

--- a/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/command/impl/ResourcePullHandler.java
+++ b/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/command/impl/ResourcePullHandler.java
@@ -12,6 +12,8 @@
 **********************************************************************/
 package org.eclipse.sensinact.prototype.command.impl;
 
+import java.util.function.Consumer;
+
 import org.eclipse.sensinact.core.twin.TimedValue;
 import org.osgi.util.promise.Promise;
 
@@ -23,16 +25,17 @@ public interface ResourcePullHandler {
     /**
      * Pulls the value from the external getter.
      *
-     * @param <T>         Expected resource value type
-     * @param model       Model name
-     * @param provider    Provider name
-     * @param service     Service name
-     * @param resource    Resource name
-     * @param clazz       Expected resource value type
-     * @param cachedValue Current cached value (value and time stamp can be null)
+     * @param <T>           Expected resource value type
+     * @param model         Model name
+     * @param provider      Provider name
+     * @param service       Service name
+     * @param resource      Resource name
+     * @param clazz         Expected resource value type
+     * @param cachedValue   Current cached value (value and time stamp can be null)
+     * @param gatewayUpdate Method to call in the gateway thread to update the twin
      * @return The promise of the value to be returned by the external getter (can't
      *         be null). This value will be stored in the twin.
      */
     <T> Promise<TimedValue<T>> pullValue(String model, String provider, String service, String resource, Class<T> clazz,
-            TimedValue<T> cachedValue);
+            TimedValue<T> cachedValue, Consumer<TimedValue<T>> gatewayUpdate);
 }

--- a/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/command/impl/ResourcePullHandler.java
+++ b/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/command/impl/ResourcePullHandler.java
@@ -16,12 +16,12 @@ import org.eclipse.sensinact.core.twin.TimedValue;
 import org.osgi.util.promise.Promise;
 
 /**
- *
+ * Definition of the external get caller
  */
 public interface ResourcePullHandler {
 
     /**
-     * Pulls the value
+     * Pulls the value from the external getter.
      *
      * @param <T>         Expected resource value type
      * @param model       Model name
@@ -29,8 +29,9 @@ public interface ResourcePullHandler {
      * @param service     Service name
      * @param resource    Resource name
      * @param clazz       Expected resource value type
-     * @param cachedValue Current cached value (value and timestamp can be null)
-     * @return The promise of a new value (can't be null)
+     * @param cachedValue Current cached value (value and time stamp can be null)
+     * @return The promise of the value to be returned by the external getter (can't
+     *         be null). This value will be stored in the twin.
      */
     <T> Promise<TimedValue<T>> pullValue(String model, String provider, String service, String resource, Class<T> clazz,
             TimedValue<T> cachedValue);

--- a/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/command/impl/ResourcePushHandler.java
+++ b/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/command/impl/ResourcePushHandler.java
@@ -12,6 +12,8 @@
 **********************************************************************/
 package org.eclipse.sensinact.prototype.command.impl;
 
+import java.util.function.Consumer;
+
 import org.eclipse.sensinact.core.twin.TimedValue;
 import org.osgi.util.promise.Promise;
 
@@ -23,19 +25,20 @@ public interface ResourcePushHandler {
     /**
      * Pushes a value to the external setter.
      *
-     * @param <T>         Expected resource value type
-     * @param model       Model name
-     * @param provider    Provider name
-     * @param service     Service name
-     * @param resource    Resource name
-     * @param clazz       Expected resource value type
-     * @param cachedValue Current cached value (value and time stamp can be null)
-     * @param newValue    Pushed value
+     * @param <T>           Expected resource value type
+     * @param model         Model name
+     * @param provider      Provider name
+     * @param service       Service name
+     * @param resource      Resource name
+     * @param clazz         Expected resource value type
+     * @param cachedValue   Current cached value (value and time stamp can be null)
+     * @param newValue      Pushed value
+     * @param gatewayUpdate Method to call in the gateway thread to update the twin
      * @return The promise of the value to be returned by the external setter (can't
      *         be null). This value must reflect the real state of the resource and
      *         might therefore be different from newValue. The returned value will
      *         be stored in the twin.
      */
     <T> Promise<TimedValue<T>> pushValue(String model, String provider, String service, String resource, Class<T> clazz,
-            TimedValue<T> cachedValue, TimedValue<T> newValue);
+            TimedValue<T> cachedValue, TimedValue<T> newValue, Consumer<TimedValue<T>> gatewayUpdate);
 }

--- a/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/command/impl/ResourcePushHandler.java
+++ b/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/command/impl/ResourcePushHandler.java
@@ -16,12 +16,12 @@ import org.eclipse.sensinact.core.twin.TimedValue;
 import org.osgi.util.promise.Promise;
 
 /**
- *
+ * Definition of the external set caller
  */
 public interface ResourcePushHandler {
 
     /**
-     * Pushes a value
+     * Pushes a value to the external setter.
      *
      * @param <T>         Expected resource value type
      * @param model       Model name
@@ -29,9 +29,12 @@ public interface ResourcePushHandler {
      * @param service     Service name
      * @param resource    Resource name
      * @param clazz       Expected resource value type
-     * @param cachedValue Current cached value (value and timestamp can be null)
+     * @param cachedValue Current cached value (value and time stamp can be null)
      * @param newValue    Pushed value
-     * @return The promise of a new value (can't be null)
+     * @return The promise of the value to be returned by the external setter (can't
+     *         be null). This value must reflect the real state of the resource and
+     *         might therefore be different from newValue. The returned value will
+     *         be stored in the twin.
      */
     <T> Promise<TimedValue<T>> pushValue(String model, String provider, String service, String resource, Class<T> clazz,
             TimedValue<T> cachedValue, TimedValue<T> newValue);

--- a/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/command/impl/ResourcePushHandler.java
+++ b/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/command/impl/ResourcePushHandler.java
@@ -1,0 +1,38 @@
+/*********************************************************************
+* Copyright (c) 2023 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Kentyou - initial implementation
+**********************************************************************/
+package org.eclipse.sensinact.prototype.command.impl;
+
+import org.eclipse.sensinact.core.twin.TimedValue;
+import org.osgi.util.promise.Promise;
+
+/**
+ *
+ */
+public interface ResourcePushHandler {
+
+    /**
+     * Pushes a value
+     *
+     * @param <T>         Expected resource value type
+     * @param model       Model name
+     * @param provider    Provider name
+     * @param service     Service name
+     * @param resource    Resource name
+     * @param clazz       Expected resource value type
+     * @param cachedValue Current cached value (value and timestamp can be null)
+     * @param newValue    Pushed value
+     * @return The promise of a new value (can't be null)
+     */
+    <T> Promise<TimedValue<T>> pushValue(String model, String provider, String service, String resource, Class<T> clazz,
+            TimedValue<T> cachedValue, TimedValue<T> newValue);
+}

--- a/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/impl/SensiNactSessionImpl.java
+++ b/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/impl/SensiNactSessionImpl.java
@@ -235,7 +235,7 @@ public class SensiNactSessionImpl implements SensiNactSession {
                         return pf.resolved(null);
                     }
                     // TODO: get the GetLevel from argument
-                    return sensinactResource.getValue(clazz, GetLevel.CACHED);
+                    return sensinactResource.getValue(clazz, GetLevel.NORMAL);
                 } else {
                     return pf.resolved(null);
                 }
@@ -330,7 +330,7 @@ public class SensiNactSessionImpl implements SensiNactSession {
                         break;
 
                     default:
-                        val = sensinactResource.getValue(Object.class, GetLevel.CACHED);
+                        val = sensinactResource.getValue(Object.class, GetLevel.NORMAL);
                         break;
                     }
 

--- a/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/impl/SensiNactSessionImpl.java
+++ b/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/impl/SensiNactSessionImpl.java
@@ -186,14 +186,18 @@ public class SensiNactSessionImpl implements SensiNactSession {
         return safeExecute(new AbstractTwinCommand<T>() {
             @Override
             protected Promise<T> call(SensinactDigitalTwin model, PromiseFactory pf) {
-                I modelValue = caller.apply(model);
-                T value;
-                if (modelValue != null) {
-                    value = converter.apply(modelValue);
-                } else {
-                    value = defaultValue;
+                try {
+                    I modelValue = caller.apply(model);
+                    T value;
+                    if (modelValue != null) {
+                        value = converter.apply(modelValue);
+                    } else {
+                        value = defaultValue;
+                    }
+                    return pf.resolved(value);
+                } catch (Exception e) {
+                    return pf.failed(e);
                 }
-                return pf.resolved(value);
             }
         });
     }

--- a/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/model/impl/ResourceBuilderImpl.java
+++ b/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/model/impl/ResourceBuilderImpl.java
@@ -106,9 +106,9 @@ public class ResourceBuilderImpl<R, T> extends NestableBuilderImpl<R, ServiceImp
     }
 
     @Override
-    public ResourceBuilder<R, T> withGetter() {
+    public ResourceBuilder<R, T> withGetter(boolean hasGet) {
         checkValid();
-        this.hasGetter = true;
+        this.hasGetter = hasGet;
         return this;
     }
 
@@ -124,9 +124,9 @@ public class ResourceBuilderImpl<R, T> extends NestableBuilderImpl<R, ServiceImp
     }
 
     @Override
-    public ResourceBuilder<R, T> withSetter() {
+    public ResourceBuilder<R, T> withSetter(boolean hasSet) {
         checkValid();
-        this.hasSetter = true;
+        this.hasSetter = hasSet;
         return this;
     }
 

--- a/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/twin/impl/SensinactResourceImpl.java
+++ b/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/twin/impl/SensinactResourceImpl.java
@@ -206,7 +206,7 @@ public class SensinactResourceImpl extends CommandScopedImpl implements Sensinac
         if (!hasExternalGetter || getLevel == GetLevel.WEAK) {
             // Push-based or weak get: return the cached value
             return promiseFactory.resolved(cachedValue);
-        } else if (getLevel == GetLevel.HARD || cachedValue.getTimestamp() == null || cacheThreshold == null
+        } else if (getLevel == GetLevel.STRONG || cachedValue.getTimestamp() == null || cacheThreshold == null
                 || Instant.now().minus(cacheThreshold).isAfter(cachedValue.getTimestamp())) {
             // Hard get or no value or no cache policy or threshold exceed: pull the
             // value...

--- a/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/whiteboard/impl/AbstractResourceMethod.java
+++ b/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/whiteboard/impl/AbstractResourceMethod.java
@@ -1,0 +1,150 @@
+/*********************************************************************
+* Copyright (c) 2023 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Kentyou - initial implementation
+**********************************************************************/
+package org.eclipse.sensinact.prototype.whiteboard.impl;
+
+import static java.util.stream.Collectors.toList;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.function.Function;
+
+import org.eclipse.sensinact.core.annotation.verb.ActParam;
+import org.eclipse.sensinact.core.annotation.verb.UriParam;
+import org.eclipse.sensinact.prototype.model.nexus.emf.EMFUtil;
+
+/**
+ * Share code between ACT and GET methods
+ */
+abstract class AbstractResourceMethod {
+
+    /**
+     * Invoked method
+     */
+    protected final Method method;
+
+    /**
+     * Bound instance
+     */
+    protected final Object instance;
+
+    final Long serviceId;
+
+    /**
+     * Associated providers
+     */
+    final Set<String> providers;
+
+    public AbstractResourceMethod(final Method method, final Object instance, final Long serviceId,
+            final Set<String> providers) {
+        super();
+        this.method = method;
+        this.instance = instance;
+        this.serviceId = serviceId;
+        this.providers = providers;
+    }
+
+    /**
+     * Checks if the bound instance can be used for any provider
+     */
+    public boolean isCatchAll() {
+        return providers.isEmpty();
+    }
+
+    /**
+     * Checks if this method overlaps the providers of another
+     */
+    public boolean overlaps(AbstractResourceMethod otherMethod) {
+        return (providers.isEmpty() && otherMethod.providers.isEmpty())
+                || Collections.disjoint(providers, otherMethod.providers);
+    }
+
+    /**
+     * Returns the list of parameters of the invoked method
+     */
+    public List<Entry<String, Class<?>>> getNamedParameterTypes() {
+        return Arrays.stream(method.getParameters()).filter(p -> !p.isAnnotationPresent(UriParam.class)).map(
+                p -> new AbstractMap.SimpleImmutableEntry<String, Class<?>>(getActionParameterName(p), p.getType()))
+                .collect(toList());
+    }
+
+    private String getActionParameterName(Parameter p) {
+        String name;
+        if (p.isAnnotationPresent(ActParam.class)) {
+            name = p.getAnnotation(ActParam.class).name();
+        } else {
+            name = p.getName();
+        }
+        return name;
+    }
+
+    public Class<?> getReturnType() {
+        return method.getReturnType();
+    }
+
+    protected <A extends Annotation, E extends Enum<E>> Object invoke(String model, String provider, String service,
+            String resource, Map<Object, Object> params, Class<A> extraArgumentAnnotation,
+            Function<A, E> argNameExtractor) throws Exception {
+        Parameter[] parameters = method.getParameters();
+        Object[] args = new Object[parameters.length];
+        for (int i = 0; i < parameters.length; i++) {
+            final Parameter p = parameters[i];
+            final UriParam param = p.getAnnotation(UriParam.class);
+            if (param != null) {
+                switch (param.value()) {
+                case MODEL:
+                    args[i] = model;
+                    break;
+                case PROVIDER:
+                    args[i] = provider;
+                    break;
+                case RESOURCE:
+                    args[i] = resource;
+                    break;
+                case SERVICE:
+                    args[i] = service;
+                    break;
+                case URI:
+                    args[i] = String.format("%s/%s/%s/%s", model, provider, service, resource);
+                    break;
+                default:
+                    throw new IllegalArgumentException(param.value().toString());
+                }
+            } else {
+                if (extraArgumentAnnotation != null) {
+                    final A extraAnnotation = p.getAnnotation(extraArgumentAnnotation);
+                    Object key = argNameExtractor.apply(extraAnnotation);
+                    args[i] = params.get(key);
+                } else {
+                    String name = getActionParameterName(p);
+                    final Object o = params.get(name);
+                    args[i] = o == null ? null
+                            : p.getType().isInstance(o) ? o : EMFUtil.convertToTargetType(p.getType(), o);
+                }
+            }
+        }
+        return method.invoke(instance, args);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "[serviceId=" + serviceId + ", providers=" + providers + "]";
+    }
+}

--- a/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/whiteboard/impl/ActMethod.java
+++ b/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/whiteboard/impl/ActMethod.java
@@ -12,104 +12,20 @@
 **********************************************************************/
 package org.eclipse.sensinact.prototype.whiteboard.impl;
 
-import static java.util.stream.Collectors.toList;
-
 import java.lang.reflect.Method;
-import java.lang.reflect.Parameter;
-import java.util.AbstractMap;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 
-import org.eclipse.sensinact.core.annotation.verb.ActParam;
-import org.eclipse.sensinact.core.annotation.verb.UriParam;
-import org.eclipse.sensinact.prototype.model.nexus.emf.EMFUtil;
-
-class ActMethod {
-    private final Method method;
-    private final Object instance;
-    final Long serviceId;
-    final Set<String> providers;
+class ActMethod extends AbstractResourceMethod {
 
     public ActMethod(Method method, Object instance, Long serviceId, Set<String> providers) {
-        super();
-        this.method = method;
-        this.instance = instance;
-        this.serviceId = serviceId;
-        this.providers = providers;
-    }
-
-    public boolean isCatchAll() {
-        return providers.isEmpty();
-    }
-
-    public boolean overlaps(ActMethod actMethod) {
-        return (providers.isEmpty() && actMethod.providers.isEmpty())
-                || Collections.disjoint(providers, actMethod.providers);
-    }
-
-    public List<Entry<String, Class<?>>> getNamedParameterTypes() {
-        return Arrays.stream(method.getParameters()).filter(p -> !p.isAnnotationPresent(UriParam.class)).map(
-                p -> new AbstractMap.SimpleImmutableEntry<String, Class<?>>(getActionParameterName(p), p.getType()))
-                .collect(toList());
-    }
-
-    private String getActionParameterName(Parameter p) {
-        String name;
-        if (p.isAnnotationPresent(ActParam.class)) {
-            name = p.getAnnotation(ActParam.class).name();
-        } else {
-            name = p.getName();
-        }
-        return name;
-    }
-
-    public Class<?> getReturnType() {
-        return method.getReturnType();
+        super(method, instance, serviceId, providers);
     }
 
     public Object invoke(String model, String provider, String service, String resource, Map<String, Object> params)
             throws Exception {
-        Parameter[] parameters = method.getParameters();
-        Object[] args = new Object[parameters.length];
-        for (int i = 0; i < parameters.length; i++) {
-            Parameter p = parameters[i];
-            UriParam param = p.getAnnotation(UriParam.class);
-            if (param != null) {
-                switch (param.value()) {
-                case MODEL:
-                    args[i] = model;
-                    break;
-                case PROVIDER:
-                    args[i] = provider;
-                    break;
-                case RESOURCE:
-                    args[i] = resource;
-                    break;
-                case SERVICE:
-                    args[i] = service;
-                    break;
-                case URI:
-                    args[i] = String.format("%s/%s/%s/%s", model, provider, service, resource);
-                    break;
-                default:
-                    throw new IllegalArgumentException(param.value().toString());
-                }
-            } else {
-                String name = getActionParameterName(p);
-                Object o = params.get(name);
-                args[i] = o == null ? null
-                        : p.getType().isInstance(o) ? o : EMFUtil.convertToTargetType(p.getType(), o);
-            }
-        }
-        return method.invoke(instance, args);
-    }
-
-    @Override
-    public String toString() {
-        return "ActMethod [serviceId=" + serviceId + ", providers=" + providers + "]";
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        final Map<Object, Object> rawParam = (Map) params;
+        return super.invoke(model, provider, service, resource, rawParam, null, null);
     }
 }

--- a/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/whiteboard/impl/GetMethod.java
+++ b/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/whiteboard/impl/GetMethod.java
@@ -1,0 +1,48 @@
+/*********************************************************************
+* Copyright (c) 2023 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Kentyou - initial API and implementation
+**********************************************************************/
+package org.eclipse.sensinact.prototype.whiteboard.impl;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.sensinact.core.annotation.dto.NullAction;
+import org.eclipse.sensinact.core.annotation.verb.GetParam;
+import org.eclipse.sensinact.core.annotation.verb.GetParam.GetSegment;
+import org.eclipse.sensinact.core.twin.TimedValue;
+
+class GetMethod extends AbstractResourceMethod {
+
+    /**
+     * Action to apply when the result is null
+     */
+    private final NullAction nullAction;
+
+    public GetMethod(Method method, Object instance, Long serviceId, Set<String> providers, NullAction onNull) {
+        super(method, instance, serviceId, providers);
+        this.nullAction = onNull;
+    }
+
+    public <T> Object invoke(String model, String provider, String service, String resource, Class<T> resultType,
+            TimedValue<T> cachedValue) throws Exception {
+        final Map<Object, Object> params = new HashMap<>();
+        params.put(GetSegment.RESULT_TYPE, resultType);
+        params.put(GetSegment.CACHED_VALUE, cachedValue);
+        return super.invoke(model, provider, service, resource, params, GetParam.class, GetParam::value);
+    }
+
+    public NullAction actionOnNull() {
+        return nullAction;
+    }
+}

--- a/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/whiteboard/impl/SensinactWhiteboard.java
+++ b/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/whiteboard/impl/SensinactWhiteboard.java
@@ -16,24 +16,35 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Stream.concat;
 import static java.util.stream.Stream.of;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Array;
 import java.lang.reflect.Method;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.eclipse.sensinact.core.annotation.dto.NullAction;
 import org.eclipse.sensinact.core.annotation.verb.ACT;
 import org.eclipse.sensinact.core.annotation.verb.ACT.ACTs;
+import org.eclipse.sensinact.core.annotation.verb.GET;
+import org.eclipse.sensinact.core.annotation.verb.GET.GETs;
+import org.eclipse.sensinact.core.annotation.verb.SET;
+import org.eclipse.sensinact.core.annotation.verb.SET.SETs;
 import org.eclipse.sensinact.core.command.AbstractSensinactCommand;
 import org.eclipse.sensinact.core.command.GatewayThread;
 import org.eclipse.sensinact.core.model.Model;
@@ -43,7 +54,9 @@ import org.eclipse.sensinact.core.model.ResourceType;
 import org.eclipse.sensinact.core.model.SensinactModelManager;
 import org.eclipse.sensinact.core.model.Service;
 import org.eclipse.sensinact.core.twin.SensinactDigitalTwin;
+import org.eclipse.sensinact.core.twin.TimedValue;
 import org.eclipse.sensinact.prototype.model.nexus.ModelNexus;
+import org.eclipse.sensinact.prototype.twin.impl.TimedValueImpl;
 import org.osgi.framework.Constants;
 import org.osgi.util.promise.Deferred;
 import org.osgi.util.promise.Promise;
@@ -58,8 +71,12 @@ public class SensinactWhiteboard {
     private final GatewayThread gatewayThread;
 
     private final Map<Long, List<RegistryKey>> serviceIdToActMethods = new ConcurrentHashMap<>();
+    private final Map<Long, List<RegistryKey>> serviceIdToGetMethods = new ConcurrentHashMap<>();
+    private final Map<Long, List<RegistryKey>> serviceIdToSetMethods = new ConcurrentHashMap<>();
 
     private final Map<RegistryKey, List<ActMethod>> actMethodRegistry = new ConcurrentHashMap<>();
+    private final Map<RegistryKey, List<GetMethod>> getMethodRegistry = new ConcurrentHashMap<>();
+    private final Map<RegistryKey, List<SetMethod>> setMethodRegistry = new ConcurrentHashMap<>();
 
     public SensinactWhiteboard(GatewayThread gatewayThread) {
         this.gatewayThread = gatewayThread;
@@ -72,36 +89,41 @@ public class SensinactWhiteboard {
 
         Class<?> clz = service.getClass();
 
-        List<Method> actMethods = Stream
-                .concat(Arrays.stream(clz.getMethods()),
-                        Arrays.stream(clz.getInterfaces()).flatMap(c -> Arrays.stream(c.getMethods())))
-                .filter(m -> m.isAnnotationPresent(ACT.class) || m.isAnnotationPresent(ACTs.class))
-                .collect(Collectors.toList());
-
+        List<Method> actMethods = findMethods(clz, List.of(ACT.class, ACTs.class));
         handleActMethods(serviceId, service, providers, actMethods);
+
+        List<Method> getMethods = findMethods(clz, List.of(GET.class, GETs.class));
+        List<Method> setMethods = findMethods(clz, List.of(SET.class, SETs.class));
+        handlePullMethods(serviceId, service, providers, getMethods, setMethods);
     }
 
-    public void updatedWhiteboardService(Object service, Map<String, Object> props) {
-        Long serviceId = (Long) props.get(Constants.SERVICE_ID);
+    private List<Method> findMethods(Class<?> clz, Collection<Class<? extends Annotation>> annotations) {
+        return Stream
+                .concat(Arrays.stream(clz.getMethods()),
+                        Arrays.stream(clz.getInterfaces()).flatMap(c -> Arrays.stream(c.getMethods())))
+                .filter(m -> annotations.stream().anyMatch(a -> m.isAnnotationPresent(a)))
+                .collect(Collectors.toList());
+    }
 
-        Set<String> providers = toSet(props.get("sensiNact.provider.name"));
-
-        for (RegistryKey key : serviceIdToActMethods.getOrDefault(serviceId, List.of())) {
-            actMethodRegistry.computeIfPresent(key, (x, v) -> {
+    private <T extends AbstractResourceMethod> void updateServiceReferences(final String kind, final Long serviceId,
+            final Set<String> providers, final Map<Long, List<RegistryKey>> serviceKeysHolder,
+            final Map<RegistryKey, List<T>> methodRegistry) {
+        for (RegistryKey key : serviceKeysHolder.getOrDefault(serviceId, List.of())) {
+            methodRegistry.computeIfPresent(key, (x, v) -> {
                 for (int i = 0; i < v.size(); i++) {
-                    ActMethod actMethod = v.get(i);
+                    T actMethod = v.get(i);
                     if (actMethod.serviceId.equals(serviceId)) {
                         if (providers.equals(actMethod.providers)
                                 || (!providers.isEmpty() && !actMethod.providers.isEmpty())) {
                             LOG.debug(
-                                    "The update to the whiteboard action service {} did not change the act resource {}",
-                                    serviceId, key);
+                                    "The update to the whiteboard {} service {} did not change the resource {}",
+                                    kind, serviceId, key);
                             return v;
                         } else {
                             LOG.debug(
-                                    "The update to the whiteboard action service {} changed the act resource {} from providers {} to providers {}",
-                                    serviceId, key, actMethod.providers, providers);
-                            List<ActMethod> result = new ArrayList<>(v.size());
+                                    "The update to the whiteboard {} service {} changed the resource {} from providers {} to providers {}",
+                                    kind, serviceId, key, actMethod.providers, providers);
+                            List<T> result = new ArrayList<>(v.size());
                             result.addAll(v.subList(0, i));
                             result.addAll(v.subList(i + 1, v.size()));
                             result.add(actMethod);
@@ -115,24 +137,36 @@ public class SensinactWhiteboard {
         }
     }
 
-    public void removeWhiteboardService(Object service, Map<String, Object> props) {
+    public void updatedWhiteboardService(Object service, Map<String, Object> props) {
         Long serviceId = (Long) props.get(Constants.SERVICE_ID);
+        Set<String> providers = toSet(props.get("sensiNact.provider.name"));
 
-        List<RegistryKey> keys = serviceIdToActMethods.remove(serviceId);
+        updateServiceReferences("act", serviceId, providers, serviceIdToActMethods, actMethodRegistry);
+        updateServiceReferences("get", serviceId, providers, serviceIdToGetMethods, getMethodRegistry);
+        updateServiceReferences("set", serviceId, providers, serviceIdToSetMethods, setMethodRegistry);
+    }
 
+    private <T extends AbstractResourceMethod> void clearServiceReferences(final Long serviceId,
+            final Map<Long, List<RegistryKey>> serviceKeysHolder, final Map<RegistryKey, List<T>> methodRegistry) {
+        final List<RegistryKey> keys = serviceKeysHolder.remove(serviceId);
         if (keys != null) {
             for (RegistryKey key : keys) {
-                actMethodRegistry.computeIfPresent(key, (x, v) -> {
-                    List<ActMethod> l = v.stream().filter(a -> !serviceId.equals(a.serviceId)).collect(toList());
+                methodRegistry.computeIfPresent(key, (x, v) -> {
+                    List<T> l = v.stream().filter(a -> !serviceId.equals(a.serviceId)).collect(toList());
                     if (l.equals(v)) {
-                        LOG.warn("There were no act methods to remove for service {} and resource {}", serviceId, key);
                         return v;
                     }
-
                     return l.isEmpty() ? null : l;
                 });
             }
         }
+    }
+
+    public void removeWhiteboardService(Object service, Map<String, Object> props) {
+        final Long serviceId = (Long) props.get(Constants.SERVICE_ID);
+        clearServiceReferences(serviceId, serviceIdToActMethods, actMethodRegistry);
+        clearServiceReferences(serviceId, serviceIdToGetMethods, getMethodRegistry);
+        clearServiceReferences(serviceId, serviceIdToSetMethods, setMethodRegistry);
     }
 
     private Set<String> toSet(Object object) {
@@ -170,27 +204,126 @@ public class SensinactWhiteboard {
         }
     }
 
-    private void processActMethod(ActMethod am, ACT act) {
+    private void handlePullMethods(Long serviceId, Object service, Set<String> providers, List<Method> getMethods,
+            List<Method> setMethods) {
+        // We can find different behaviors for the handling of NullAction
+        final Map<NullAction, GetMethod> cachedMethod = new HashMap<>();
 
-        RegistryKey key = new RegistryKey(act.model(), act.service(), act.resource());
+        final class MethodHolder<A extends Annotation, RM extends AbstractResourceMethod> {
+            A annotation;
+            RM rcMethod;
+        }
 
-        serviceIdToActMethods.merge(am.serviceId, List.of(key),
+        // List the resources that are GET only, SET only or both
+        final Set<RegistryKey> resources = new LinkedHashSet<>();
+        final Map<RegistryKey, List<MethodHolder<GET, GetMethod>>> listGetMethods = new HashMap<>();
+        final Map<RegistryKey, List<MethodHolder<SET, SetMethod>>> listSetMethods = new HashMap<>();
+
+        // Walk GET-annotated methods
+        for (Method annotatedMethod : getMethods) {
+            if (annotatedMethod.isAnnotationPresent(GET.class)) {
+                final GET get = annotatedMethod.getAnnotation(GET.class);
+                final RegistryKey key = new RegistryKey(get.model(), get.service(), get.resource());
+                resources.add(key);
+
+                final GetMethod getMethod = cachedMethod.computeIfAbsent(get.onNull(),
+                        (onNull) -> new GetMethod(annotatedMethod, service, serviceId, providers, onNull));
+
+                final MethodHolder<GET, GetMethod> getHolder = new MethodHolder<>();
+                getHolder.annotation = get;
+                getHolder.rcMethod = getMethod;
+                listGetMethods.computeIfAbsent(key, k -> new ArrayList<MethodHolder<GET, GetMethod>>()).add(getHolder);
+            }
+
+            if (annotatedMethod.isAnnotationPresent(GETs.class)) {
+                final GETs gets = annotatedMethod.getAnnotation(GETs.class);
+                for (GET get : gets.value()) {
+                    final RegistryKey key = new RegistryKey(get.model(), get.service(), get.resource());
+                    resources.add(key);
+
+                    final GetMethod getMethod = cachedMethod.computeIfAbsent(get.onNull(),
+                            (onNull) -> new GetMethod(annotatedMethod, service, serviceId, providers, onNull));
+
+                    final MethodHolder<GET, GetMethod> getHolder = new MethodHolder<>();
+                    getHolder.annotation = get;
+                    getHolder.rcMethod = getMethod;
+                    listGetMethods.computeIfAbsent(key, k -> new ArrayList<MethodHolder<GET, GetMethod>>())
+                            .add(getHolder);
+                }
+            }
+        }
+
+        // Walk SET-annotated methods
+        for (Method annotatedMethod : setMethods) {
+            final SetMethod setMethod = new SetMethod(annotatedMethod, service, serviceId, providers);
+
+            if (annotatedMethod.isAnnotationPresent(SET.class)) {
+                final SET set = annotatedMethod.getAnnotation(SET.class);
+                final RegistryKey key = new RegistryKey(set.model(), set.service(), set.resource());
+                resources.add(key);
+
+                final MethodHolder<SET, SetMethod> setHolder = new MethodHolder<>();
+                setHolder.annotation = set;
+                setHolder.rcMethod = setMethod;
+                listSetMethods.computeIfAbsent(key, k -> new ArrayList<MethodHolder<SET, SetMethod>>()).add(setHolder);
+            }
+            if (annotatedMethod.isAnnotationPresent(SETs.class)) {
+                final SETs sets = annotatedMethod.getAnnotation(SETs.class);
+                for (SET set : sets.value()) {
+                    final RegistryKey key = new RegistryKey(set.model(), set.service(), set.resource());
+                    resources.add(key);
+                    final MethodHolder<SET, SetMethod> setHolder = new MethodHolder<>();
+                    setHolder.annotation = set;
+                    setHolder.rcMethod = setMethod;
+                    listSetMethods.computeIfAbsent(key, k -> new ArrayList<MethodHolder<SET, SetMethod>>())
+                            .add(setHolder);
+                }
+            }
+        }
+
+        for (final RegistryKey key : resources) {
+            final List<MethodHolder<GET, GetMethod>> definedGetMethods = listGetMethods.get(key);
+            final List<MethodHolder<SET, SetMethod>> definedSetMethods = listSetMethods.get(key);
+            final boolean hasGet = definedGetMethods != null && !definedGetMethods.isEmpty();
+            final boolean hasSet = definedSetMethods != null && !definedSetMethods.isEmpty();
+
+            if (hasGet) {
+                for (MethodHolder<GET, GetMethod> getHolder : definedGetMethods) {
+                    processGetMethod(key, getHolder.rcMethod, getHolder.annotation, hasSet);
+                }
+            }
+
+            if (hasSet) {
+                for (MethodHolder<SET, SetMethod> setHolder : definedSetMethods) {
+                    processSetMethod(key, setHolder.rcMethod, setHolder.annotation, hasGet);
+                }
+            }
+        }
+    }
+
+    private <T extends AbstractResourceMethod> void processAnnotatedMethod(final RegistryKey key,
+            final Predicate<ResourceType> validateResourceType,
+            final Consumer<ResourceBuilder<?, Object>> builderCaller,
+            T method, Map<RegistryKey, List<T>> methodsRegistry,
+            Map<Long, List<RegistryKey>> serviceIdRegistry) {
+
+        serviceIdRegistry.merge(method.serviceId, List.of(key),
                 (k, v) -> concat(v.stream(), of(key)).collect(toList()));
 
-        actMethodRegistry.merge(key, List.of(am), (k, v) -> {
-            Stream<ActMethod> stream;
-            if (am.isCatchAll()) {
-                ActMethod previous = v.get(v.size() - 1);
+        methodsRegistry.merge(key, List.of(method), (k, v) -> {
+            Stream<T> stream;
+            if (method.isCatchAll()) {
+                T previous = v.get(v.size() - 1);
                 if (previous.isCatchAll()) {
-                    LOG.warn("There are two catch all services {} and {} defined for act resource {}",
-                            previous.serviceId, am.serviceId, key);
+                    LOG.warn("There are two catch all services {} and {} defined for GET resource {}",
+                            previous.serviceId, method.serviceId, key);
                 }
-                stream = concat(v.stream(), of(am));
+                stream = concat(v.stream(), of(method));
             } else {
-                if (v.stream().anyMatch(a -> a.overlaps(am))) {
-                    LOG.warn("There are overlapping services defined for act resource {}: {}", key, v);
+                if (v.stream().anyMatch(a -> a.overlaps(method))) {
+                    LOG.warn("There are overlapping services defined for GET resource {}: {}", key, v);
                 }
-                stream = concat(of(am), v.stream());
+                stream = concat(of(method), v.stream());
             }
             return stream.collect(toList());
         });
@@ -199,6 +332,7 @@ public class SensinactWhiteboard {
             protected Promise<Void> call(SensinactDigitalTwin twin, SensinactModelManager modelMgr,
                     PromiseFactory promiseFactory) {
                 ResourceBuilder<?, Object> builder = null;
+                Resource resource = null;
 
                 Model model = modelMgr.getModel(key.getModel());
                 if (model == null) {
@@ -209,25 +343,64 @@ public class SensinactWhiteboard {
                     if (service == null) {
                         builder = model.createService(key.getService()).withResource(key.getResource());
                     } else {
-                        Resource resource = service.getResources().get(key.getResource());
+                        resource = service.getResources().get(key.getResource());
                         if (resource == null) {
                             builder = service.createResource(key.getResource());
-                        } else {
-                            ResourceType type = resource.getResourceType();
-                            if (type != ResourceType.ACTION) {
-                                LOG.error("The resource {} in service {} already exists for the model {} as type {}",
-                                        key.getResource(), key.getService(), key.getModel(), type);
-                            }
                         }
                     }
                 }
 
                 if (builder != null) {
-                    builder.withType(am.getReturnType()).withAction(am.getNamedParameterTypes()).buildAll();
+                    // Construct the resource
+                    builderCaller.accept(builder);
+                } else if (resource != null) {
+                    // Resource exists, check if we can update it
+                    ResourceType type = resource.getResourceType();
+                    if (!validateResourceType.test(type)) {
+                        LOG.error("The resource {} in service {} already exists for the model {} as type {}",
+                                key.getResource(), key.getService(), key.getModel(), type);
+                        return promiseFactory.failed(
+                                new IllegalStateException("Updating resource of type " + type + " is not allowed"));
+                    }
                 }
+
                 return promiseFactory.resolved(null);
             }
         });
+    }
+
+    private Class<?> getType(Class<?> methodReturnType, Class<?> givenType) {
+        return givenType != null ? givenType : methodReturnType;
+    }
+
+    private void processActMethod(ActMethod method, ACT annotation) {
+        RegistryKey key = new RegistryKey(annotation.model(), annotation.service(), annotation.resource());
+        processAnnotatedMethod(key, (type) -> type == ResourceType.ACTION,
+                (b) -> b.withType(method.getReturnType()).withAction(method.getNamedParameterTypes()).buildAll(),
+                method, actMethodRegistry, serviceIdToActMethods);
+    }
+
+    private void processGetMethod(final RegistryKey key, final GetMethod method, final GET annotation,
+            final boolean hasSet) {
+        processAnnotatedMethod(key, (type) -> type != ResourceType.ACTION, (b) -> {
+            ResourceBuilder<?, ?> builder = b.withType(getType(method.getReturnType(), annotation.type())).withGetter()
+                    .withGetterCache(Duration.of(annotation.cacheDuration(), annotation.cacheDurationUnit()));
+            if (hasSet) {
+                builder = builder.withSetter();
+            }
+            builder.buildAll();
+        }, method, getMethodRegistry, serviceIdToGetMethods);
+    }
+
+    private void processSetMethod(final RegistryKey key, final SetMethod method, final SET annotation,
+            final boolean hasGet) {
+        processAnnotatedMethod(key, (type) -> type != ResourceType.ACTION, (b) -> {
+            ResourceBuilder<?, ?> builder = b.withType(getType(method.getReturnType(), annotation.type())).withSetter();
+            if (hasGet) {
+                builder = builder.withGetter();
+            }
+            builder.buildAll();
+        }, method, setMethodRegistry, serviceIdToSetMethods);
     }
 
     public Promise<Object> act(String model, String provider, String service, String resource,
@@ -251,6 +424,90 @@ public class SensinactWhiteboard {
                         d.resolveWith((Promise<?>) o);
                     } else {
                         d.resolve(o);
+                    }
+                } catch (Exception e) {
+                    d.fail(e);
+                }
+            });
+            return d.getPromise();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> Promise<TimedValue<T>> pullValue(String model, String provider, String service, String resource,
+            Class<T> type, TimedValue<T> cachedValue) {
+        RegistryKey key = new RegistryKey(model, service, resource);
+
+        Optional<GetMethod> opt = getMethodRegistry.getOrDefault(key, List.of()).stream()
+                .filter(a -> a.providers.isEmpty() || a.providers.contains(provider)).findFirst();
+
+        PromiseFactory promiseFactory = gatewayThread.getPromiseFactory();
+        if (opt.isEmpty()) {
+            return promiseFactory.failed(new NoSuchElementException(
+                    String.format("No suitable provider for model %s, provider %s, service %s, resource %s", model,
+                            provider, service, resource)));
+        } else {
+            Deferred<TimedValue<T>> d = promiseFactory.deferred();
+            final GetMethod getMethod = opt.get();
+            promiseFactory.executor().execute(() -> {
+                try {
+                    Object o = getMethod.invoke(model, provider, service, resource, type, cachedValue);
+                    if (o instanceof Promise) {
+                        d.resolveWith((Promise<TimedValue<T>>) o);
+                    } else if (o instanceof TimedValue) {
+                        d.resolve((TimedValue<T>) o);
+                    } else if (o == null) {
+                        switch (getMethod.actionOnNull()) {
+                        case IGNORE:
+                            d.resolve(null);
+                            break;
+
+                        case UPDATE:
+                            d.resolve(new TimedValueImpl<T>(null));
+                            break;
+                        }
+                    } else if (type.isAssignableFrom(o.getClass())) {
+                        d.resolve(new TimedValueImpl<T>(type.cast(o)));
+                    } else {
+                        d.fail(new Exception("Invalid result type: " + o.getClass()));
+                    }
+                } catch (Exception e) {
+                    d.fail(e);
+                }
+            });
+            return d.getPromise();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> Promise<TimedValue<T>> pushValue(String model, String provider, String service, String resource,
+            Class<T> type, TimedValue<T> cachedValue, TimedValue<T> newValue) {
+        RegistryKey key = new RegistryKey(model, service, resource);
+
+        Optional<SetMethod> opt = setMethodRegistry.getOrDefault(key, List.of()).stream()
+                .filter(a -> a.providers.isEmpty() || a.providers.contains(provider)).findFirst();
+
+        PromiseFactory promiseFactory = gatewayThread.getPromiseFactory();
+        if (opt.isEmpty()) {
+            return promiseFactory.failed(new NoSuchElementException(
+                    String.format("No suitable provider for model %s, provider %s, service %s, resource %s", model,
+                            provider, service, resource)));
+        } else {
+            Deferred<TimedValue<T>> d = promiseFactory.deferred();
+            final SetMethod setMethod = opt.get();
+            promiseFactory.executor().execute(() -> {
+                try {
+                    Object o = setMethod.invoke(model, provider, service, resource, type, cachedValue, newValue);
+                    if (o instanceof Promise) {
+                        d.resolveWith((Promise<TimedValue<T>>) o);
+                    } else if (o instanceof TimedValue) {
+                        d.resolve((TimedValue<T>) o);
+                    } else if (o == null) {
+                        d.resolve(null);
+                    } else if (type.isAssignableFrom(o.getClass())) {
+                        d.resolve(new TimedValueImpl<T>(type.cast(o)));
+                    } else {
+                        d.fail(new Exception("Invalid result type: " + o.getClass()));
                     }
                 } catch (Exception e) {
                     d.fail(e);

--- a/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/whiteboard/impl/SetMethod.java
+++ b/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/whiteboard/impl/SetMethod.java
@@ -1,0 +1,38 @@
+/*********************************************************************
+* Copyright (c) 2023 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Kentyou - initial API and implementation
+**********************************************************************/
+package org.eclipse.sensinact.prototype.whiteboard.impl;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.sensinact.core.annotation.verb.SetParam;
+import org.eclipse.sensinact.core.annotation.verb.SetParam.SetSegment;
+import org.eclipse.sensinact.core.twin.TimedValue;
+
+class SetMethod extends AbstractResourceMethod {
+
+    public SetMethod(Method method, Object instance, Long serviceId, Set<String> providers) {
+        super(method, instance, serviceId, providers);
+    }
+
+    public <T> Object invoke(String model, String provider, String service, String resource, Class<T> resultType,
+            TimedValue<T> cachedValue, TimedValue<T> newValue) throws Exception {
+        final Map<Object, Object> params = new HashMap<>();
+        params.put(SetSegment.RESULT_TYPE, resultType);
+        params.put(SetSegment.CACHED_VALUE, cachedValue);
+        params.put(SetSegment.NEW_VALUE, newValue);
+        return super.invoke(model, provider, service, resource, params, SetParam.class, SetParam::value);
+    }
+}

--- a/prototype/core/impl/src/test/java/org/eclipse/sensinact/prototype/model/impl/ModelBuildingTest.java
+++ b/prototype/core/impl/src/test/java/org/eclipse/sensinact/prototype/model/impl/ModelBuildingTest.java
@@ -57,7 +57,7 @@ public class ModelBuildingTest {
     @BeforeEach
     void start() {
         resourceSet = EMFTestUtil.createResourceSet();
-        nexus = new ModelNexus(resourceSet, ProviderPackage.eINSTANCE, () -> accumulator, null);
+        nexus = new ModelNexus(resourceSet, ProviderPackage.eINSTANCE, () -> accumulator);
         manager = new SensinactModelManagerImpl(nexus);
     }
 

--- a/prototype/core/impl/src/test/java/org/eclipse/sensinact/prototype/model/nexus/impl/NexusTest.java
+++ b/prototype/core/impl/src/test/java/org/eclipse/sensinact/prototype/model/nexus/impl/NexusTest.java
@@ -207,7 +207,7 @@ public class NexusTest {
                 }
             });
 
-            ModelNexus nexus = new ModelNexus(resourceSet, ProviderPackage.eINSTANCE, () -> accumulator, null);
+            ModelNexus nexus = new ModelNexus(resourceSet, ProviderPackage.eINSTANCE, () -> accumulator);
 
             Instant now = Instant.now();
             EClass model = nexus.createModel("TestModel", now);
@@ -246,7 +246,7 @@ public class NexusTest {
         @Test
         void sensiNactProvider() {
 
-            ModelNexus nexus = new ModelNexus(resourceSet, ProviderPackage.eINSTANCE, () -> accumulator, null);
+            ModelNexus nexus = new ModelNexus(resourceSet, ProviderPackage.eINSTANCE, () -> accumulator);
 
             Collection<Provider> providers = nexus.getProviders();
 
@@ -286,7 +286,7 @@ public class NexusTest {
         @Test
         void basicServiceExtensionTest() {
 
-            ModelNexus nexus = new ModelNexus(resourceSet, ProviderPackage.eINSTANCE, () -> accumulator, null);
+            ModelNexus nexus = new ModelNexus(resourceSet, ProviderPackage.eINSTANCE, () -> accumulator);
 
             Instant now = Instant.now();
             EClass model = nexus.createModel("TestModel", now);
@@ -335,7 +335,7 @@ public class NexusTest {
         @Test
         void basicSecondServiceTest() {
 
-            ModelNexus nexus = new ModelNexus(resourceSet, ProviderPackage.eINSTANCE, () -> accumulator, null);
+            ModelNexus nexus = new ModelNexus(resourceSet, ProviderPackage.eINSTANCE, () -> accumulator);
 
             Instant now = Instant.now();
             EClass model = nexus.createModel("TestModel", now);
@@ -388,7 +388,7 @@ public class NexusTest {
 
         @Test
         void basicFullProviderTest() {
-            ModelNexus nexus = new ModelNexus(resourceSet, ProviderPackage.eINSTANCE, () -> accumulator, null);
+            ModelNexus nexus = new ModelNexus(resourceSet, ProviderPackage.eINSTANCE, () -> accumulator);
             for (int modelIdx = 0; modelIdx < 2; modelIdx++) {
                 EClass model = nexus.createModel("model_" + modelIdx, Instant.now());
                 for (int svcIdx = 0; svcIdx < 2; svcIdx++) {
@@ -428,7 +428,7 @@ public class NexusTest {
         @Test
         void basicPersistanceTest() throws IOException {
 
-            ModelNexus nexus = new ModelNexus(resourceSet, ProviderPackage.eINSTANCE, () -> accumulator, null);
+            ModelNexus nexus = new ModelNexus(resourceSet, ProviderPackage.eINSTANCE, () -> accumulator);
             Instant now = Instant.now();
 
             EClass model = nexus.createModel("TestModel", now);
@@ -445,7 +445,7 @@ public class NexusTest {
 
             nexus.shutDown();
 
-            nexus = new ModelNexus(resourceSet, ProviderPackage.eINSTANCE, () -> accumulator, null);
+            nexus = new ModelNexus(resourceSet, ProviderPackage.eINSTANCE, () -> accumulator);
             Provider provider = nexus.getProvider("TestModel", "testprovider");
             assertNotNull(provider);
             EStructuralFeature serviceFeature = provider.eClass().getEStructuralFeature("testservice2");
@@ -464,7 +464,7 @@ public class NexusTest {
         @Test
         void basicPersistanceTestMultiple() throws IOException {
 
-            ModelNexus nexus = new ModelNexus(resourceSet, ProviderPackage.eINSTANCE, () -> accumulator, null);
+            ModelNexus nexus = new ModelNexus(resourceSet, ProviderPackage.eINSTANCE, () -> accumulator);
             Instant now = Instant.now();
 
             EClass model = nexus.createModel("TestModel", now);
@@ -489,7 +489,7 @@ public class NexusTest {
 
             nexus.shutDown();
 
-            nexus = new ModelNexus(resourceSet, ProviderPackage.eINSTANCE, () -> accumulator, null);
+            nexus = new ModelNexus(resourceSet, ProviderPackage.eINSTANCE, () -> accumulator);
 
             assertObject(nexus, "TestModel", "testprovider", "testservice", "testValue", "test");
             assertObject(nexus, "TestModelNew", "testproviderNew", "testservice2", "testValue", "test2");
@@ -515,7 +515,7 @@ public class NexusTest {
 
         @Test
         void testFindProviderWithoutModel() {
-            ModelNexus nexus = new ModelNexus(resourceSet, ProviderPackage.eINSTANCE, () -> accumulator, null);
+            ModelNexus nexus = new ModelNexus(resourceSet, ProviderPackage.eINSTANCE, () -> accumulator);
             Instant now = Instant.now();
 
             EClass model = nexus.createModel("TestModel", now);
@@ -537,7 +537,7 @@ public class NexusTest {
 
         @Test
         void testUnableToCreateProviderNoModel() {
-            ModelNexus nexus = new ModelNexus(resourceSet, ProviderPackage.eINSTANCE, () -> accumulator, null);
+            ModelNexus nexus = new ModelNexus(resourceSet, ProviderPackage.eINSTANCE, () -> accumulator);
 
             Instant now = Instant.now();
 
@@ -547,7 +547,7 @@ public class NexusTest {
 
         @Test
         void testUnableToCreateProviderDifferentModelAndClashingId() {
-            ModelNexus nexus = new ModelNexus(resourceSet, ProviderPackage.eINSTANCE, () -> accumulator, null);
+            ModelNexus nexus = new ModelNexus(resourceSet, ProviderPackage.eINSTANCE, () -> accumulator);
 
             Instant now = Instant.now();
 
@@ -566,7 +566,7 @@ public class NexusTest {
         @Test
         void addLink() {
 
-            ModelNexus nexus = new ModelNexus(resourceSet, ProviderPackage.eINSTANCE, () -> accumulator, null);
+            ModelNexus nexus = new ModelNexus(resourceSet, ProviderPackage.eINSTANCE, () -> accumulator);
             Instant now = Instant.now();
 
             EClass model = nexus.createModel("TestModel", now);
@@ -602,7 +602,7 @@ public class NexusTest {
         @Test
         void removeLink() {
 
-            ModelNexus nexus = new ModelNexus(resourceSet, ProviderPackage.eINSTANCE, () -> accumulator, null);
+            ModelNexus nexus = new ModelNexus(resourceSet, ProviderPackage.eINSTANCE, () -> accumulator);
 
             Instant now = Instant.now();
 

--- a/prototype/core/impl/src/test/java/org/eclipse/sensinact/prototype/model/nexus/impl/SubscriptionTest.java
+++ b/prototype/core/impl/src/test/java/org/eclipse/sensinact/prototype/model/nexus/impl/SubscriptionTest.java
@@ -96,7 +96,7 @@ public class SubscriptionTest {
         @Test
         void basicTest() {
 
-            ModelNexus nexus = new ModelNexus(resourceSet, ProviderPackage.eINSTANCE, () -> accumulator, null);
+            ModelNexus nexus = new ModelNexus(resourceSet, ProviderPackage.eINSTANCE, () -> accumulator);
             // Ignore the setup of the sensiNact provider
             Mockito.clearInvocations(accumulator);
 
@@ -151,7 +151,7 @@ public class SubscriptionTest {
         @Test
         void basicServiceExtensionTest() {
 
-            ModelNexus nexus = new ModelNexus(resourceSet, ProviderPackage.eINSTANCE, () -> accumulator, null);
+            ModelNexus nexus = new ModelNexus(resourceSet, ProviderPackage.eINSTANCE, () -> accumulator);
             // Ignore the setup of the sensiNact provider
             Mockito.clearInvocations(accumulator);
 
@@ -213,7 +213,7 @@ public class SubscriptionTest {
         @Test
         void basicSecondServiceTest() {
 
-            ModelNexus nexus = new ModelNexus(resourceSet, ProviderPackage.eINSTANCE, () -> accumulator, null);
+            ModelNexus nexus = new ModelNexus(resourceSet, ProviderPackage.eINSTANCE, () -> accumulator);
             // Ignore the setup of the sensiNact provider
             Mockito.clearInvocations(accumulator);
 
@@ -310,7 +310,7 @@ public class SubscriptionTest {
                 }
             };
 
-            nexus = new ModelNexus(resourceSet, ProviderPackage.eINSTANCE, () -> accumulator, null);
+            nexus = new ModelNexus(resourceSet, ProviderPackage.eINSTANCE, () -> accumulator);
 
             Resource extendedPackageResource = resourceSet
                     .createResource(URI.createURI("https://eclipse.org/sensinact/test/1.0"));

--- a/prototype/core/impl/src/test/java/org/eclipse/sensinact/prototype/whiteboard/impl/WhiteboardImplTest.java
+++ b/prototype/core/impl/src/test/java/org/eclipse/sensinact/prototype/whiteboard/impl/WhiteboardImplTest.java
@@ -284,7 +284,7 @@ public class WhiteboardImplTest {
                 assertThrows(IllegalArgumentException.class, () -> r.getArguments());
 
                 // No value at first
-                TimedValue<String> result = r.getValue(String.class, GetLevel.HARD).getValue();
+                TimedValue<String> result = r.getValue(String.class, GetLevel.STRONG).getValue();
                 assertEquals(rc, result.getValue());
                 assertNotNull(result.getTimestamp(), "No timestamp returned");
                 final Instant initialTimestamp = result.getTimestamp();
@@ -292,7 +292,7 @@ public class WhiteboardImplTest {
                 // Wait a bit
                 Thread.sleep(200);
 
-                result = r.getValue(String.class, GetLevel.HARD).getValue();
+                result = r.getValue(String.class, GetLevel.STRONG).getValue();
                 assertEquals("resource:" + rc, result.getValue());
                 assertNotNull(result.getTimestamp(), "No timestamp returned");
                 final Instant secondTimestamp = result.getTimestamp();
@@ -317,19 +317,19 @@ public class WhiteboardImplTest {
             assertThrows(IllegalArgumentException.class, () -> r.getArguments());
 
             // No value at first: should get a 1
-            TimedValue<Integer> result = r.getValue(Integer.class, GetLevel.CACHED).getValue();
+            TimedValue<Integer> result = r.getValue(Integer.class, GetLevel.NORMAL).getValue();
             assertEquals(1, result.getValue());
             assertNotNull(result.getTimestamp(), "No timestamp returned");
             final Instant initialTimestamp = result.getTimestamp();
 
             // Second cache call should have the same value and timestamp
             Thread.sleep(200);
-            result = r.getValue(Integer.class, GetLevel.CACHED).getValue();
+            result = r.getValue(Integer.class, GetLevel.NORMAL).getValue();
             assertEquals(1, result.getValue());
             assertEquals(initialTimestamp, result.getTimestamp());
 
             // Hard call
-            result = r.getValue(Integer.class, GetLevel.HARD).getValue();
+            result = r.getValue(Integer.class, GetLevel.STRONG).getValue();
             assertEquals(2, result.getValue());
             final Instant secondTimestamp = result.getTimestamp();
             assertTrue(initialTimestamp.isBefore(secondTimestamp), "Timestamp wasn't updated");
@@ -340,7 +340,7 @@ public class WhiteboardImplTest {
             assertEquals(secondTimestamp, result.getTimestamp());
 
             // Cached call
-            result = r.getValue(Integer.class, GetLevel.CACHED).getValue();
+            result = r.getValue(Integer.class, GetLevel.NORMAL).getValue();
             assertEquals(2, result.getValue());
             assertEquals(secondTimestamp, result.getTimestamp());
 
@@ -353,7 +353,7 @@ public class WhiteboardImplTest {
             assertEquals(secondTimestamp, result.getTimestamp());
 
             // Cached call must recall the value
-            result = r.getValue(Integer.class, GetLevel.CACHED).getValue();
+            result = r.getValue(Integer.class, GetLevel.NORMAL).getValue();
             assertEquals(4, result.getValue());
             assertTrue(secondTimestamp.isBefore(result.getTimestamp()), "Timestamp wasn't updated");
         }
@@ -382,7 +382,7 @@ public class WhiteboardImplTest {
             assertEquals(initialTimesamp, result.getTimestamp());
 
             // Check the CACHED call behavior
-            result = r.getValue(Integer.class, GetLevel.CACHED).getValue();
+            result = r.getValue(Integer.class, GetLevel.NORMAL).getValue();
             assertEquals(42, result.getValue());
             assertNotNull(result.getTimestamp(), "No timestamp returned");
             assertEquals(initialTimesamp, result.getTimestamp());
@@ -390,7 +390,7 @@ public class WhiteboardImplTest {
             Thread.sleep(110);
 
             // Check the HARD call
-            result = r.getValue(Integer.class, GetLevel.HARD).getValue();
+            result = r.getValue(Integer.class, GetLevel.STRONG).getValue();
             assertEquals(84, result.getValue());
             assertNotNull(result.getTimestamp(), "No timestamp returned");
             assertTrue(initialTimesamp.isBefore(result.getTimestamp()), "Timestamp not updated");
@@ -453,7 +453,7 @@ public class WhiteboardImplTest {
                 r.setValue("toto", setTimestamp).getValue();
 
                 // Get the value
-                result = r.getValue(String.class, GetLevel.HARD).getValue();
+                result = r.getValue(String.class, GetLevel.STRONG).getValue();
                 assertEquals("toto", result.getValue());
                 assertNotNull(result.getTimestamp(), "No timestamp returned");
                 assertEquals(setTimestamp, result.getTimestamp());
@@ -463,7 +463,7 @@ public class WhiteboardImplTest {
                 r.setValue("titi", setTimestamp2).getValue();
 
                 // Get the value
-                result = r.getValue(String.class, GetLevel.HARD).getValue();
+                result = r.getValue(String.class, GetLevel.STRONG).getValue();
                 assertEquals("resource:toto", result.getValue());
                 assertNotNull(result.getTimestamp(), "No timestamp returned");
                 assertEquals(setTimestamp2, result.getTimestamp());
@@ -543,7 +543,7 @@ public class WhiteboardImplTest {
                 r.setValue("toto", setTimestamp).getValue();
 
                 // Get the value
-                result = r.getValue(Content.class, GetLevel.HARD).getValue();
+                result = r.getValue(Content.class, GetLevel.STRONG).getValue();
                 assertNotNull(result.getValue(), "No value");
                 assertEquals(setTimestamp, result.getTimestamp());
                 assertEquals("toto", result.getValue().oldValue);
@@ -554,7 +554,7 @@ public class WhiteboardImplTest {
                 r.setValue("titi", setTimestamp2).getValue();
 
                 // Get the value
-                result = r.getValue(Content.class, GetLevel.HARD).getValue();
+                result = r.getValue(Content.class, GetLevel.STRONG).getValue();
                 assertEquals(setTimestamp2, result.getTimestamp());
                 assertEquals("titi", result.getValue().oldValue);
                 assertEquals("+titi", result.getValue().newValue);

--- a/prototype/core/impl/src/test/java/org/eclipse/sensinact/prototype/whiteboard/impl/WhiteboardImplTest.java
+++ b/prototype/core/impl/src/test/java/org/eclipse/sensinact/prototype/whiteboard/impl/WhiteboardImplTest.java
@@ -92,12 +92,9 @@ public class WhiteboardImplTest {
     void start() throws NoSuchMethodException, SecurityException {
         resourceSet = EMFTestUtil.createResourceSet();
         whiteboard = new SensinactWhiteboard(thread);
-        nexus = new ModelNexus(resourceSet, ProviderPackage.eINSTANCE, () -> accumulator, whiteboard::act,
-                whiteboard::pullValue, whiteboard::pushValue);
+        nexus = new ModelNexus(resourceSet, ProviderPackage.eINSTANCE, () -> accumulator, whiteboard);
         manager = new SensinactModelManagerImpl(nexus);
         twinImpl = new SensinactDigitalTwinImpl(nexus, promiseFactory);
-
-        Mockito.when(thread.getPromiseFactory()).thenReturn(promiseFactory);
 
         Method m = AbstractSensinactCommand.class.getDeclaredMethod("call", SensinactDigitalTwin.class,
                 SensinactModelManager.class, PromiseFactory.class);
@@ -235,7 +232,8 @@ public class WhiteboardImplTest {
         @GET(model = "bar", service = "pull", resource = "a")
         @GET(model = "bar", service = "pull", resource = "b")
         public String doMultiResource(@UriParam(UriSegment.RESOURCE) String resource,
-                @GetParam(GetSegment.RESULT_TYPE) Class<?> type, @GetParam(GetSegment.CACHED_VALUE) TimedValue<?> cached) {
+                @GetParam(GetSegment.RESULT_TYPE) Class<?> type,
+                @GetParam(GetSegment.CACHED_VALUE) TimedValue<?> cached) {
             switch (resource) {
             case "a":
             case "b":

--- a/prototype/core/models/metadata/src/main/resources/model/metadata.ecore
+++ b/prototype/core/models/metadata/src/main/resources/model/metadata.ecore
@@ -18,6 +18,8 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="valueType" eType="ecore:EEnum ../../../../../provider/src/main/resources/model/sensinact.ecore#//ValueType"
         defaultValueLiteral="MODIFIABLE"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="externalGet" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="externalGetCacheMs" eType="ecore:EDataType ../../../../../org.eclipse.emf.ecore/model/Ecore.ecore#//ELong"
+        defaultValueLiteral="0"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="externalSet" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="stale" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EInt">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">

--- a/prototype/core/models/metadata/src/main/resources/model/metadata.genmodel
+++ b/prototype/core/models/metadata/src/main/resources/model/metadata.genmodel
@@ -4,7 +4,7 @@
     modelDirectory="/org.eclipse.sensinact.core.model/src/main/java" modelPluginID="org.eclipse.sensinact.core.model"
     modelName="sensinact" rootExtendsClass="org.eclipse.emf.ecore.impl.MinimalEObjectImpl$Container$Dynamic$Permissive"
     importerID="org.eclipse.emf.importer.ecore" complianceLevel="11.0" suppressGenModelAnnotations="false"
-    copyrightFields="false" usedGenPackages="../../../../../provider/src/main/resources/model/sensinact.genmodel#//provider"
+    copyrightFields="false" usedGenPackages="../../../../../provider/src/main/resources/model/sensinact.genmodel#//provider ../../../../../org.eclipse.emf.ecore/model/Ecore.genmodel#//ecore"
     operationReflection="true" importOrganizing="true" oSGiCompatible="true">
   <foreignModel>metadata.ecore</foreignModel>
   <genPackages prefix="Metadata" basePackage="org.eclipse.sensinact.model.core" disposableProviderFactory="true"
@@ -18,6 +18,7 @@
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute metadata.ecore#//ResourceAttribute/resourceType"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute metadata.ecore#//ResourceAttribute/valueType"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute metadata.ecore#//ResourceAttribute/externalGet"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute metadata.ecore#//ResourceAttribute/externalGetCacheMs"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute metadata.ecore#//ResourceAttribute/externalSet"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute metadata.ecore#//ResourceAttribute/stale"/>
     </genClasses>

--- a/prototype/distribution/features/timescale-history-provider-feature/src/test/java/org/eclipse/sensinact/gateway/feature/integration/history/timescale/TimescaleHistoryFeatureIntegrationTest.java
+++ b/prototype/distribution/features/timescale-history-provider-feature/src/test/java/org/eclipse/sensinact/gateway/feature/integration/history/timescale/TimescaleHistoryFeatureIntegrationTest.java
@@ -112,7 +112,9 @@ class TimescaleHistoryFeatureIntegrationTest {
     @AfterAll
     static void stop() throws Exception {
         server.stopSensinact();
-        container.stop();
+        if (container != null) {
+            container.stop();
+        }
     }
 
     @Test

--- a/prototype/examples/reflective/src/main/java/org/eclipse/sensinact/prototype/reflective/ProgrammaticModelProvider.java
+++ b/prototype/examples/reflective/src/main/java/org/eclipse/sensinact/prototype/reflective/ProgrammaticModelProvider.java
@@ -27,7 +27,7 @@ public class ProgrammaticModelProvider implements ModelProvider {
     @Override
     public void init(SensinactModelManager manager) {
         manager.createModel("reflective").withAutoDeletion(true).build().createService("testService").build()
-                .createResource("testResource").withType(Integer.class).withGetter(() -> random.nextInt(16))
+                .createResource("testResource").withType(Integer.class).withGetter()
                 .withValueType(ValueType.UPDATABLE);
     }
 


### PR DESCRIPTION
* Uses `isExternalGet` and `isExternalSet` flags of the `ResourceAttribute` to check if an external handler must be called
* Adds the `externalGetCacheMs` entry in `ResourceAttribute` to define the time to wait before calling again the external Get handler
* The value returned by the handlers is stored in the twin
* Added `GetLevel` to define 3 levels of resource access:
  * `WEAK`: always return the twin value, never call the external get
  * `NORMAL`: call the external get if no twin value is available or if the `externalGetCacheMs` duration expired
  * `STRONG`: always call the external get.
* Doesn't work with resources defined outside the ModelBuilder, like pre-defined admin resources.

Also adds a small fix in the history provider integration tests to protect against a null pointer when Docker is not available.
