### PR TITLE
Rename PrototypePush

### DIFF
--- a/core/api/src/main/java/org/eclipse/sensinact/core/push/DataUpdate.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/push/DataUpdate.java
@@ -14,7 +14,7 @@ package org.eclipse.sensinact.core.push;
 
 import org.osgi.util.promise.Promise;
 
-public interface PrototypePush {
+public interface DataUpdate {
 
     Promise<?> pushUpdate(Object o);
 

--- a/core/impl/src/main/java/org/eclipse/sensinact/prototype/impl/DataUpdateImpl.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/prototype/impl/DataUpdateImpl.java
@@ -22,7 +22,7 @@ import java.util.WeakHashMap;
 import org.eclipse.sensinact.core.command.AbstractSensinactCommand;
 import org.eclipse.sensinact.core.command.GatewayThread;
 import org.eclipse.sensinact.core.command.IndependentCommands;
-import org.eclipse.sensinact.core.push.PrototypePush;
+import org.eclipse.sensinact.core.push.DataUpdate;
 import org.eclipse.sensinact.core.push.dto.BulkGenericDto;
 import org.eclipse.sensinact.core.push.dto.GenericDto;
 import org.eclipse.sensinact.model.core.provider.Provider;
@@ -38,7 +38,7 @@ import org.osgi.service.component.annotations.Reference;
 import org.osgi.util.promise.Promise;
 
 @Component
-public class PrototypePushImpl implements PrototypePush {
+public class DataUpdateImpl implements DataUpdate {
     // TODO wrap this in a more pleasant type?
     @Reference
     GatewayThread thread;

--- a/core/impl/src/test/java/org/eclipse/sensinact/prototype/integration/filter/FilterTest.java
+++ b/core/impl/src/test/java/org/eclipse/sensinact/prototype/integration/filter/FilterTest.java
@@ -21,7 +21,7 @@ import java.util.function.Predicate;
 
 import org.eclipse.sensinact.core.command.AbstractTwinCommand;
 import org.eclipse.sensinact.core.command.GatewayThread;
-import org.eclipse.sensinact.core.push.PrototypePush;
+import org.eclipse.sensinact.core.push.DataUpdate;
 import org.eclipse.sensinact.core.push.dto.BulkGenericDto;
 import org.eclipse.sensinact.core.push.dto.GenericDto;
 import org.eclipse.sensinact.core.snapshot.ProviderSnapshot;
@@ -39,7 +39,7 @@ import org.osgi.util.promise.PromiseFactory;
 public class FilterTest {
 
     @InjectService
-    PrototypePush push;
+    DataUpdate push;
 
     @InjectService
     GatewayThread thread;

--- a/core/impl/src/test/java/org/eclipse/sensinact/prototype/integration/notification/SubscribeTest.java
+++ b/core/impl/src/test/java/org/eclipse/sensinact/prototype/integration/notification/SubscribeTest.java
@@ -22,7 +22,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.sensinact.core.notification.ResourceDataNotification;
-import org.eclipse.sensinact.core.push.PrototypePush;
+import org.eclipse.sensinact.core.push.DataUpdate;
 import org.eclipse.sensinact.core.push.dto.GenericDto;
 import org.eclipse.sensinact.core.security.UserInfo;
 import org.eclipse.sensinact.core.session.SensiNactSession;
@@ -51,7 +51,7 @@ public class SubscribeTest {
     SensiNactSessionManager sessionManager;
 
     @InjectService
-    PrototypePush push;
+    DataUpdate push;
 
     @AfterEach
     void stop() {

--- a/core/impl/src/test/java/org/eclipse/sensinact/prototype/integration/session/AdminServiceTest.java
+++ b/core/impl/src/test/java/org/eclipse/sensinact/prototype/integration/session/AdminServiceTest.java
@@ -19,7 +19,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
-import org.eclipse.sensinact.core.push.PrototypePush;
+import org.eclipse.sensinact.core.push.DataUpdate;
 import org.eclipse.sensinact.core.push.dto.GenericDto;
 import org.eclipse.sensinact.core.security.UserInfo;
 import org.eclipse.sensinact.core.session.ResourceDescription;
@@ -47,7 +47,7 @@ public class AdminServiceTest {
     private static final String RESOURCE = "resource";
 
     @InjectService
-    PrototypePush push;
+    DataUpdate push;
     @InjectService
     SensiNactSessionManager sessionManager;
     SensiNactSession session;

--- a/distribution/features/northbound-ogc-sensorthings-mqtt-feature/pom.xml
+++ b/distribution/features/northbound-ogc-sensorthings-mqtt-feature/pom.xml
@@ -110,6 +110,15 @@
       <version>1.2.5</version>
       <scope>test</scope>
     </dependency>
+    <!-- This is needed indirectly in testing as part of the test gateway -->
+    <dependency>
+      <groupId>org.eclipse.sensinact.gateway.distribution.features</groupId>
+      <artifactId>virtual-temperature-sensor-feature</artifactId>
+      <version>${sensinact.version}</version>
+      <type>json</type>
+      <classifier>osgifeature</classifier>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/docs/core/ThreadingModel.md
+++ b/docs/core/ThreadingModel.md
@@ -37,7 +37,7 @@ Southbound providers can operate in one of two ways, *push based* or *pull based
 
 ### Push based providers
 
-Push based Southbound providers receive data pushed from a sensor or actuator. This data should be converted into a suitable update DTO and passed to the `PrototypePush` service which will wrap the update data in a command and submit it to the gateway thread. Once the gateway thread has processed the update then the returned `Promise` will be resolved.
+Push based Southbound providers receive data pushed from a sensor or actuator. This data should be converted into a suitable update DTO and passed to the `DataUpdate` service which will wrap the update data in a command and submit it to the gateway thread. Once the gateway thread has processed the update then the returned `Promise` will be resolved.
 
 ### Pull based providers
 

--- a/docs/core/data-model/DataModel.md
+++ b/docs/core/data-model/DataModel.md
@@ -16,7 +16,7 @@ Creating a model can be achieved in several different ways
 
 ### The data first approach
 
-The data first approach appears, at first, to avoid creating a model entirely. In the data first approach users simply push data updates into sensiNact using the `PrototypePush` service
+The data first approach appears, at first, to avoid creating a model entirely. In the data first approach users simply push data updates into sensiNact using the `DataUpdate` service
 
 ```java
 GenericDto dto = new GenericDto();
@@ -25,7 +25,7 @@ dto.service = "service";
 dto.resource = "resource";
 dto.value = 42;
 
-push.pushUpdate(dto);
+dataUpdate.pushUpdate(dto);
 ```
 
 In this approach the sensiNact core will automatically create a model for `provider1` if it doesn't already exist. The model will automatically be extended with a service called `service` and a resource called `resource` if needed, and then the resource will be set with a value of 42.
@@ -43,7 +43,7 @@ This process gives maximum flexibility, but it is important to remember that any
 
 ### The code first approach
 
-The code first approach is similar to the data first approach in that no formal model is created, and that users simply push data updates into sensiNact using the `PrototypePush` service. The key difference is that unlike the data first approach users define one or more custom DTOs representing the resources that they want to update. These DTOs form the template for the model, with the field names and type information being used to generate the model as updates are received.
+The code first approach is similar to the data first approach in that no formal model is created, and that users simply push data updates into sensiNact using the `DataUpdate` service. The key difference is that unlike the data first approach users define one or more custom DTOs representing the resources that they want to update. These DTOs form the template for the model, with the field names and type information being used to generate the model as updates are received.
 
 For example, the following DTO:
 

--- a/docs/core/metrics.md
+++ b/docs/core/metrics.md
@@ -95,7 +95,7 @@ Statistics of complex metrics like histograms and timers are stored in two ways:
   * `-p99`: 99th percentile of values / times
   * `-p99_9`: 99.9th percentile of values / times
 
-All reported metrics are stored in the sensiNact twin model at once using the `PrototypePush` service.
+All reported metrics are stored in the sensiNact twin model at once using the `DataUpdate` service.
 As a result, if many metrics have to be stored, the operation might impact the measured metrics themselves, like the core task time.
 
 ## Listen to metrics reports

--- a/docs/southbound/custom/custom.md
+++ b/docs/southbound/custom/custom.md
@@ -4,7 +4,7 @@ Building a custom Southbound connector is a relatively simple task, however we r
 
 ## Pushing updates
 
-Pushing updates is the simplest way to set data in the sensiNact digital twin. Updates are pushed using the `PrototypePush` service which allows update objects to be sent to sensiNact.
+Pushing updates is the simplest way to set data in the sensiNact digital twin. Updates are pushed using the `DataUpdate` service which allows update objects to be sent to sensiNact.
 
 ### Using a Generic DTO
 

--- a/examples/generic/src/main/java/org/eclipse/sensinact/prototype/generic/GenericPushComponent.java
+++ b/examples/generic/src/main/java/org/eclipse/sensinact/prototype/generic/GenericPushComponent.java
@@ -13,7 +13,7 @@
 package org.eclipse.sensinact.prototype.generic;
 
 import org.eclipse.sensinact.core.push.EventTopicNames;
-import org.eclipse.sensinact.core.push.PrototypePush;
+import org.eclipse.sensinact.core.push.DataUpdate;
 import org.eclipse.sensinact.core.push.dto.GenericDto;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -36,7 +36,7 @@ public class GenericPushComponent {
      * Service to send the update event through the update DTO handler
      */
     @Reference
-    private PrototypePush sensiNact;
+    private DataUpdate sensiNact;
 
     /**
      * Message coming in from the sensor, just like a custom model

--- a/examples/push-based/src/main/java/org/eclipse/sensinact/prototype/push/PushComponent.java
+++ b/examples/push-based/src/main/java/org/eclipse/sensinact/prototype/push/PushComponent.java
@@ -13,7 +13,7 @@
 package org.eclipse.sensinact.prototype.push;
 
 import org.eclipse.sensinact.core.push.EventTopicNames;
-import org.eclipse.sensinact.core.push.PrototypePush;
+import org.eclipse.sensinact.core.push.DataUpdate;
 import org.eclipse.sensinact.prototype.push.dto._01_SimpleDTO;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -35,7 +35,7 @@ public class PushComponent {
      * Service to send the update event through the update DTO handler
      */
     @Reference
-    private PrototypePush sensiNact;
+    private DataUpdate sensiNact;
 
     /**
      * Message coming in from the sensor

--- a/northbound/filters/ldap/src/test/java/org/eclipse/sensinact/northbound/filters/ldap/integration/LdapComponentTest.java
+++ b/northbound/filters/ldap/src/test/java/org/eclipse/sensinact/northbound/filters/ldap/integration/LdapComponentTest.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 import org.eclipse.sensinact.core.command.GatewayThread;
-import org.eclipse.sensinact.core.push.PrototypePush;
+import org.eclipse.sensinact.core.push.DataUpdate;
 import org.eclipse.sensinact.core.push.dto.BulkGenericDto;
 import org.eclipse.sensinact.core.push.dto.GenericDto;
 import org.eclipse.sensinact.core.snapshot.ICriterion;
@@ -37,7 +37,7 @@ import org.osgi.test.junit5.service.ServiceExtension;
 public class LdapComponentTest {
 
     @InjectService
-    PrototypePush push;
+    DataUpdate push;
 
     @InjectService
     GatewayThread thread;

--- a/northbound/filters/ldap/src/test/java/org/eclipse/sensinact/northbound/filters/ldap/integration/LdapFilterTest.java
+++ b/northbound/filters/ldap/src/test/java/org/eclipse/sensinact/northbound/filters/ldap/integration/LdapFilterTest.java
@@ -24,7 +24,7 @@ import java.util.stream.Collectors;
 import org.eclipse.sensinact.northbound.filters.ldap.LdapParserTest;
 import org.eclipse.sensinact.core.command.AbstractTwinCommand;
 import org.eclipse.sensinact.core.command.GatewayThread;
-import org.eclipse.sensinact.core.push.PrototypePush;
+import org.eclipse.sensinact.core.push.DataUpdate;
 import org.eclipse.sensinact.core.push.dto.BulkGenericDto;
 import org.eclipse.sensinact.core.push.dto.GenericDto;
 import org.eclipse.sensinact.core.snapshot.ICriterion;
@@ -43,7 +43,7 @@ import org.osgi.util.promise.PromiseFactory;
 public class LdapFilterTest {
 
     @InjectService
-    PrototypePush push;
+    DataUpdate push;
 
     @InjectService
     GatewayThread thread;

--- a/northbound/query-handler/src/test/java/org/eclipse/sensinact/northbound/query/test/integration/DescriptionsTest.java
+++ b/northbound/query-handler/src/test/java/org/eclipse/sensinact/northbound/query/test/integration/DescriptionsTest.java
@@ -20,7 +20,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.eclipse.sensinact.core.push.PrototypePush;
+import org.eclipse.sensinact.core.push.DataUpdate;
 import org.eclipse.sensinact.core.push.dto.GenericDto;
 import org.eclipse.sensinact.core.security.UserInfo;
 import org.eclipse.sensinact.core.session.SensiNactSession;
@@ -63,7 +63,7 @@ public class DescriptionsTest {
     SensiNactSession session;
 
     @InjectService
-    PrototypePush push;
+    DataUpdate push;
 
     @InjectService
     IQueryHandler handler;

--- a/northbound/query-handler/src/test/java/org/eclipse/sensinact/northbound/query/test/integration/MissingEntityTest.java
+++ b/northbound/query-handler/src/test/java/org/eclipse/sensinact/northbound/query/test/integration/MissingEntityTest.java
@@ -23,7 +23,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.List;
 
-import org.eclipse.sensinact.core.push.PrototypePush;
+import org.eclipse.sensinact.core.push.DataUpdate;
 import org.eclipse.sensinact.core.push.dto.BulkGenericDto;
 import org.eclipse.sensinact.core.push.dto.GenericDto;
 import org.eclipse.sensinact.core.security.UserInfo;
@@ -64,7 +64,7 @@ public class MissingEntityTest {
     SensiNactSession session;
 
     @InjectService
-    PrototypePush push;
+    DataUpdate push;
 
     @InjectService
     IQueryHandler handler;

--- a/northbound/query-handler/src/test/java/org/eclipse/sensinact/northbound/query/test/integration/ResourceAccessTest.java
+++ b/northbound/query-handler/src/test/java/org/eclipse/sensinact/northbound/query/test/integration/ResourceAccessTest.java
@@ -30,7 +30,7 @@ import java.util.concurrent.TimeUnit;
 import org.eclipse.sensinact.core.annotation.verb.ACT;
 import org.eclipse.sensinact.core.annotation.verb.ActParam;
 import org.eclipse.sensinact.core.notification.ResourceDataNotification;
-import org.eclipse.sensinact.core.push.PrototypePush;
+import org.eclipse.sensinact.core.push.DataUpdate;
 import org.eclipse.sensinact.core.push.dto.GenericDto;
 import org.eclipse.sensinact.core.security.UserInfo;
 import org.eclipse.sensinact.core.session.SensiNactSession;
@@ -71,7 +71,7 @@ public class ResourceAccessTest {
     SensiNactSession session;
 
     @InjectService
-    PrototypePush push;
+    DataUpdate push;
 
     @InjectService
     IQueryHandler handler;

--- a/northbound/query-handler/src/test/java/org/eclipse/sensinact/northbound/query/test/integration/TestUtils.java
+++ b/northbound/query-handler/src/test/java/org/eclipse/sensinact/northbound/query/test/integration/TestUtils.java
@@ -29,14 +29,14 @@ public class TestUtils {
     private final ObjectMapper mapper = new ObjectMapper();
 
     /**
-     * Constructs a DTO to use with PrototypePush
+     * Constructs a DTO to use with DataUpdate
      */
     public GenericDto makeDto(String provider, String service, String resource, Object value, Class<?> type) {
         return makeDto(provider, provider, service, resource, value, type);
     }
 
     /**
-     * Constructs a DTO to use with PrototypePush
+     * Constructs a DTO to use with DataUpdate
      */
     public GenericDto makeDto(String model, String provider, String service, String resource, Object value,
             Class<?> type) {

--- a/northbound/rest/src/test/java/org/eclipse/sensinact/northbound/rest/integration/DescriptionsTest.java
+++ b/northbound/rest/src/test/java/org/eclipse/sensinact/northbound/rest/integration/DescriptionsTest.java
@@ -29,7 +29,7 @@ import java.util.TreeMap;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-import org.eclipse.sensinact.core.push.PrototypePush;
+import org.eclipse.sensinact.core.push.DataUpdate;
 import org.eclipse.sensinact.core.push.dto.GenericDto;
 import org.eclipse.sensinact.gateway.geojson.GeoJsonObject;
 import org.eclipse.sensinact.northbound.query.api.EResultType;
@@ -100,7 +100,7 @@ public class DescriptionsTest {
     private static final Integer VALUE = 42;
 
     @InjectService
-    PrototypePush push;
+    DataUpdate push;
 
     final TestUtils utils = new TestUtils();
 

--- a/northbound/rest/src/test/java/org/eclipse/sensinact/northbound/rest/integration/MissingEntityTest.java
+++ b/northbound/rest/src/test/java/org/eclipse/sensinact/northbound/rest/integration/MissingEntityTest.java
@@ -21,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.time.Instant;
 import java.util.List;
 
-import org.eclipse.sensinact.core.push.PrototypePush;
+import org.eclipse.sensinact.core.push.DataUpdate;
 import org.eclipse.sensinact.core.push.dto.BulkGenericDto;
 import org.eclipse.sensinact.core.push.dto.GenericDto;
 import org.eclipse.sensinact.northbound.query.dto.result.ErrorResultDTO;
@@ -82,7 +82,7 @@ public class MissingEntityTest {
     private static final Integer VALUE = 42;
 
     @InjectService
-    PrototypePush push;
+    DataUpdate push;
 
     final TestUtils utils = new TestUtils();
 

--- a/northbound/rest/src/test/java/org/eclipse/sensinact/northbound/rest/integration/ResourceAccessTest.java
+++ b/northbound/rest/src/test/java/org/eclipse/sensinact/northbound/rest/integration/ResourceAccessTest.java
@@ -31,7 +31,7 @@ import java.util.concurrent.TimeUnit;
 import org.eclipse.sensinact.core.annotation.verb.ACT;
 import org.eclipse.sensinact.core.annotation.verb.ActParam;
 import org.eclipse.sensinact.core.notification.ResourceDataNotification;
-import org.eclipse.sensinact.core.push.PrototypePush;
+import org.eclipse.sensinact.core.push.DataUpdate;
 import org.eclipse.sensinact.core.push.dto.GenericDto;
 import org.eclipse.sensinact.core.security.UserInfo;
 import org.eclipse.sensinact.core.session.SensiNactSession;
@@ -110,7 +110,7 @@ public class ResourceAccessTest {
     SensiNactSessionManager sessionManager;
 
     @InjectService
-    PrototypePush push;
+    DataUpdate push;
 
     BlockingQueue<ResourceDataNotification> queue;
 

--- a/northbound/rest/src/test/java/org/eclipse/sensinact/northbound/rest/integration/SecureAccessTest.java
+++ b/northbound/rest/src/test/java/org/eclipse/sensinact/northbound/rest/integration/SecureAccessTest.java
@@ -24,7 +24,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Map;
 import java.util.Set;
 
-import org.eclipse.sensinact.core.push.PrototypePush;
+import org.eclipse.sensinact.core.push.DataUpdate;
 import org.eclipse.sensinact.core.push.dto.GenericDto;
 import org.eclipse.sensinact.core.security.UserInfo;
 import org.eclipse.sensinact.core.session.SensiNactSessionManager;
@@ -100,7 +100,7 @@ public class SecureAccessTest {
     SensiNactSessionManager sessionManager;
 
     @InjectService
-    PrototypePush push;
+    DataUpdate push;
 
     @InjectBundleContext
     BundleContext ctx;

--- a/northbound/rest/src/test/java/org/eclipse/sensinact/northbound/rest/integration/TestUtils.java
+++ b/northbound/rest/src/test/java/org/eclipse/sensinact/northbound/rest/integration/TestUtils.java
@@ -42,14 +42,14 @@ public class TestUtils {
     static final HttpClient client = HttpClient.newHttpClient();
 
     /**
-     * Constructs a DTO to use with PrototypePush
+     * Constructs a DTO to use with DataUpdate
      */
     public GenericDto makeDto(String provider, String service, String resource, Object value, Class<?> type) {
         return makeDto(provider, provider, service, resource, value, type);
     }
 
     /**
-     * Constructs a DTO to use with PrototypePush
+     * Constructs a DTO to use with DataUpdate
      */
     public GenericDto makeDto(String model, String provider, String service, String resource, Object value,
             Class<?> type) {

--- a/northbound/rest/src/test/java/org/eclipse/sensinact/northbound/rest/integration/notification/ResourceNotificationsTest.java
+++ b/northbound/rest/src/test/java/org/eclipse/sensinact/northbound/rest/integration/notification/ResourceNotificationsTest.java
@@ -26,7 +26,7 @@ import java.util.concurrent.TimeUnit;
 import org.eclipse.jetty.util.BlockingArrayQueue;
 import org.eclipse.sensinact.core.notification.LifecycleNotification;
 import org.eclipse.sensinact.core.notification.ResourceDataNotification;
-import org.eclipse.sensinact.core.push.PrototypePush;
+import org.eclipse.sensinact.core.push.DataUpdate;
 import org.eclipse.sensinact.core.push.dto.GenericDto;
 import org.eclipse.sensinact.core.security.UserInfo;
 import org.eclipse.sensinact.core.session.SensiNactSession;
@@ -98,7 +98,7 @@ public class ResourceNotificationsTest {
     SensiNactSessionManager sessionManager;
 
     @InjectService
-    PrototypePush push;
+    DataUpdate push;
 
     @InjectService
     ClientBuilder clientBuilder;

--- a/northbound/sensorthings/mqtt/src/test/java/org/eclipse/sensinact/gateway/northbound/sensorthings/mqtt/integration/InsecureMqttNotificationsTest.java
+++ b/northbound/sensorthings/mqtt/src/test/java/org/eclipse/sensinact/gateway/northbound/sensorthings/mqtt/integration/InsecureMqttNotificationsTest.java
@@ -38,7 +38,7 @@ import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.sensinact.core.command.AbstractSensinactCommand;
 import org.eclipse.sensinact.core.command.GatewayThread;
 import org.eclipse.sensinact.core.model.SensinactModelManager;
-import org.eclipse.sensinact.core.push.PrototypePush;
+import org.eclipse.sensinact.core.push.DataUpdate;
 import org.eclipse.sensinact.core.push.dto.GenericDto;
 import org.eclipse.sensinact.core.twin.SensinactDigitalTwin;
 import org.eclipse.sensinact.core.twin.SensinactProvider;
@@ -74,7 +74,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 public class InsecureMqttNotificationsTest {
 
     @InjectService
-    PrototypePush push;
+    DataUpdate push;
 
     @InjectService
     GatewayThread thread;

--- a/northbound/sensorthings/rest.gateway/src/test/java/org/eclipse/sensinact/sensorthings/sensing/rest/integration/AbstractIntegrationTest.java
+++ b/northbound/sensorthings/rest.gateway/src/test/java/org/eclipse/sensinact/sensorthings/sensing/rest/integration/AbstractIntegrationTest.java
@@ -21,7 +21,7 @@ import java.time.Instant;
 import org.eclipse.sensinact.core.command.AbstractSensinactCommand;
 import org.eclipse.sensinact.core.command.GatewayThread;
 import org.eclipse.sensinact.core.model.SensinactModelManager;
-import org.eclipse.sensinact.core.push.PrototypePush;
+import org.eclipse.sensinact.core.push.DataUpdate;
 import org.eclipse.sensinact.core.push.dto.GenericDto;
 import org.eclipse.sensinact.core.security.UserInfo;
 import org.eclipse.sensinact.core.session.SensiNactSession;
@@ -58,7 +58,7 @@ public class AbstractIntegrationTest {
     private static final UserInfo USER = UserInfo.ANONYMOUS;
 
     @InjectService
-    protected PrototypePush push;
+    protected DataUpdate push;
 
     @InjectService
     protected GatewayThread thread;

--- a/northbound/sensorthings/rest.gateway/src/test/java/org/eclipse/sensinact/sensorthings/sensing/rest/integration/TestUtils.java
+++ b/northbound/sensorthings/rest.gateway/src/test/java/org/eclipse/sensinact/sensorthings/sensing/rest/integration/TestUtils.java
@@ -51,7 +51,7 @@ public class TestUtils {
     }
 
     /**
-     * Constructs a DTO to use with PrototypePush
+     * Constructs a DTO to use with DataUpdate
      */
     public GenericDto makeDto(String provider, String service, String resource, Object value, Class<?> type) {
         GenericDto dto = new GenericDto();

--- a/northbound/websocket/src/test/java/org/eclipse/sensinact/northbound/websocket/integration/SecureWebSocketTest.java
+++ b/northbound/websocket/src/test/java/org/eclipse/sensinact/northbound/websocket/integration/SecureWebSocketTest.java
@@ -93,7 +93,7 @@ public class SecureWebSocketTest {
     }
 
     /**
-     * Constructs a DTO to use with PrototypePush
+     * Constructs a DTO to use with DataUpdate
      */
     public GenericDto makeDto(String provider, String service, String resource, Object value, Class<?> type) {
         GenericDto dto = new GenericDto();

--- a/northbound/websocket/src/test/java/org/eclipse/sensinact/northbound/websocket/integration/SecureWebSocketTest.java
+++ b/northbound/websocket/src/test/java/org/eclipse/sensinact/northbound/websocket/integration/SecureWebSocketTest.java
@@ -31,7 +31,7 @@ import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.api.exceptions.UpgradeException;
 import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
-import org.eclipse.sensinact.core.push.PrototypePush;
+import org.eclipse.sensinact.core.push.DataUpdate;
 import org.eclipse.sensinact.core.push.dto.GenericDto;
 import org.eclipse.sensinact.core.security.UserInfo;
 import org.eclipse.sensinact.core.session.SensiNactSessionManager;
@@ -63,7 +63,7 @@ public class SecureWebSocketTest {
     SensiNactSessionManager sessionManager;
 
     @InjectService
-    PrototypePush push;
+    DataUpdate push;
 
     final ObjectMapper mapper = new ObjectMapper();
 

--- a/northbound/websocket/src/test/java/org/eclipse/sensinact/northbound/websocket/integration/WebSocketTest.java
+++ b/northbound/websocket/src/test/java/org/eclipse/sensinact/northbound/websocket/integration/WebSocketTest.java
@@ -99,7 +99,7 @@ public class WebSocketTest {
     }
 
     /**
-     * Constructs a DTO to use with PrototypePush
+     * Constructs a DTO to use with DataUpdate
      */
     public GenericDto makeDto(String provider, String service, String resource, Object value, Class<?> type) {
         GenericDto dto = new GenericDto();

--- a/northbound/websocket/src/test/java/org/eclipse/sensinact/northbound/websocket/integration/WebSocketTest.java
+++ b/northbound/websocket/src/test/java/org/eclipse/sensinact/northbound/websocket/integration/WebSocketTest.java
@@ -33,7 +33,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.eclipse.jetty.util.BlockingArrayQueue;
 import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
-import org.eclipse.sensinact.core.push.PrototypePush;
+import org.eclipse.sensinact.core.push.DataUpdate;
 import org.eclipse.sensinact.core.push.dto.BulkGenericDto;
 import org.eclipse.sensinact.core.push.dto.GenericDto;
 import org.eclipse.sensinact.core.session.SensiNactSessionManager;
@@ -69,7 +69,7 @@ public class WebSocketTest {
     SensiNactSessionManager sessionManager;
 
     @InjectService
-    PrototypePush push;
+    DataUpdate push;
 
     final ObjectMapper mapper = new ObjectMapper();
 

--- a/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/FactoryParserHandler.java
+++ b/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/FactoryParserHandler.java
@@ -38,7 +38,7 @@ import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.eclipse.sensinact.core.push.PrototypePush;
+import org.eclipse.sensinact.core.push.DataUpdate;
 import org.eclipse.sensinact.core.push.dto.BulkGenericDto;
 import org.eclipse.sensinact.core.push.dto.GenericDto;
 import org.eclipse.sensinact.gateway.geojson.Coordinates;
@@ -119,7 +119,7 @@ public class FactoryParserHandler implements IDeviceMappingHandler, IPlaceHolder
      * SensiNact update endpoint
      */
     @Reference
-    PrototypePush prototypePush;
+    DataUpdate prototypePush;
 
     /**
      * JSON mapper

--- a/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/FactoryParserHandler.java
+++ b/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/FactoryParserHandler.java
@@ -119,7 +119,7 @@ public class FactoryParserHandler implements IDeviceMappingHandler, IPlaceHolder
      * SensiNact update endpoint
      */
     @Reference
-    DataUpdate prototypePush;
+    DataUpdate dataUpdate;
 
     /**
      * JSON mapper
@@ -200,7 +200,7 @@ public class FactoryParserHandler implements IDeviceMappingHandler, IPlaceHolder
 
                 if (!bulk.dtos.isEmpty()) {
                     // Send all updates to the gateway thread at once
-                    prototypePush.pushUpdate(bulk);
+                    dataUpdate.pushUpdate(bulk);
                 }
             }
         } finally {

--- a/southbound/device-factory/device-factory-core/src/test/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/RecordHandlingTest.java
+++ b/southbound/device-factory/device-factory-core/src/test/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/RecordHandlingTest.java
@@ -52,9 +52,9 @@ public class RecordHandlingTest {
     @BeforeEach
     void start() throws InterruptedException {
         deviceMapper = new FactoryParserHandler();
-        deviceMapper.prototypePush = Mockito.mock(DataUpdate.class);
+        deviceMapper.dataUpdate = Mockito.mock(DataUpdate.class);
 
-        Mockito.when(deviceMapper.prototypePush.pushUpdate(Mockito.any())).thenAnswer(i -> {
+        Mockito.when(deviceMapper.dataUpdate.pushUpdate(Mockito.any())).thenAnswer(i -> {
             final BulkGenericDto dto = i.getArgument(0, BulkGenericDto.class);
             bulks.add(dto);
             return Promises.resolved(dto);

--- a/southbound/device-factory/device-factory-core/src/test/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/RecordHandlingTest.java
+++ b/southbound/device-factory/device-factory-core/src/test/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/RecordHandlingTest.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.sensinact.core.annotation.dto.NullAction;
-import org.eclipse.sensinact.core.push.PrototypePush;
+import org.eclipse.sensinact.core.push.DataUpdate;
 import org.eclipse.sensinact.core.push.dto.BulkGenericDto;
 import org.eclipse.sensinact.core.push.dto.GenericDto;
 import org.eclipse.sensinact.gateway.geojson.Point;
@@ -52,7 +52,7 @@ public class RecordHandlingTest {
     @BeforeEach
     void start() throws InterruptedException {
         deviceMapper = new FactoryParserHandler();
-        deviceMapper.prototypePush = Mockito.mock(PrototypePush.class);
+        deviceMapper.prototypePush = Mockito.mock(DataUpdate.class);
 
         Mockito.when(deviceMapper.prototypePush.pushUpdate(Mockito.any())).thenAnswer(i -> {
             final BulkGenericDto dto = i.getArgument(0, BulkGenericDto.class);

--- a/southbound/device-factory/parser-csv/src/test/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/CSVParserTest.java
+++ b/southbound/device-factory/parser-csv/src/test/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/CSVParserTest.java
@@ -56,9 +56,9 @@ public class CSVParserTest {
     @BeforeEach
     void start() throws InterruptedException {
         deviceMapper = new FactoryParserHandler();
-        deviceMapper.prototypePush = Mockito.mock(DataUpdate.class);
+        deviceMapper.dataUpdate = Mockito.mock(DataUpdate.class);
 
-        Mockito.when(deviceMapper.prototypePush.pushUpdate(Mockito.any())).thenAnswer(i -> {
+        Mockito.when(deviceMapper.dataUpdate.pushUpdate(Mockito.any())).thenAnswer(i -> {
             final BulkGenericDto dto = i.getArgument(0, BulkGenericDto.class);
             bulks.add(dto);
             return Promises.resolved(dto);

--- a/southbound/device-factory/parser-csv/src/test/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/CSVParserTest.java
+++ b/southbound/device-factory/parser-csv/src/test/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/CSVParserTest.java
@@ -26,7 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import org.eclipse.sensinact.core.push.PrototypePush;
+import org.eclipse.sensinact.core.push.DataUpdate;
 import org.eclipse.sensinact.core.push.dto.BulkGenericDto;
 import org.eclipse.sensinact.core.push.dto.GenericDto;
 import org.eclipse.sensinact.gateway.geojson.Point;
@@ -56,7 +56,7 @@ public class CSVParserTest {
     @BeforeEach
     void start() throws InterruptedException {
         deviceMapper = new FactoryParserHandler();
-        deviceMapper.prototypePush = Mockito.mock(PrototypePush.class);
+        deviceMapper.prototypePush = Mockito.mock(DataUpdate.class);
 
         Mockito.when(deviceMapper.prototypePush.pushUpdate(Mockito.any())).thenAnswer(i -> {
             final BulkGenericDto dto = i.getArgument(0, BulkGenericDto.class);

--- a/southbound/device-factory/parser-json/src/test/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/JSONParserTest.java
+++ b/southbound/device-factory/parser-json/src/test/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/JSONParserTest.java
@@ -27,7 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import org.eclipse.sensinact.core.push.PrototypePush;
+import org.eclipse.sensinact.core.push.DataUpdate;
 import org.eclipse.sensinact.core.push.dto.BulkGenericDto;
 import org.eclipse.sensinact.core.push.dto.GenericDto;
 import org.eclipse.sensinact.gateway.geojson.Point;
@@ -56,7 +56,7 @@ public class JSONParserTest {
     @BeforeEach
     void start() throws InterruptedException {
         deviceMapper = new FactoryParserHandler();
-        deviceMapper.prototypePush = Mockito.mock(PrototypePush.class);
+        deviceMapper.prototypePush = Mockito.mock(DataUpdate.class);
 
         Mockito.when(deviceMapper.prototypePush.pushUpdate(Mockito.any())).thenAnswer(i -> {
             final BulkGenericDto dto = i.getArgument(0, BulkGenericDto.class);

--- a/southbound/device-factory/parser-json/src/test/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/JSONParserTest.java
+++ b/southbound/device-factory/parser-json/src/test/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/JSONParserTest.java
@@ -56,9 +56,9 @@ public class JSONParserTest {
     @BeforeEach
     void start() throws InterruptedException {
         deviceMapper = new FactoryParserHandler();
-        deviceMapper.prototypePush = Mockito.mock(DataUpdate.class);
+        deviceMapper.dataUpdate = Mockito.mock(DataUpdate.class);
 
-        Mockito.when(deviceMapper.prototypePush.pushUpdate(Mockito.any())).thenAnswer(i -> {
+        Mockito.when(deviceMapper.dataUpdate.pushUpdate(Mockito.any())).thenAnswer(i -> {
             final BulkGenericDto dto = i.getArgument(0, BulkGenericDto.class);
             bulks.add(dto);
             return Promises.resolved(dto);

--- a/southbound/history/timescale-provider/src/test/java/org/eclipse/sensinact/gateway/southbound/history/timescale/integration/TimescaleHistoryTest.java
+++ b/southbound/history/timescale-provider/src/test/java/org/eclipse/sensinact/gateway/southbound/history/timescale/integration/TimescaleHistoryTest.java
@@ -35,7 +35,7 @@ import org.eclipse.sensinact.core.command.AbstractSensinactCommand;
 import org.eclipse.sensinact.core.command.GatewayThread;
 import org.eclipse.sensinact.core.command.ResourceCommand;
 import org.eclipse.sensinact.core.model.SensinactModelManager;
-import org.eclipse.sensinact.core.push.PrototypePush;
+import org.eclipse.sensinact.core.push.DataUpdate;
 import org.eclipse.sensinact.core.push.dto.GenericDto;
 import org.eclipse.sensinact.core.twin.SensinactDigitalTwin;
 import org.eclipse.sensinact.core.twin.SensinactProvider;
@@ -117,7 +117,7 @@ public class TimescaleHistoryTest {
     }
 
     @InjectService
-    PrototypePush push;
+    DataUpdate push;
     @InjectService
     GatewayThread thread;
 

--- a/southbound/virtual/virtual-temperature-sensor/src/main/java/org/eclipse/sensinact/gateway/southbound/virtual/temperature/VirtualTemperatureSensor.java
+++ b/southbound/virtual/virtual-temperature-sensor/src/main/java/org/eclipse/sensinact/gateway/southbound/virtual/temperature/VirtualTemperatureSensor.java
@@ -15,7 +15,7 @@ package org.eclipse.sensinact.gateway.southbound.virtual.temperature;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.eclipse.sensinact.core.push.PrototypePush;
+import org.eclipse.sensinact.core.push.DataUpdate;
 import org.eclipse.sensinact.core.push.dto.GenericDto;
 import org.eclipse.sensinact.gateway.geojson.GeoJsonObject;
 import org.osgi.service.component.annotations.Deactivate;
@@ -23,7 +23,7 @@ import org.osgi.util.promise.Promise;
 
 public class VirtualTemperatureSensor {
 
-    private final PrototypePush push;
+    private final DataUpdate push;
 
     private final String name;
 
@@ -37,7 +37,7 @@ public class VirtualTemperatureSensor {
 
     private final AtomicBoolean active = new AtomicBoolean(true);
 
-    VirtualTemperatureSensor(PrototypePush push, String name, Random random, long interval, double min, double max,
+    VirtualTemperatureSensor(DataUpdate push, String name, Random random, long interval, double min, double max,
             GeoJsonObject location) throws Exception {
 
         this.push = push;

--- a/southbound/virtual/virtual-temperature-sensor/src/main/java/org/eclipse/sensinact/gateway/southbound/virtual/temperature/VirtualTemperatureSensorComponent.java
+++ b/southbound/virtual/virtual-temperature-sensor/src/main/java/org/eclipse/sensinact/gateway/southbound/virtual/temperature/VirtualTemperatureSensorComponent.java
@@ -16,7 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
-import org.eclipse.sensinact.core.push.PrototypePush;
+import org.eclipse.sensinact.core.push.DataUpdate;
 import org.eclipse.sensinact.gateway.geojson.Coordinates;
 import org.eclipse.sensinact.gateway.geojson.Point;
 import org.osgi.service.component.annotations.Activate;
@@ -46,7 +46,7 @@ public class VirtualTemperatureSensorComponent {
     }
 
     @Reference
-    PrototypePush push;
+    DataUpdate push;
 
     private Random random = new Random();
 


### PR DESCRIPTION
The PrototypePush name is clearly not appropriate now that the reworked sensiNact codebase has been merged into master. This commit changes it to the more appropriate DataUpdate.