### PR TITLE
Add NullAction field to GenericDTO

### DIFF
--- a/core/api/src/main/java/org/eclipse/sensinact/core/push/dto/GenericDto.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/push/dto/GenericDto.java
@@ -14,6 +14,8 @@ package org.eclipse.sensinact.core.push.dto;
 
 import java.time.Instant;
 
+import org.eclipse.sensinact.core.annotation.dto.NullAction;
+
 /**
  * A special update dto type where the data is found in "value" with an optional
  * target data type
@@ -32,4 +34,8 @@ public final class GenericDto extends BaseValueDto {
      */
     public Instant timestamp;
 
+    /**
+     * Action to apply if value is null
+     */
+    public NullAction nullAction = NullAction.IGNORE;
 }

--- a/core/impl/src/main/java/org/eclipse/sensinact/prototype/extract/impl/GenericDtoDataExtractor.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/prototype/extract/impl/GenericDtoDataExtractor.java
@@ -16,6 +16,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.eclipse.sensinact.core.annotation.dto.NullAction;
 import org.eclipse.sensinact.core.push.dto.GenericDto;
 import org.eclipse.sensinact.prototype.dto.impl.AbstractUpdateDto;
 import org.eclipse.sensinact.prototype.dto.impl.DataUpdateDto;
@@ -32,7 +33,8 @@ public class GenericDtoDataExtractor implements DataExtractor {
 
         Instant instant = dto.timestamp == null ? Instant.now() : dto.timestamp;
 
-        if (dto.value != null) {
+        // Accept a null value if this is not a metadata update
+        if (dto.value != null || dto.nullAction == NullAction.UPDATE) {
             DataUpdateDto dud = new DataUpdateDto();
             instant = copyCommonFields(dto, instant, dud);
             if (dto.type != null)

--- a/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/dto/DeviceMappingOptionsDTO.java
+++ b/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/dto/DeviceMappingOptionsDTO.java
@@ -12,6 +12,8 @@
 **********************************************************************/
 package org.eclipse.sensinact.gateway.southbound.device.factory.dto;
 
+import org.eclipse.sensinact.core.annotation.dto.NullAction;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -33,4 +35,7 @@ public class DeviceMappingOptionsDTO {
 
     @JsonProperty("numbers.locale")
     public String numbersLocale;
+
+    @JsonProperty("null.action")
+    public NullAction nullAction = NullAction.UPDATE;
 }

--- a/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/FactoryParserHandler.java
+++ b/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/FactoryParserHandler.java
@@ -345,6 +345,11 @@ public class FactoryParserHandler implements IDeviceMappingHandler, IPlaceHolder
             }
         }
 
+        // Set the null action to all DTOs
+        bulk.stream().forEach(dto -> {
+            dto.nullAction = options.nullAction;
+        });
+
         return bulk;
     }
 


### PR DESCRIPTION
This option allows to choose if updates with a null value are accepted or ignored (previous and now default behaviour).

The device factory core has also been updated to accept a "null.action" entry in its mapping options.
It accepts null values by default.