### PR TITLE
Use String instead of char[] for password configuration

### DIFF
--- a/southbound/mqtt/mqtt-client/src/main/java/org/eclipse/sensinact/gateway/southbound/mqtt/impl/MqttClientConfiguration.java
+++ b/southbound/mqtt/mqtt-client/src/main/java/org/eclipse/sensinact/gateway/southbound/mqtt/impl/MqttClientConfiguration.java
@@ -60,5 +60,5 @@ public @interface MqttClientConfiguration {
     /**
      * MQTT authentication password
      */
-    char[] _password();
+    String _password();
 }

--- a/southbound/mqtt/mqtt-client/src/main/java/org/eclipse/sensinact/gateway/southbound/mqtt/impl/MqttClientHandler.java
+++ b/southbound/mqtt/mqtt-client/src/main/java/org/eclipse/sensinact/gateway/southbound/mqtt/impl/MqttClientHandler.java
@@ -126,9 +126,9 @@ public class MqttClientHandler implements MqttCallback {
             options.setUserName(userName);
         }
 
-        final char[] userPass = config._password();
+        final String userPass = config._password();
         if (userPass != null) {
-            options.setPassword(userPass);
+            options.setPassword(userPass.toCharArray());
         }
 
         // Start client (blocking)
@@ -151,7 +151,9 @@ public class MqttClientHandler implements MqttCallback {
     @Deactivate
     public void deactivate() throws Exception {
         if (client != null) {
-            client.disconnect();
+            if (client.isConnected()) {
+                client.disconnect();
+            }
             client.close();
             logger.info("MQTT client {} stopped", client.getClientId());
             client = null;

--- a/southbound/mqtt/mqtt-client/src/test/java/org/eclipse/sensinact/gateway/southbound/mqtt/test/MqttAuthTest.java
+++ b/southbound/mqtt/mqtt-client/src/test/java/org/eclipse/sensinact/gateway/southbound/mqtt/test/MqttAuthTest.java
@@ -113,7 +113,7 @@ public class MqttAuthTest {
         Mockito.when(mock.port()).thenReturn(2183);
         Mockito.when(mock.topics()).thenReturn(topics);
         Mockito.when(mock.user()).thenReturn(user);
-        Mockito.when(mock._password()).thenReturn(password != null ? password.toCharArray() : null);
+        Mockito.when(mock._password()).thenReturn(password != null ? password : null);
         handler.activate(mock);
         return handler;
     }


### PR DESCRIPTION
The password field is always null if of type char[]. It is loaded correctly as a String.