### PR TITLE
Fix cases where a northbound result had 2 'type' keys

### DIFF
--- a/northbound/query-handler/src/main/java/org/eclipse/sensinact/northbound/query/api/AbstractResultDTO.java
+++ b/northbound/query-handler/src/main/java/org/eclipse/sensinact/northbound/query/api/AbstractResultDTO.java
@@ -28,6 +28,9 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeId;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 
 /**
  * Represents a Northbound query response
@@ -43,6 +46,7 @@ import com.fasterxml.jackson.annotation.JsonTypeId;
         @Type(value = ResultSubscribeDTO.class, name = "SUBSCRIPTION_RESPONSE"),
         @Type(value = ResultResourceNotificationDTO.class, name = "SUBSCRIPTION_NOTIFICATION"),
         @Type(value = ResultUnsubscribeDTO.class, name = "UNSUBSCRIPTION_RESPONSE") })
+@JsonTypeInfo(use = Id.NAME, include = As.PROPERTY, property = "type", visible = true)
 public abstract class AbstractResultDTO {
 
     /**

--- a/northbound/query-handler/src/main/java/org/eclipse/sensinact/northbound/query/api/AbstractResultDTO.java
+++ b/northbound/query-handler/src/main/java/org/eclipse/sensinact/northbound/query/api/AbstractResultDTO.java
@@ -27,9 +27,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
-import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.annotation.JsonTypeId;
 
 /**
  * Represents a Northbound query response
@@ -45,8 +43,13 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
         @Type(value = ResultSubscribeDTO.class, name = "SUBSCRIPTION_RESPONSE"),
         @Type(value = ResultResourceNotificationDTO.class, name = "SUBSCRIPTION_NOTIFICATION"),
         @Type(value = ResultUnsubscribeDTO.class, name = "UNSUBSCRIPTION_RESPONSE") })
-@JsonTypeInfo(use = Id.NAME, include = As.PROPERTY, property = "type")
 public abstract class AbstractResultDTO {
+
+    /**
+     * Result content type
+     */
+    @JsonTypeId
+    public final EResultType type;
 
     /**
      * Targeted URI as used
@@ -69,11 +72,6 @@ public abstract class AbstractResultDTO {
      */
     @JsonInclude(Include.NON_NULL)
     public String error;
-
-    /**
-     * Result content type
-     */
-    public EResultType type;
 
     /**
      * Sets up the result type

--- a/northbound/query-handler/src/main/java/org/eclipse/sensinact/northbound/query/dto/result/ResponseSetDTO.java
+++ b/northbound/query-handler/src/main/java/org/eclipse/sensinact/northbound/query/dto/result/ResponseSetDTO.java
@@ -1,0 +1,19 @@
+/*********************************************************************
+* Copyright (c) 2023 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Kentyou - initial implementation
+**********************************************************************/
+package org.eclipse.sensinact.northbound.query.dto.result;
+
+/**
+ * Resource/metadata SET response
+ */
+public class ResponseSetDTO extends ResponseGetDTO {
+}

--- a/northbound/query-handler/src/main/java/org/eclipse/sensinact/northbound/query/dto/result/TypedResponse.java
+++ b/northbound/query-handler/src/main/java/org/eclipse/sensinact/northbound/query/dto/result/TypedResponse.java
@@ -14,24 +14,16 @@ package org.eclipse.sensinact.northbound.query.dto.result;
 
 import org.eclipse.sensinact.northbound.query.api.AbstractResultDTO;
 import org.eclipse.sensinact.northbound.query.api.EResultType;
+import org.eclipse.sensinact.northbound.query.dto.result.jackson.TypedResponseDeserializer;
 
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
-import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 /**
  * Holds a response of a given type
  */
+@JsonDeserialize(using = TypedResponseDeserializer.class)
 public class TypedResponse<T extends SubResult> extends AbstractResultDTO {
 
-    @JsonSubTypes({ @Type(value = ResponseDescribeProviderDTO.class, name = "DESCRIBE_PROVIDER"),
-            @Type(value = ResponseDescribeServiceDTO.class, name = "DESCRIBE_SERVICE"),
-            @Type(value = ResponseDescribeResourceDTO.class, name = "DESCRIBE_RESOURCE"),
-            @Type(value = ResponseGetDTO.class, name = "GET_RESPONSE"),
-            @Type(value = ResponseSetDTO.class, names = "SET_RESPONSE") })
-    @JsonTypeInfo(use = Id.NAME, include = As.EXTERNAL_PROPERTY, property = "type")
     public T response;
 
     public TypedResponse() {

--- a/northbound/query-handler/src/main/java/org/eclipse/sensinact/northbound/query/dto/result/TypedResponse.java
+++ b/northbound/query-handler/src/main/java/org/eclipse/sensinact/northbound/query/dto/result/TypedResponse.java
@@ -22,14 +22,15 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 
 /**
- *
+ * Holds a response of a given type
  */
 public class TypedResponse<T extends SubResult> extends AbstractResultDTO {
 
     @JsonSubTypes({ @Type(value = ResponseDescribeProviderDTO.class, name = "DESCRIBE_PROVIDER"),
             @Type(value = ResponseDescribeServiceDTO.class, name = "DESCRIBE_SERVICE"),
             @Type(value = ResponseDescribeResourceDTO.class, name = "DESCRIBE_RESOURCE"),
-            @Type(value = ResponseGetDTO.class, names = { "GET_RESPONSE", "SET_RESPONSE" }) })
+            @Type(value = ResponseGetDTO.class, name = "GET_RESPONSE"),
+            @Type(value = ResponseSetDTO.class, names = "SET_RESPONSE") })
     @JsonTypeInfo(use = Id.NAME, include = As.EXTERNAL_PROPERTY, property = "type")
     public T response;
 

--- a/northbound/query-handler/src/main/java/org/eclipse/sensinact/northbound/query/dto/result/jackson/TypedResponseDeserializer.java
+++ b/northbound/query-handler/src/main/java/org/eclipse/sensinact/northbound/query/dto/result/jackson/TypedResponseDeserializer.java
@@ -1,0 +1,147 @@
+/*********************************************************************
+* Copyright (c) 2023 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Kentyou - initial implementation
+**********************************************************************/
+package org.eclipse.sensinact.northbound.query.dto.result.jackson;
+
+import static com.fasterxml.jackson.core.JsonToken.VALUE_STRING;
+import static org.eclipse.sensinact.northbound.query.api.EResultType.DESCRIBE_PROVIDER;
+import static org.eclipse.sensinact.northbound.query.api.EResultType.DESCRIBE_RESOURCE;
+import static org.eclipse.sensinact.northbound.query.api.EResultType.DESCRIBE_SERVICE;
+import static org.eclipse.sensinact.northbound.query.api.EResultType.ERROR;
+import static org.eclipse.sensinact.northbound.query.api.EResultType.GET_RESPONSE;
+import static org.eclipse.sensinact.northbound.query.api.EResultType.SET_RESPONSE;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map.Entry;
+
+import org.eclipse.sensinact.northbound.query.api.EResultType;
+import org.eclipse.sensinact.northbound.query.dto.result.ResponseDescribeProviderDTO;
+import org.eclipse.sensinact.northbound.query.dto.result.ResponseDescribeResourceDTO;
+import org.eclipse.sensinact.northbound.query.dto.result.ResponseDescribeServiceDTO;
+import org.eclipse.sensinact.northbound.query.dto.result.ResponseGetDTO;
+import org.eclipse.sensinact.northbound.query.dto.result.ResponseSetDTO;
+import org.eclipse.sensinact.northbound.query.dto.result.SubResult;
+import org.eclipse.sensinact.northbound.query.dto.result.TypedResponse;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+@SuppressWarnings("rawtypes")
+public class TypedResponseDeserializer extends StdDeserializer<TypedResponse> {
+
+    private static final long serialVersionUID = -2337413302718463311L;
+
+    public TypedResponseDeserializer() {
+        super(TypedResponse.class);
+    }
+
+    @Override
+    public TypedResponse<SubResult> deserialize(JsonParser p, DeserializationContext ctxt)
+            throws IOException, JacksonException {
+        JsonNode root = ctxt.readTree(p);
+        JsonNode typeNode = root.get("type");
+        if (typeNode == null || !typeNode.isTextual()) {
+            ctxt.reportWrongTokenException(this, VALUE_STRING,
+                    "Unable to find the type property to identify this typed response");
+        }
+
+        String typeId = typeNode.asText();
+        JsonNode responseNode = root.get("response");
+
+        SubResult response;
+        EResultType resultType;
+        switch (typeId) {
+        case "DESCRIBE_PROVIDER":
+            response = ctxt.readTreeAsValue(responseNode, ResponseDescribeProviderDTO.class);
+            resultType = DESCRIBE_PROVIDER;
+            break;
+        case "DESCRIBE_SERVICE":
+            response = ctxt.readTreeAsValue(responseNode, ResponseDescribeServiceDTO.class);
+            resultType = DESCRIBE_SERVICE;
+            break;
+        case "DESCRIBE_RESOURCE":
+            response = ctxt.readTreeAsValue(responseNode, ResponseDescribeResourceDTO.class);
+            resultType = DESCRIBE_RESOURCE;
+            break;
+        case "GET_RESPONSE":
+            response = ctxt.readTreeAsValue(responseNode, ResponseGetDTO.class);
+            resultType = GET_RESPONSE;
+            break;
+        case "SET_RESPONSE":
+            response = ctxt.readTreeAsValue(responseNode, ResponseSetDTO.class);
+            resultType = SET_RESPONSE;
+            break;
+        case "ERROR":
+            response = null;
+            resultType = ERROR;
+        default:
+            throw ctxt.invalidTypeIdException(ctxt.getContextualType(), typeId,
+                    "Unrecognized type id - unable to identify a suitable SubResult type");
+        }
+
+        TypedResponse<SubResult> tr = new TypedResponse<>(resultType);
+        tr.response = response;
+
+        Iterator<Entry<String, JsonNode>> fields = ((ObjectNode) root).fields();
+
+        boolean hasStatus = false, hasUri = false;
+        while (fields.hasNext()) {
+            Entry<String, JsonNode> next = fields.next();
+            switch (next.getKey()) {
+            case "type":
+            case "response":
+                // Already handled
+                break;
+            case "error":
+                tr.error = ctxt.readTreeAsValue(next.getValue(), String.class);
+                break;
+            case "requestId":
+                tr.requestId = ctxt.readTreeAsValue(next.getValue(), String.class);
+                break;
+            case "statusCode":
+                Integer status = ctxt.readTreeAsValue(next.getValue(), Integer.class);
+                if (status == null) {
+                    throw ctxt.wrongTokenException(ctxt.getParser(), Integer.class, JsonToken.VALUE_NUMBER_INT,
+                            "The status code must be a number");
+                }
+                tr.statusCode = status.intValue();
+                hasStatus = true;
+                break;
+            case "uri":
+                tr.uri = ctxt.readTreeAsValue(next.getValue(), String.class);
+                hasUri = true;
+                break;
+            default:
+                if (!ctxt.handleUnknownProperty(p, this, TypedResponse.class, next.getKey())) {
+                    ctxt.reportPropertyInputMismatch(TypedResponse.class, next.getKey(),
+                            "Unable to deserialize property {} for a TypedResponse", next.getKey());
+                }
+            }
+        }
+
+        if (!hasStatus) {
+            ctxt.reportPropertyInputMismatch(TypedResponse.class, "statusCode",
+                    "No status code was present for this TypedResponse");
+        }
+        if (!hasUri) {
+            ctxt.reportPropertyInputMismatch(TypedResponse.class, "uri", "No uri was present for this TypedResponse");
+        }
+
+        return tr;
+    }
+}

--- a/northbound/query-handler/src/main/java/org/eclipse/sensinact/northbound/query/impl/QueryHandler.java
+++ b/northbound/query-handler/src/main/java/org/eclipse/sensinact/northbound/query/impl/QueryHandler.java
@@ -66,6 +66,7 @@ import org.eclipse.sensinact.northbound.query.dto.result.ResponseDescribeProvide
 import org.eclipse.sensinact.northbound.query.dto.result.ResponseDescribeResourceDTO;
 import org.eclipse.sensinact.northbound.query.dto.result.ResponseDescribeServiceDTO;
 import org.eclipse.sensinact.northbound.query.dto.result.ResponseGetDTO;
+import org.eclipse.sensinact.northbound.query.dto.result.ResponseSetDTO;
 import org.eclipse.sensinact.northbound.query.dto.result.ResultActDTO;
 import org.eclipse.sensinact.northbound.query.dto.result.ResultDescribeProvidersDTO;
 import org.eclipse.sensinact.northbound.query.dto.result.ResultListProvidersDTO;
@@ -297,8 +298,8 @@ public class QueryHandler implements IQueryHandler {
             return new ErrorResultDTO(405, "Can only set a resource or its metadata");
         }
 
-        final TypedResponse<ResponseGetDTO> result = new TypedResponse<>(EResultType.SET_RESPONSE);
-        final ResponseGetDTO response = new ResponseGetDTO();
+        final TypedResponse<ResponseSetDTO> result = new TypedResponse<>(EResultType.SET_RESPONSE);
+        final ResponseSetDTO response = new ResponseSetDTO();
 
         // Force the timestamp so that we are sure we are coherent with what we return
         final Instant timestamp = Instant.now();

--- a/northbound/query-handler/src/test/java/org/eclipse/sensinact/northbound/query/test/integration/SerializationTest.java
+++ b/northbound/query-handler/src/test/java/org/eclipse/sensinact/northbound/query/test/integration/SerializationTest.java
@@ -24,6 +24,7 @@ import org.eclipse.sensinact.core.model.ResourceType;
 import org.eclipse.sensinact.gateway.geojson.Coordinates;
 import org.eclipse.sensinact.gateway.geojson.GeoJsonType;
 import org.eclipse.sensinact.gateway.geojson.Point;
+import org.eclipse.sensinact.northbound.query.api.AbstractResultDTO;
 import org.eclipse.sensinact.northbound.query.api.EQueryType;
 import org.eclipse.sensinact.northbound.query.api.EReadWriteMode;
 import org.eclipse.sensinact.northbound.query.api.EResultType;
@@ -45,6 +46,7 @@ import org.eclipse.sensinact.northbound.query.dto.result.ResponseGetDTO;
 import org.eclipse.sensinact.northbound.query.dto.result.ResponseSetDTO;
 import org.eclipse.sensinact.northbound.query.dto.result.ResultActDTO;
 import org.eclipse.sensinact.northbound.query.dto.result.ResultDescribeProvidersDTO;
+import org.eclipse.sensinact.northbound.query.dto.result.ResultListProvidersDTO;
 import org.eclipse.sensinact.northbound.query.dto.result.ShortResourceDescriptionDTO;
 import org.eclipse.sensinact.northbound.query.dto.result.TypedResponse;
 import org.junit.jupiter.api.Test;
@@ -474,10 +476,10 @@ public class SerializationTest {
     }
 
     @Test
-    void testTypeResponseSerialization() throws JsonProcessingException {
+    void testTypedResponseSerialization() throws JsonProcessingException {
         // Original version
         final TypedResponse<ResponseGetDTO> original = new TypedResponse<>(EResultType.GET_RESPONSE);
-        original.statusCode = 42;
+        original.statusCode = 218;
         original.uri = "a/b/c";
         original.response = new ResponseGetDTO();
         original.response.name = "c";
@@ -502,5 +504,29 @@ public class SerializationTest {
         assertEquals(original.requestId, parsed.requestId);
         assertEquals(original.statusCode, parsed.statusCode);
         assertEquals(original.response.getClass(), parsed.response.getClass());
+    }
+
+    @Test
+    void testProvidersList() throws JsonProcessingException {
+        final ResultListProvidersDTO original = new ResultListProvidersDTO();
+        original.statusCode = 200;
+        original.uri = "/";
+        original.providers = List.of("toto", "titi", "tutu");
+
+        final String strJson = mapper.writeValueAsString(original);
+
+        // Test direct conversion
+        final ResultListProvidersDTO typedParsed = mapper.readValue(strJson, ResultListProvidersDTO.class);
+        assertEquals(original.type, typedParsed.type);
+        assertEquals(original.statusCode, typedParsed.statusCode);
+        assertEquals(original.uri, typedParsed.uri);
+        assertEquals(original.providers, typedParsed.providers);
+
+        // Test via abstract
+        final AbstractResultDTO abstractParsed = mapper.readValue(strJson, AbstractResultDTO.class);
+        assertEquals(original.type, abstractParsed.type);
+        assertEquals(original.statusCode, abstractParsed.statusCode);
+        assertEquals(original.uri, abstractParsed.uri);
+        assertEquals(original.providers, ((ResultListProvidersDTO) abstractParsed).providers);
     }
 }


### PR DESCRIPTION
In some cases, the JSON result sent by sensiNact had two "type" keys at root level.
This PR fixes the Jackson serialization annotations and adds a test to avoid reproducing the error.