### PR TITLE
Northbound websocket improvements

### DIFF
--- a/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/impl/SensiNactSessionImpl.java
+++ b/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/impl/SensiNactSessionImpl.java
@@ -75,7 +75,10 @@ public class SensiNactSessionImpl implements SensiNactSession {
 
     private final GatewayThread thread;
 
-    public SensiNactSessionImpl(final GatewayThread thread) {
+    private final UserInfo user;
+
+    public SensiNactSessionImpl(UserInfo user, final GatewayThread thread) {
+        this.user = user;
         expiry = Instant.now().plusSeconds(600);
         this.thread = thread;
     }
@@ -595,7 +598,6 @@ public class SensiNactSessionImpl implements SensiNactSession {
 
     @Override
     public UserInfo getUserInfo() {
-        // TODO Auto-generated method stub
-        return null;
+        return user;
     }
 }

--- a/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/impl/SessionManager.java
+++ b/prototype/core/impl/src/main/java/org/eclipse/sensinact/prototype/impl/SessionManager.java
@@ -153,7 +153,7 @@ public class SessionManager implements SensiNactSessionManager, TypedEventHandle
     @Override
     public SensiNactSession createNewSession(UserInfo user) {
         Objects.requireNonNull(user);
-        SensiNactSessionImpl session = new SensiNactSessionImpl(thread);
+        SensiNactSessionImpl session = new SensiNactSessionImpl(user, thread);
         String sessionId = session.getSessionId();
 
         synchronized (lock) {

--- a/prototype/northbound/rest/integration-test.bndrun
+++ b/prototype/northbound/rest/integration-test.bndrun
@@ -44,7 +44,7 @@
 	junit-platform-launcher;version='[1.9.0,1.9.1)',\
 	org.antlr.antlr4-runtime;version='[4.12.0,4.12.1)',\
 	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
-	org.apache.aries.spifly.dynamic.framework.extension;version='[1.3.5,1.3.6)',\
+	org.apache.aries.spifly.dynamic.framework.extension;version='[1.3.6,1.3.7)',\
 	org.apache.aries.typedevent.bus;version='[0.0.2,0.0.3)',\
 	org.apache.felix.cm.json;version='[2.0.0,2.0.1)',\
 	org.apache.felix.configadmin;version='[1.9.24,1.9.25)',\

--- a/prototype/northbound/sensorthings/rest.gateway/integration-test.bndrun
+++ b/prototype/northbound/sensorthings/rest.gateway/integration-test.bndrun
@@ -45,7 +45,7 @@
 	net.bytebuddy.byte-buddy-agent;version='[1.12.13,1.12.14)',\
 	org.antlr.antlr4-runtime;version='[4.12.0,4.12.1)',\
 	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
-	org.apache.aries.spifly.dynamic.framework.extension;version='[1.3.5,1.3.6)',\
+	org.apache.aries.spifly.dynamic.framework.extension;version='[1.3.6,1.3.7)',\
 	org.apache.aries.typedevent.bus;version='[0.0.2,0.0.3)',\
 	org.apache.commons.commons-compress;version='[1.22.0,1.22.1)',\
 	org.apache.felix.cm.json;version='[2.0.0,2.0.1)',\

--- a/prototype/northbound/websocket/integration-test.bndrun
+++ b/prototype/northbound/websocket/integration-test.bndrun
@@ -35,7 +35,7 @@
 	junit-platform-launcher;version='[1.9.0,1.9.1)',\
 	org.antlr.antlr4-runtime;version='[4.12.0,4.12.1)',\
 	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
-	org.apache.aries.spifly.dynamic.framework.extension;version='[1.3.5,1.3.6)',\
+	org.apache.aries.spifly.dynamic.framework.extension;version='[1.3.6,1.3.7)',\
 	org.apache.aries.typedevent.bus;version='[0.0.2,0.0.3)',\
 	org.apache.felix.cm.json;version='[2.0.0,2.0.1)',\
 	org.apache.felix.configadmin;version='[1.9.24,1.9.25)',\
@@ -47,11 +47,14 @@
 	org.eclipse.emf.ecore;version='[2.33.0,2.33.1)',\
 	org.eclipse.emf.ecore.xmi;version='[2.18.0,2.18.1)',\
 	org.eclipse.jetty.alpn.client;version='[11.0.13,11.0.14)',\
+	org.eclipse.jetty.annotations;version='[11.0.13,11.0.14)',\
 	org.eclipse.jetty.client;version='[11.0.13,11.0.14)',\
 	org.eclipse.jetty.http;version='[11.0.13,11.0.14)',\
 	org.eclipse.jetty.jndi;version='[11.0.13,11.0.14)',\
 	org.eclipse.jetty.plus;version='[11.0.13,11.0.14)',\
 	org.eclipse.jetty.security;version='[11.0.13,11.0.14)',\
+	org.eclipse.jetty.server;version='[11.0.13,11.0.14)',\
+	org.eclipse.jetty.servlet;version='[11.0.13,11.0.14)',\
 	org.eclipse.jetty.util;version='[11.0.13,11.0.14)',\
 	org.eclipse.jetty.webapp;version='[11.0.13,11.0.14)',\
 	org.eclipse.jetty.websocket.api;version='[11.0.13,11.0.14)',\
@@ -74,6 +77,7 @@
 	org.eclipse.sensinact.gateway.northbound.filters.filters.core;version='[0.0.2,0.0.3)',\
 	org.eclipse.sensinact.gateway.northbound.filters.ldap;version='[0.0.2,0.0.3)',\
 	org.eclipse.sensinact.gateway.northbound.query-handler;version='[0.0.2,0.0.3)',\
+	org.eclipse.sensinact.gateway.northbound.security.authentication-api;version='[0.0.2,0.0.3)',\
 	org.eclipse.sensinact.gateway.northbound.websocket;version='[0.0.2,0.0.3)',\
 	org.eclipse.sensinact.gateway.northbound.websocket-tests;version='[0.0.2,0.0.3)',\
 	org.gecko.emf.osgi.api;version='[4.6.2,4.6.3)',\
@@ -84,6 +88,7 @@
 	org.osgi.service.typedevent;version='[1.0.0,1.0.1)',\
 	org.osgi.test.common;version='[1.2.1,1.2.2)',\
 	org.osgi.test.junit5;version='[1.2.1,1.2.2)',\
+	org.osgi.test.junit5.cm;version='[1.2.1,1.2.2)',\
 	org.osgi.util.converter;version='[1.0.9,1.0.10)',\
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
 	org.osgi.util.promise;version='[1.3.0,1.3.1)',\

--- a/prototype/northbound/websocket/pom.xml
+++ b/prototype/northbound/websocket/pom.xml
@@ -44,6 +44,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.sensinact.gateway.northbound.security</groupId>
+      <artifactId>authentication-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.sensinact.gateway.northbound.filters</groupId>
       <artifactId>ldap</artifactId>
       <version>${project.version}</version>
@@ -80,6 +85,11 @@
       <groupId>org.eclipse.sensinact.gateway.core</groupId>
       <artifactId>impl</artifactId>
       <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.test.junit5.cm</artifactId>
       <scope>test</scope>
     </dependency>
 
@@ -161,7 +171,6 @@
     <dependency>
       <groupId>org.apache.felix</groupId>
       <artifactId>org.apache.felix.http.servlet-api</artifactId>
-      <version>2.1.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -195,7 +204,6 @@
       <plugin>
         <groupId>biz.aQute.bnd</groupId>
         <artifactId>bnd-resolver-maven-plugin</artifactId>
-        <version>6.4.0</version>
       </plugin>
       <plugin>
         <groupId>biz.aQute.bnd</groupId>

--- a/prototype/northbound/websocket/src/main/java/org/eclipse/sensinact/northbound/ws/impl/WebSocketCreator.java
+++ b/prototype/northbound/websocket/src/main/java/org/eclipse/sensinact/northbound/ws/impl/WebSocketCreator.java
@@ -19,6 +19,7 @@ import java.util.List;
 import org.eclipse.jetty.websocket.server.JettyServerUpgradeRequest;
 import org.eclipse.jetty.websocket.server.JettyServerUpgradeResponse;
 import org.eclipse.jetty.websocket.server.JettyWebSocketCreator;
+import org.eclipse.sensinact.core.security.UserInfo;
 import org.eclipse.sensinact.core.session.SensiNactSessionManager;
 import org.eclipse.sensinact.northbound.query.api.IQueryHandler;
 import org.slf4j.Logger;
@@ -80,7 +81,9 @@ public class WebSocketCreator implements JettyWebSocketCreator {
 
     @Override
     public Object createWebSocket(final JettyServerUpgradeRequest req, final JettyServerUpgradeResponse resp) {
-        final WebSocketEndpoint wsConnection = new WebSocketEndpoint(this, sessionManager, queryHandler);
+        UserInfo userInfo = (UserInfo) req.getServletAttribute(WebSocketJettyRegistrar.SENSINACT_USER_INFO);
+        final WebSocketEndpoint wsConnection = new WebSocketEndpoint(this, sessionManager.createNewSession(userInfo),
+                queryHandler);
         sessions.add(wsConnection);
         return wsConnection;
     }

--- a/prototype/northbound/websocket/src/main/java/org/eclipse/sensinact/northbound/ws/impl/WebSocketJettyRegistrar.java
+++ b/prototype/northbound/websocket/src/main/java/org/eclipse/sensinact/northbound/ws/impl/WebSocketJettyRegistrar.java
@@ -12,9 +12,20 @@
 **********************************************************************/
 package org.eclipse.sensinact.northbound.ws.impl;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.eclipse.sensinact.northbound.security.api.Authenticator.Scheme.TOKEN;
+import static org.eclipse.sensinact.northbound.security.api.Authenticator.Scheme.USER_PASSWORD;
+import static org.osgi.service.component.annotations.ReferencePolicy.DYNAMIC;
+
 import java.io.IOException;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.servlet.ServletContextHandler;
@@ -22,17 +33,24 @@ import org.eclipse.jetty.websocket.core.server.WebSocketServerComponents;
 import org.eclipse.jetty.websocket.server.JettyWebSocketServerContainer;
 import org.eclipse.jetty.websocket.server.JettyWebSocketServlet;
 import org.eclipse.jetty.websocket.server.JettyWebSocketServletFactory;
+import org.eclipse.sensinact.core.security.UserInfo;
 import org.eclipse.sensinact.core.session.SensiNactSessionManager;
 import org.eclipse.sensinact.northbound.query.api.IQueryHandler;
-import org.osgi.service.component.ComponentContext;
+import org.eclipse.sensinact.northbound.security.api.Authenticator;
+import org.eclipse.sensinact.northbound.security.api.Authenticator.Scheme;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.http.whiteboard.annotations.RequireHttpWhiteboard;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardFilterPattern;
 import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardServletAsyncSupported;
 import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardServletPattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
 import jakarta.servlet.Servlet;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletException;
@@ -40,14 +58,24 @@ import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletRequestWrapper;
+import jakarta.servlet.http.HttpServletResponse;
 
-@Component(service = { Servlet.class, JettyWebSocketServlet.class })
+@Component(service = { Servlet.class, Filter.class }, configurationPid = "sensinact.northbound.websocket")
 @RequireHttpWhiteboard
 @HttpWhiteboardServletPattern("/ws/sensinact")
+@HttpWhiteboardFilterPattern("/ws/sensinact")
 @HttpWhiteboardServletAsyncSupported
-public class WebSocketJettyRegistrar extends JettyWebSocketServlet {
+public class WebSocketJettyRegistrar extends JettyWebSocketServlet implements Filter {
+
+    static final String SENSINACT_USER_INFO = "sensinact.user.info";
+
+    private static final Logger LOG = LoggerFactory.getLogger(WebSocketJettyRegistrar.class);
 
     private static final long serialVersionUID = 1L;
+
+    @interface Config {
+        boolean allow_anonymous() default false;
+    }
 
     @Reference
     SensiNactSessionManager sessionManager;
@@ -55,10 +83,15 @@ public class WebSocketJettyRegistrar extends JettyWebSocketServlet {
     @Reference
     IQueryHandler queryHandler;
 
+    @Reference(policy = DYNAMIC)
+    private final Set<Authenticator> authenticators = new CopyOnWriteArraySet<>();
+
     /**
      * WebSocket sessions tracker
      */
     private WebSocketCreator sessionPool;
+
+    private Config config;
 
     /**
      * Flag to indicate if the servlet was initialized
@@ -71,7 +104,8 @@ public class WebSocketJettyRegistrar extends JettyWebSocketServlet {
     private final CountDownLatch initComplete = new CountDownLatch(1);
 
     @Activate
-    void activate(final ComponentContext ctx) {
+    void activate(final Config config) {
+        this.config = config;
         sessionPool = new WebSocketCreator(sessionManager, queryHandler);
     }
 
@@ -126,5 +160,85 @@ public class WebSocketJettyRegistrar extends JettyWebSocketServlet {
     @Override
     protected void configure(final JettyWebSocketServletFactory factory) {
         factory.setCreator(sessionPool);
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        HttpServletRequest req = (HttpServletRequest) request;
+        HttpServletResponse resp = (HttpServletResponse) response;
+
+        String authHeader = req.getHeader("Authorization");
+
+        if (authHeader == null) {
+            if (!config.allow_anonymous()) {
+                unauthorizedResponse(resp);
+            } else {
+                req.setAttribute(SENSINACT_USER_INFO, UserInfo.ANONYMOUS);
+                chain.doFilter(request, response);
+            }
+        } else {
+            String[] headerChunks = authHeader.split(" ", 2);
+
+            if (headerChunks.length != 2) {
+                resp.sendError(400);
+            } else {
+
+                Scheme authScheme;
+                String userid;
+                String credential;
+                if ("Bearer".equals(headerChunks[0])) {
+                    authScheme = TOKEN;
+                    userid = null;
+                    credential = headerChunks[1];
+                } else if ("Basic".equals(headerChunks[0])) {
+                    authScheme = USER_PASSWORD;
+                    String cred = new String(Base64.getMimeDecoder().decode(headerChunks[1]), UTF_8);
+                    String[] credChunks = cred.split(":", 2);
+                    userid = credChunks[0];
+                    credential = credChunks[1];
+                } else {
+                    authScheme = null;
+                    userid = null;
+                    credential = null;
+                }
+
+                Optional<UserInfo> user = Set.copyOf(authenticators).stream().filter(a -> a.getScheme() == authScheme)
+                        .map(a -> tryAuth(a, userid, credential)).filter(u -> u != null).findFirst();
+
+                if (user.isEmpty()) {
+                    unauthorizedResponse(resp);
+                } else {
+                    req.setAttribute(SENSINACT_USER_INFO, user.get());
+                    chain.doFilter(request, response);
+                }
+            }
+        }
+    }
+
+    private void unauthorizedResponse(HttpServletResponse response) throws IOException {
+        Collection<Authenticator> authenticators = Set.copyOf(this.authenticators);
+        if (authenticators.isEmpty()) {
+            response.sendError(503);
+        } else {
+            response.setHeader("WWW-Authenticate", getAuthHeader(authenticators));
+            response.sendError(401);
+        }
+    }
+
+    private String getAuthHeader(Collection<Authenticator> authenticators) {
+        return authenticators.stream()
+                .map(a -> String.format("%s realm=%s", a.getScheme().getHttpScheme(), a.getRealm()))
+                .collect(Collectors.joining(", "));
+    }
+
+    private UserInfo tryAuth(Authenticator a, String user, String credential) {
+        UserInfo ui = null;
+        try {
+            ui = a.authenticate(user, credential);
+        } catch (Exception e) {
+            LOG.warn("Failed to authenticate user {}", user, e);
+        }
+        return ui;
     }
 }

--- a/prototype/northbound/websocket/src/test/java/org/eclipse/sensinact/northbound/websocket/integration/SecureWebSocketTest.java
+++ b/prototype/northbound/websocket/src/test/java/org/eclipse/sensinact/northbound/websocket/integration/SecureWebSocketTest.java
@@ -1,0 +1,351 @@
+/*********************************************************************
+* Copyright (c) 2023 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Kentyou - initial implementation
+**********************************************************************/
+package org.eclipse.sensinact.northbound.websocket.integration;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Base64;
+import java.util.Hashtable;
+import java.util.Random;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.api.exceptions.UpgradeException;
+import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
+import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.eclipse.sensinact.core.push.PrototypePush;
+import org.eclipse.sensinact.core.push.dto.GenericDto;
+import org.eclipse.sensinact.core.security.UserInfo;
+import org.eclipse.sensinact.core.session.SensiNactSessionManager;
+import org.eclipse.sensinact.northbound.query.api.AbstractQueryDTO;
+import org.eclipse.sensinact.northbound.query.api.AbstractResultDTO;
+import org.eclipse.sensinact.northbound.query.api.EResultType;
+import org.eclipse.sensinact.northbound.query.dto.SensinactPath;
+import org.eclipse.sensinact.northbound.query.dto.query.QueryGetDTO;
+import org.eclipse.sensinact.northbound.query.dto.result.ResponseGetDTO;
+import org.eclipse.sensinact.northbound.query.dto.result.TypedResponse;
+import org.eclipse.sensinact.northbound.security.api.Authenticator;
+import org.eclipse.sensinact.northbound.security.api.Authenticator.Scheme;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.osgi.framework.BundleContext;
+import org.osgi.test.common.annotation.InjectBundleContext;
+import org.osgi.test.common.annotation.InjectService;
+import org.osgi.test.junit5.cm.ConfigurationExtension;
+import org.osgi.test.junit5.service.ServiceExtension;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@ExtendWith({ ServiceExtension.class, ConfigurationExtension.class })
+public class SecureWebSocketTest {
+
+    @InjectService
+    SensiNactSessionManager sessionManager;
+
+    @InjectService
+    PrototypePush push;
+
+    final ObjectMapper mapper = new ObjectMapper();
+
+    static URI wsUri;
+
+    @BeforeAll
+    static void setup() throws URISyntaxException {
+        wsUri = new URI("ws://localhost:14001/ws/sensinact");
+    }
+
+    /**
+     * Utility class to auto-close a web socket client
+     */
+    class WSClient implements AutoCloseable {
+        WebSocketClient ws;
+
+        public WSClient() throws Exception {
+            ws = new WebSocketClient();
+            ws.start();
+        }
+
+        @Override
+        public void close() throws Exception {
+            ws.stop();
+            ws.destroy();
+        }
+    }
+
+    /**
+     * Constructs a DTO to use with PrototypePush
+     */
+    public GenericDto makeDto(String provider, String service, String resource, Object value, Class<?> type) {
+        GenericDto dto = new GenericDto();
+        dto.model = provider;
+        dto.provider = provider;
+        dto.service = service;
+        dto.resource = resource;
+        dto.value = value;
+        dto.type = type;
+        return dto;
+    }
+
+    /**
+     * Sends a DTO over the websocket
+     */
+    void sendDTO(final Session session, final AbstractQueryDTO dto) {
+        try {
+            session.getRemote().sendString(mapper.writeValueAsString(dto));
+        } catch (Exception e) {
+            fail("Error sending DTO", e);
+        }
+    }
+
+    @Test
+    void testConnectNoCredentialsOrAuthenticators() throws Exception {
+        final WSHandler handler = new WSHandler();
+
+        try (final WSClient client = new WSClient()) {
+            client.ws.connect(handler, wsUri).join();
+            fail("Should fail to connect");
+        } catch (CompletionException ce) {
+            Throwable cause = ce.getCause();
+            assertInstanceOf(UpgradeException.class, cause);
+            assertEquals(503, ((UpgradeException) cause).getResponseStatusCode());
+        }
+    }
+
+    @Test
+    void testConnectNoCredentials(@InjectBundleContext BundleContext ctx) throws Exception {
+
+        TestAuthenticator auth = new TestAuthenticator("test_realm", Scheme.USER_PASSWORD, "test", "testPw");
+
+        ctx.registerService(Authenticator.class, auth, new Hashtable<>());
+
+        final WSHandler handler = new WSHandler();
+
+        try (final WSClient client = new WSClient()) {
+            client.ws.connect(handler, wsUri).join();
+            fail("Should fail to connect");
+        } catch (CompletionException ce) {
+            Throwable cause = ce.getCause();
+            assertInstanceOf(UpgradeException.class, cause);
+            assertEquals(401, ((UpgradeException) cause).getResponseStatusCode());
+        }
+    }
+
+    @Test
+    void testConnectBadCredentials(@InjectBundleContext BundleContext ctx) throws Exception {
+
+        TestAuthenticator auth = new TestAuthenticator("test_realm", Scheme.USER_PASSWORD, "test", "testPw");
+
+        ctx.registerService(Authenticator.class, auth, new Hashtable<>());
+
+        ClientUpgradeRequest req = new ClientUpgradeRequest();
+        req.setHeader("Authorization", Base64.getUrlEncoder().encodeToString("test:incorrect".getBytes(UTF_8)));
+
+        final WSHandler handler = new WSHandler();
+
+        try (final WSClient client = new WSClient()) {
+            client.ws.connect(handler, wsUri).join();
+            fail("Should fail to connect");
+        } catch (CompletionException ce) {
+            Throwable cause = ce.getCause();
+            assertInstanceOf(UpgradeException.class, cause);
+            assertEquals(401, ((UpgradeException) cause).getResponseStatusCode());
+        }
+    }
+
+    @Test
+    void testConnectBasicCredentials(@InjectBundleContext BundleContext ctx) throws Exception {
+
+        TestAuthenticator auth = new TestAuthenticator("test_realm", Scheme.USER_PASSWORD, "test", "testPw");
+
+        ctx.registerService(Authenticator.class, auth, new Hashtable<>());
+
+        final WSHandler handler = new WSHandler();
+        final CountDownLatch barrier = new CountDownLatch(1);
+
+        final QueryGetDTO query = new QueryGetDTO();
+        query.uri = new SensinactPath("sensiNact", "admin", "friendlyName");
+        query.requestId = String.valueOf(new Random().nextInt());
+        handler.onConnect = s -> sendDTO(s, query);
+
+        final AtomicReference<Throwable> error = new AtomicReference<>();
+        handler.onError = (s, t) -> {
+            error.set(t);
+            barrier.countDown();
+        };
+        handler.onClose = (s, c) -> barrier.countDown();
+
+        final AtomicReference<AbstractResultDTO> resultHolder = new AtomicReference<>();
+        handler.onMessage = (s, m) -> {
+            try {
+                resultHolder.set(mapper.readValue(m, AbstractResultDTO.class));
+                barrier.countDown();
+            } catch (JsonProcessingException e) {
+                fail("Error parsing WS response", e);
+            }
+        };
+
+        ClientUpgradeRequest req = new ClientUpgradeRequest();
+        req.setHeader("Authorization", "Basic " + Base64.getUrlEncoder().encodeToString("test:testPw".getBytes(UTF_8)));
+        try (final WSClient client = new WSClient()) {
+            client.ws.connect(handler, wsUri, req).get();
+            barrier.await();
+        }
+
+        if (error.get() != null) {
+            fail(error.get());
+        }
+
+        final AbstractResultDTO result = resultHolder.get();
+        assertNotNull(result, "No WS query result");
+        assertEquals(200, result.statusCode);
+        assertEquals(query.requestId, result.requestId);
+        assertEquals(EResultType.GET_RESPONSE, result.type);
+
+        @SuppressWarnings("unchecked")
+        final TypedResponse<ResponseGetDTO> typed = (TypedResponse<ResponseGetDTO>) result;
+        assertEquals("sensiNact", typed.response.value);
+    }
+
+    @Test
+    void testConnectBearerCredentials(@InjectBundleContext BundleContext ctx) throws Exception {
+
+        TestAuthenticator auth = new TestAuthenticator("test_realm", Scheme.TOKEN, null, "my_token");
+
+        ctx.registerService(Authenticator.class, auth, new Hashtable<>());
+
+        final WSHandler handler = new WSHandler();
+        final CountDownLatch barrier = new CountDownLatch(1);
+
+        final QueryGetDTO query = new QueryGetDTO();
+        query.uri = new SensinactPath("sensiNact", "admin", "friendlyName");
+        query.requestId = String.valueOf(new Random().nextInt());
+        handler.onConnect = s -> sendDTO(s, query);
+
+        final AtomicReference<Throwable> error = new AtomicReference<>();
+        handler.onError = (s, t) -> {
+            error.set(t);
+            barrier.countDown();
+        };
+        handler.onClose = (s, c) -> barrier.countDown();
+
+        final AtomicReference<AbstractResultDTO> resultHolder = new AtomicReference<>();
+        handler.onMessage = (s, m) -> {
+            try {
+                resultHolder.set(mapper.readValue(m, AbstractResultDTO.class));
+                barrier.countDown();
+            } catch (JsonProcessingException e) {
+                fail("Error parsing WS response", e);
+            }
+        };
+
+        ClientUpgradeRequest req = new ClientUpgradeRequest();
+        req.setHeader("Authorization", "Bearer my_token");
+        try (final WSClient client = new WSClient()) {
+            client.ws.connect(handler, wsUri, req).get();
+            barrier.await();
+        }
+
+        if (error.get() != null) {
+            fail(error.get());
+        }
+
+        final AbstractResultDTO result = resultHolder.get();
+        assertNotNull(result, "No WS query result");
+        assertEquals(200, result.statusCode);
+        assertEquals(query.requestId, result.requestId);
+        assertEquals(EResultType.GET_RESPONSE, result.type);
+
+        @SuppressWarnings("unchecked")
+        final TypedResponse<ResponseGetDTO> typed = (TypedResponse<ResponseGetDTO>) result;
+        assertEquals("sensiNact", typed.response.value);
+    }
+
+    private static class TestAuthenticator implements Authenticator {
+
+        private final String realm;
+
+        private final Scheme scheme;
+
+        private final String user;
+
+        private final String credential;
+
+        private final UserInfo info = new UserInfo() {
+
+            @Override
+            public boolean isMemberOfGroup(String group) {
+                return false;
+            }
+
+            @Override
+            public boolean isAuthenticated() {
+                return true;
+            }
+
+            @Override
+            public boolean isAnonymous() {
+                return false;
+            }
+
+            @Override
+            public String getUserId() {
+                return user;
+            }
+        };
+
+        public TestAuthenticator(String realm, Scheme scheme, String user, String credential) {
+            super();
+            this.realm = realm;
+            this.scheme = scheme;
+            this.user = user;
+            this.credential = credential;
+        }
+
+        @Override
+        public UserInfo authenticate(String user, String credential) {
+            if (this.user == null && user != null) {
+                return null;
+            }
+
+            if (this.user != null && !this.user.equals(user)) {
+                return null;
+            }
+
+            if (!this.credential.equals(credential)) {
+                return null;
+            }
+            return info;
+        }
+
+        @Override
+        public String getRealm() {
+            return realm;
+        }
+
+        @Override
+        public Scheme getScheme() {
+            return scheme;
+        }
+
+    }
+}

--- a/prototype/northbound/websocket/src/test/java/org/eclipse/sensinact/northbound/websocket/integration/WebSocketTest.java
+++ b/prototype/northbound/websocket/src/test/java/org/eclipse/sensinact/northbound/websocket/integration/WebSocketTest.java
@@ -51,12 +51,16 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.osgi.test.common.annotation.InjectService;
+import org.osgi.test.common.annotation.Property;
+import org.osgi.test.common.annotation.config.WithConfiguration;
+import org.osgi.test.junit5.cm.ConfigurationExtension;
 import org.osgi.test.junit5.service.ServiceExtension;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-@ExtendWith(ServiceExtension.class)
+@ExtendWith({ ServiceExtension.class, ConfigurationExtension.class })
+@WithConfiguration(pid = "sensinact.northbound.websocket", properties = @Property(key = "allow.anonymous", value = "true"))
 public class WebSocketTest {
 
     @InjectService

--- a/prototype/pom.xml
+++ b/prototype/pom.xml
@@ -136,7 +136,7 @@
     <johnzon.version>1.2.19</johnzon.version>
     <aries.component-dsl.version>1.2.2</aries.component-dsl.version>
     <aries.typedevent.version>0.0.2-SNAPSHOT</aries.typedevent.version>
-    <aries.spifly.version>1.3.5</aries.spifly.version>
+    <aries.spifly.version>1.3.6</aries.spifly.version>
     <felix.servlet.version>2.1.0</felix.servlet.version>
     <antlr.version>4.12.0</antlr.version>
 


### PR DESCRIPTION
This commit makes several improvements to the northbound websocket interface:

* Authentication using the sensinact Authenticator services
* Improved ordering guarantees. Websocket clients will always receive a subscription response before receiving their first notification for that subscription
* Thread safety - the web socket session was not updated in a thread safe way so notifications would sometimes fail with NPE