### PR TITLE
Added configuration files for ReadTheDocs builds

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -49,6 +49,7 @@ header:
     - '.github/**'
     - '.gitignore'
     - '.licenserc.yaml'
+    - '.readthedocs.yaml'
     - '**/.project'
     - '**/*.prefs'
     - 'license.templates'

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,20 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+formats:
+  - pdf
+  - htmlzip
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+  configuration: docs/source/conf.py
+
+python:
+  install:
+    - requirements: docs/requirements.txt


### PR DESCRIPTION
This file is used by ReadTheDocs to configure the build, as it's not possible in the RTD project anymore.
The RTD build trigger (WebHook or CI action) is not set up yet, an issue has been created on Eclipse HelpDesk for that.