### PR TITLE
Updates for SensorThings 

### DIFF
--- a/northbound/sensorthings/mqtt/src/main/java/org/eclipse/sensinact/gateway/northbount/sensorthings/mqtt/mappers/DatastreamMapper.java
+++ b/northbound/sensorthings/mqtt/src/main/java/org/eclipse/sensinact/gateway/northbount/sensorthings/mqtt/mappers/DatastreamMapper.java
@@ -67,7 +67,8 @@ public class DatastreamMapper extends DatastreamsMapper {
     @Override
     public Promise<Stream<Datastream>> toPayload(ResourceDataNotification notification) {
         // Force the required datastream if a relevant admin topic changes
-        return isRelevantAdminResource(notification) ? getDatastream(getResource(provider, service, resource))
+        return isRelevantAdminResource(notification)
+                ? getDatastream(getResource(provider, service, resource))
                 : emptyStream();
     }
 

--- a/northbound/sensorthings/mqtt/src/main/java/org/eclipse/sensinact/gateway/northbount/sensorthings/mqtt/mappers/DatastreamsMapper.java
+++ b/northbound/sensorthings/mqtt/src/main/java/org/eclipse/sensinact/gateway/northbount/sensorthings/mqtt/mappers/DatastreamsMapper.java
@@ -17,6 +17,7 @@ import java.util.stream.Stream;
 import org.eclipse.sensinact.core.command.GatewayThread;
 import org.eclipse.sensinact.core.notification.AbstractResourceNotification;
 import org.eclipse.sensinact.core.notification.LifecycleNotification;
+import org.eclipse.sensinact.core.notification.LifecycleNotification.Status;
 import org.eclipse.sensinact.core.notification.ResourceDataNotification;
 import org.eclipse.sensinact.core.notification.ResourceMetaDataNotification;
 import org.eclipse.sensinact.core.snapshot.ResourceSnapshot;
@@ -34,7 +35,7 @@ public class DatastreamsMapper extends SensorthingsMapper<Datastream> {
 
     @Override
     public Promise<Stream<Datastream>> toPayload(LifecycleNotification notification) {
-        if (notification.resource != null) {
+        if (notification.resource != null && notification.status != Status.RESOURCE_DELETED) {
             // This is a resource appearing
             return getDatastream(getResource(notification.provider, notification.service, notification.resource));
         }

--- a/northbound/sensorthings/mqtt/src/main/java/org/eclipse/sensinact/gateway/northbount/sensorthings/mqtt/mappers/ObservedPropertiesMapper.java
+++ b/northbound/sensorthings/mqtt/src/main/java/org/eclipse/sensinact/gateway/northbount/sensorthings/mqtt/mappers/ObservedPropertiesMapper.java
@@ -16,6 +16,7 @@ import java.util.stream.Stream;
 
 import org.eclipse.sensinact.core.command.GatewayThread;
 import org.eclipse.sensinact.core.notification.LifecycleNotification;
+import org.eclipse.sensinact.core.notification.LifecycleNotification.Status;
 import org.eclipse.sensinact.core.notification.ResourceMetaDataNotification;
 import org.eclipse.sensinact.core.snapshot.ResourceSnapshot;
 import org.eclipse.sensinact.gateway.northbount.sensorthings.mqtt.SensorthingsMapper;
@@ -32,7 +33,7 @@ public class ObservedPropertiesMapper extends SensorthingsMapper<ObservedPropert
 
     @Override
     public Promise<Stream<ObservedProperty>> toPayload(LifecycleNotification notification) {
-        if (notification.resource != null) {
+        if (notification.resource != null && notification.status != Status.RESOURCE_DELETED) {
             // This is a resource appearing
             return getObservedProperty(getResource(notification.provider, notification.service, notification.resource));
         }

--- a/northbound/sensorthings/mqtt/src/main/java/org/eclipse/sensinact/gateway/northbount/sensorthings/mqtt/mappers/SensorsMapper.java
+++ b/northbound/sensorthings/mqtt/src/main/java/org/eclipse/sensinact/gateway/northbount/sensorthings/mqtt/mappers/SensorsMapper.java
@@ -16,6 +16,7 @@ import java.util.stream.Stream;
 
 import org.eclipse.sensinact.core.command.GatewayThread;
 import org.eclipse.sensinact.core.notification.LifecycleNotification;
+import org.eclipse.sensinact.core.notification.LifecycleNotification.Status;
 import org.eclipse.sensinact.core.notification.ResourceMetaDataNotification;
 import org.eclipse.sensinact.core.snapshot.ResourceSnapshot;
 import org.eclipse.sensinact.gateway.northbount.sensorthings.mqtt.SensorthingsMapper;
@@ -32,7 +33,7 @@ public class SensorsMapper extends SensorthingsMapper<Sensor> {
 
     @Override
     public Promise<Stream<Sensor>> toPayload(LifecycleNotification notification) {
-        if (notification.resource != null) {
+        if (notification.resource != null && notification.status != Status.RESOURCE_DELETED) {
             // This is a resource appearing
             return getSensor(getResource(notification.provider, notification.service, notification.resource));
         }

--- a/northbound/sensorthings/mqtt/src/main/java/org/eclipse/sensinact/gateway/northbount/sensorthings/mqtt/mappers/ThingsMapper.java
+++ b/northbound/sensorthings/mqtt/src/main/java/org/eclipse/sensinact/gateway/northbount/sensorthings/mqtt/mappers/ThingsMapper.java
@@ -16,6 +16,7 @@ import java.util.stream.Stream;
 
 import org.eclipse.sensinact.core.command.GatewayThread;
 import org.eclipse.sensinact.core.notification.LifecycleNotification;
+import org.eclipse.sensinact.core.notification.LifecycleNotification.Status;
 import org.eclipse.sensinact.core.notification.ResourceDataNotification;
 import org.eclipse.sensinact.gateway.northbount.sensorthings.mqtt.SensorthingsMapper;
 import org.eclipse.sensinact.sensorthings.sensing.dto.Thing;
@@ -31,7 +32,7 @@ public class ThingsMapper extends SensorthingsMapper<Thing> {
 
     @Override
     public Promise<Stream<Thing>> toPayload(LifecycleNotification notification) {
-        if (notification.service == null) {
+        if (notification.service == null && notification.status != Status.PROVIDER_DELETED) {
             // This is a provider appearing
             return getThing(notification.provider);
         }


### PR DESCRIPTION
* Use a single Timescale container to test the REST gateway (requires #225). That speeds up tests and handles the table presence issues
* Wait for the REST API to be up & running before running tests
* MQTT: avoid getting providers/resources snapshots when notified of their deletion