### PR TITLE
Fix variables handling in the Device Factory

### DIFF
--- a/docs/source/southbound/device-factory/core.md
+++ b/docs/source/southbound/device-factory/core.md
@@ -258,6 +258,50 @@ We will have the provider friendly name set to "Thomas" and the "greet" service 
 * "hello": "Hello Thomas!"
 * "bye": "Bye Thomas!"
 
+### Variables
+
+Variables are defined using the `$` prefix and no brackets (`{`, `}`).
+They can be given a literal value or a value from the record.
+
+Here are some example of variable definitions:
+```json
+{
+    "$rc_value": "data", // ${rc_value} = <value in the "data" path>
+    "$rc_value.2": {
+        "path": "data"
+        // ${rc_value.2} = <value in the "data" path>
+    },
+    "$svcName": {
+        "literal": "service"
+        // "${svcName}" = "service"
+    },
+    "$rcName": {
+        "literal": "rc"
+        // "${rcName}" = "rc"
+    },
+    "$rcValuePath" {
+        "literal": "data"
+        // "${rcValuePath}" = "data"
+    }
+    // ...
+}
+```
+
+The variables can then be used both in the record paths or in the mapping definition.
+Note that unlike other mappings, which are considered as path by default, variables are considered as literals.
+
+For example:
+```json
+{
+    // ...
+    "${svcName}/${rcName}-txt": "${rcValuePath}", // service/rc-txt = "data"
+    "${svcName}/${rcName}-value":{
+        "path": "${rcValuePath}"
+        // service/rc-value = <value in the "data" path>
+    }
+}
+```
+
 ## Mapping options
 
 The device factory mapper itself can be fine-tuned with the `mapping.options` entry.

--- a/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/FactoryParserHandler.java
+++ b/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/FactoryParserHandler.java
@@ -396,8 +396,8 @@ public class FactoryParserHandler implements IDeviceMappingHandler, IPlaceHolder
             if (key.startsWith("@")) {
                 // Placeholder
                 placeholders.put(key, mapping);
-            } else if (key.startsWith("$")) {
-                // Variable
+            } else if (key.startsWith("$") && !key.startsWith("${")) {
+                // Variable definition
                 if (VariableSolver.isValidKey(key)) {
                     variablesMappings.put(key, mapping);
                 } else {

--- a/southbound/device-factory/device-factory-core/src/test/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/RecordHandlingTest.java
+++ b/southbound/device-factory/device-factory-core/src/test/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/RecordHandlingTest.java
@@ -282,4 +282,32 @@ public class RecordHandlingTest {
         assertEquals(NullAction.IGNORE, dto.nullAction);
         assertEquals(42, dto.value);
     }
+
+    @Test
+    void testVariableService() throws Exception {
+        final DeviceMappingConfigurationDTO config = prepareConfig();
+
+        // Set a record
+        final Map<String, Object> record = new HashMap<>();
+        record.put("rc_provider", "provider");
+        record.put("rc_name", "rc");
+        record.put("rc_value", 42);
+        parser.setRecords(record);
+
+        // Set a context
+        final Map<String, String> context = new HashMap<>();
+        context.put("ctx", "svc");
+
+        // Setup mapping
+        config.mapping.put("@provider", "rc_provider");
+        config.mapping.put("$service", "${context.ctx}");
+        config.mapping.put("$resource", "rc_name");
+        config.mapping.put("${service}/${resource}", "rc_value");
+
+        // Parse
+        deviceMapper.handle(config, context, new byte[0]);
+
+        // Test values
+        assertEquals(42, getResourceValue("provider", "svc", "rc").value);
+    }
 }


### PR DESCRIPTION
The device factory was considering record path `${service}/${resource}` as a variable definition as it starts with `$`.
Behaviour is fixed and documentation has been updated to have more details on how to use variables.