### PR TITLE
[BREAKING] Device Factory enhancements

### DIFF
--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -332,8 +332,8 @@ Here is the configuration of the HTTP device factory, where we declare a periodi
     "utc_offset_seconds": 0
   }
   ```
-* maps the response JSON as follows:
-   * the result is associated to a fixed provider name: `grenoble-weather`. `@Provider` is a special placeholder to name the provider that holds the data we received, this is the only mandatory field in a mapping definition.
+* will map the response JSON as follows:
+   * the result is associated to a fixed provider name: `grenoble_weather`. `@Provider` is a special placeholder to name the provider that holds the data we received, this is the only mandatory field in a mapping definition. Note that model, provider, service and resource names are normalized before being transmitted to the Eclipse sensiNact model. See [here](./southbound/device-factory/core.md#names-handling) for more information.
    * the provider friendly (human readable) name will be: `Grenoble Weather`. It is stored using the `@Name` placeholder.
    * the exact location of the weather data point is given by its latitude, longitude and elevation.
    * the weather was measured/computed at the time given in the `time` entry of the `current_weather` object. The timestamp is given as an [ISO 8601 date time](https://en.wikipedia.org/wiki/ISO_8601) (in UTC timezone), that can be given to the device factory using `@datetime` placeholder. Other time-related placeholders are: `@Date`, `@Time` and `@Timestamp` (for Unix timestamps).
@@ -353,7 +353,7 @@ Here is the configuration of the HTTP device factory, where we declare a periodi
             "parser": "json",
             "mapping": {
               "@provider": {
-                "literal": "grenoble-weather"
+                "literal": "grenoble_weather"
               },
               "@name": {
                 "literal": "Grenoble Weather"
@@ -366,15 +366,15 @@ Here is the configuration of the HTTP device factory, where we declare a periodi
                 "path": "current_weather/temperature",
                 "type": "float"
               },
-              "weather/wind-speed": {
+              "weather/wind_speed": {
                 "path": "current_weather/windspeed",
                 "type": "float"
               },
-              "weather/wind-direction": {
+              "weather/wind_direction": {
                 "path": "current_weather/winddirection",
                 "type": "int"
               },
-              "weather/weather-code": "current_weather/weathercode"
+              "weather/weather_code": "current_weather/weathercode"
             }
           }
         }
@@ -391,7 +391,6 @@ You can (re)start the configured sensiNact instance, using `./start.sh`
 :::{note}
 On Windows, that would be:
 ```powershell
-
 & java -D"sensinact.config.dir=configuration" -jar launch\launcher.jar
 ```
 :::
@@ -399,13 +398,12 @@ On Windows, that would be:
 The current temperature at Grenoble should now be accessible using:
 
 ```bash
-curl http://localhost:8082/sensinact/providers/grenoble-weather/services/weather/resources/temperature/GET
+curl http://localhost:8082/sensinact/providers/grenoble_weather/services/weather/resources/temperature/GET
 ```
 
 And the result will have the following format:
 
 ```json
-
 {
   "response": {
     "name": "temperature",
@@ -415,6 +413,6 @@ And the result will have the following format:
   },
   "statusCode": 200,
   "type": "GET_RESPONSE",
-  "uri": "/grenoble-weather/weather/temperature"
+  "uri": "/grenoble_weather/weather/temperature"
 }
 ```

--- a/docs/source/southbound/device-factory/csv.md
+++ b/docs/source/southbound/device-factory/csv.md
@@ -38,8 +38,8 @@ Here are the paths that can be used:
 
 The CSV parser has the ID `csv`.
 It accepts the following options:
-* `encoding`: the payload encoding, as supported by [`java.nio.charset.Charset`](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/charset/Charset.html), *e.g.* `"UTF-8"`, `"latin-1"`.
-* `delimiter`: the CSV delimiter character, *e.g.* ",", ";", "\t".
+* `encoding`: the payload encoding, as supported by [`java.nio.charset.Charset`](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/charset/Charset.html), *e.g.* `"UTF-8"` (default), `"latin-1"`.
+* `delimiter`: the CSV delimiter character, *e.g.* `,` (default), `;` or `\t`.
 * `header`: a boolean flag to indicate if the CSV payload has a header
 
 ## Example
@@ -55,6 +55,8 @@ Here is an example configuration to parse that payload:
 {
   "parser": "csv",
   "parser.options": {
+    "encoding": "UTF-8",
+    "delimiter": ",",
     "header": true
   },
   "mapping": {

--- a/docs/source/southbound/device-factory/tuto-parser.md
+++ b/docs/source/southbound/device-factory/tuto-parser.md
@@ -617,7 +617,7 @@ Then we configure the MQTT device factory and tell it to use our parser by a con
     "mapping": {
       "$name": "provider",
       "@provider": {
-          "literal": "sensor-${name}"
+          "literal": "sensor_${name}"
         },
         "@name": {
           "literal": "Sensor ${name}"
@@ -653,18 +653,18 @@ With those configurations, the parser will be called by the device factory core 
    **Note:** Each mapping configuration must at least contain the `@Provider` placeholder. Each record must therefore handle a path that returns a provider name.
 
    The result will be the update/creation of the following providers:
-   * `sensor-a`
-   * `admin`
+   * `sensor_a`
+     * `admin`
        * `location`: `null` @ 2023-06-20T13:40:00+0200
        * `friendlyName`: `"Sensor a"` @ 2023-06-20T13:40:00+0200
-   * `sensor`:
+     * `sensor`:
        * `temperature`: 40.0 @ 2023-06-20T13:40:00+0200
        * `humidity`: 0.0 @ 2023-06-20T13:40:00+0200
-   * `sensor-c`
-   * `admin`
+   * `sensor_c`
+     * `admin`
        * `location`: `null` @ 2023-06-20T13:40:00+0200
        * `friendlyName`: `"Sensor c"` @ 2023-06-20T13:40:00+0200
-   * `sensor`:
+     * `sensor`:
        * `temperature`: 38.0 @ 2023-06-20T13:40:00+0200
        * `humidity`: 15.0 @ 2023-06-20T13:40:00+0200
 7. Now consider a second payload:
@@ -677,21 +677,21 @@ With those configurations, the parser will be called by the device factory core 
    ```
 
    Following the same steps as before, the providers will be updated as:
-   * `sensor-a`
+   * `sensor_a`
      * `admin`
        * `location`: `null` @ 2023-06-20T13:40:00+0200
        * `friendlyName`: `"Sensor a"` @ 2023-06-20T13:50:00+0200
      * `sensor`:
        * `temperature`: 42.0 @ 2023-06-20T13:50:00+0200
        * `humidity`: 0.0 @ 2023-06-20T13:50:00+0200
-   * `sensor-b`
+   * `sensor_b`
      * `admin`
        * `location`: `null` @ 2023-06-20T13:50:00+0200
        * `friendlyName`: `"Sensor b"` @ 2023-06-20T13:50:00+0200
      * `sensor`:
        * `temperature`: 21.0 @ 2023-06-20T13:50:00+0200
        * `humidity`: 30.0 @ 2023-06-20T13:50:00+0200
-   * `sensor-c`
+   * `sensor_c`
      * `admin`
        * `location`: `null` 2023-06-20T13:40:00+0200
        * `friendlyName`: `"Sensor c"` @ 2023-06-20T13:50:00+0200
@@ -740,7 +740,7 @@ This will ensure it is visible by other Maven projects and ease the creation of 
           "mapping": {
             "$name": "provider",
             "@provider": {
-              "literal": "sensor-${name}"
+              "literal": "sensor_${name}"
             },
             "@name": {
               "literal": "Sensor ${name}"
@@ -802,7 +802,7 @@ After all those steps, the configuration file `${SENSINACT_HOME}/configuration/c
       "mapping": {
         "$name": "provider",
         "@provider": {
-          "literal": "sensor-${name}"
+          "literal": "sensor_${name}"
         },
         "@name": {
           "literal": "Sensor ${name}"
@@ -830,10 +830,10 @@ After all those steps, the configuration file `${SENSINACT_HOME}/configuration/c
 * To check the value of a resource, you can use any HTTP client (`curl`, `httPIE`, a browser...).
   With the payload we will send via MQTT, below are the URLs where we will find our resources values.
   Note that accessing those URLs before sending any data will return 404 errors.
-  * <http://localhost:8080/sensinact/providers/sensor-a/services/sensor/resources/temperature/GET>
-  * <http://localhost:8080/sensinact/providers/sensor-a/services/sensor/resources/humidity/GET>
-  * <http://localhost:8080/sensinact/providers/sensor-b/services/sensor/resources/temperature/GET>
-  * <http://localhost:8080/sensinact/providers/sensor-b/services/sensor/resources/humidity/GET>
+  * <http://localhost:8080/sensinact/providers/sensor_a/services/sensor/resources/temperature/GET>
+  * <http://localhost:8080/sensinact/providers/sensor_a/services/sensor/resources/humidity/GET>
+  * <http://localhost:8080/sensinact/providers/sensor_b/services/sensor/resources/temperature/GET>
+  * <http://localhost:8080/sensinact/providers/sensor_b/services/sensor/resources/humidity/GET>
 
 * To send messages, we will use the [MQTT dashboard websocket client](https://www.hivemq.com/demos/websocket-client/):
   1. Connect the broker using the default configuration

--- a/docs/source/southbound/http/http-device-factory.md
+++ b/docs/source/southbound/http/http-device-factory.md
@@ -58,7 +58,7 @@ Here is an example of configuration for HTTP device factory that will get the de
         "mapping": {
           "$station_id": "station_id",
           "@provider": {
-            "literal": "cycling-${station_id}"
+            "literal": "cycling_${station_id}"
           },
           "@name": "name",
           "@latitude": "lat",
@@ -80,7 +80,7 @@ Here is an example of configuration for HTTP device factory that will get the de
         "mapping": {
           "$station_id": "station_id",
           "@provider": {
-            "literal": "cycling-${station_id}"
+            "literal": "cycling_${station_id}"
           },
           "station/active": "is_installed",
           "station/stationCode": "stationCode",

--- a/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/IResourceMapping.java
+++ b/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/IResourceMapping.java
@@ -64,8 +64,10 @@ public interface IResourceMapping {
      * Returns a copy of this mapping with a path that meets the sensiNact naming
      * requirements
      *
+     * @param asciiOnly If true, the path must only contain letters, digits and
+     *                  underscores
      * @return This object if the key was valid or a new one with a new path
      * @throws InvalidResourcePathException Invalid new resource path
      */
-    IResourceMapping ensureValidPath() throws InvalidResourcePathException;
+    IResourceMapping ensureValidPath(final boolean asciiOnly) throws InvalidResourcePathException;
 }

--- a/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/dto/DeviceMappingOptionsDTO.java
+++ b/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/dto/DeviceMappingOptionsDTO.java
@@ -38,4 +38,7 @@ public class DeviceMappingOptionsDTO {
 
     @JsonProperty("null.action")
     public NullAction nullAction = NullAction.UPDATE;
+
+    @JsonProperty("names.ascii")
+    public boolean asciiNames;
 }

--- a/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/dto/DeviceMappingOptionsDTO.java
+++ b/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/dto/DeviceMappingOptionsDTO.java
@@ -40,5 +40,8 @@ public class DeviceMappingOptionsDTO {
     public NullAction nullAction = NullAction.UPDATE;
 
     @JsonProperty("names.ascii")
-    public boolean asciiNames;
+    public boolean asciiNames = false;
+
+    @JsonProperty("model.raw")
+    public boolean useRawModel = false;
 }

--- a/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/AbstractResourceMapping.java
+++ b/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/AbstractResourceMapping.java
@@ -100,6 +100,7 @@ public abstract class AbstractResourceMapping implements IResourceMapping {
     /**
      * Returns the name of the service
      */
+    @Override
     public String getService() {
         return service;
     }
@@ -107,6 +108,7 @@ public abstract class AbstractResourceMapping implements IResourceMapping {
     /**
      * Returns the name of the resource
      */
+    @Override
     public String getResource() {
         return resource;
     }
@@ -114,6 +116,7 @@ public abstract class AbstractResourceMapping implements IResourceMapping {
     /**
      * Returns the name of the metadata, if any
      */
+    @Override
     public String getMetadata() {
         return metadata;
     }
@@ -121,6 +124,7 @@ public abstract class AbstractResourceMapping implements IResourceMapping {
     /**
      * Checks if this mapping targets a metadata
      */
+    @Override
     public boolean isMetadata() {
         return metadata != null;
     }
@@ -128,18 +132,24 @@ public abstract class AbstractResourceMapping implements IResourceMapping {
     /**
      * Returns the resource path
      */
+    @Override
     public String getResourcePath() {
         return path;
     }
 
     @Override
-    public IResourceMapping ensureValidPath() throws InvalidResourcePathException {
-        if (service == null) {
+    public IResourceMapping ensureValidPath(final boolean asciiOnly) throws InvalidResourcePathException {
+        if (path == null) {
             // Not a path
             return this;
         }
 
-        final String cleaned = NamingUtils.sanitizeName(path, true);
+        final String cleaned;
+        if (asciiOnly) {
+            cleaned = NamingUtils.asciiSanitizeName(path, true);
+        } else {
+            cleaned = NamingUtils.sanitizeName(path, true);
+        }
         if (cleaned.equals(path)) {
             // Nothing to do
             return this;

--- a/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/FactoryParserHandler.java
+++ b/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/FactoryParserHandler.java
@@ -281,6 +281,8 @@ public class FactoryParserHandler implements IDeviceMappingHandler, IPlaceHolder
             final String rawModel = getFieldString(record, recordState.placeholders.get(KEY_MODEL), options);
             if (rawModel == null || rawModel.isBlank()) {
                 throw new ParserException("Empty model field for " + provider);
+            } else if (configuration.mappingOptions.useRawModel) {
+                model = rawModel;
             } else if (configuration.mappingOptions.asciiNames) {
                 model = NamingUtils.asciiSanitizeName(rawModel, false);
             } else {

--- a/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/NamingUtils.java
+++ b/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/NamingUtils.java
@@ -1,5 +1,5 @@
 /*********************************************************************
-* Copyright (c) 2023 Contributors to the Eclipse Foundation.
+* Copyright (c) 2024 Contributors to the Eclipse Foundation.
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0
@@ -12,24 +12,110 @@
 **********************************************************************/
 package org.eclipse.sensinact.gateway.southbound.device.factory.impl;
 
+import java.text.Normalizer;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 /**
- *
+ * Handles model, provider, service and resource names from the user
  */
 public class NamingUtils {
 
-    public static String sanitizeName(final String name, final boolean isPath) {
-        if (name == null) {
+    /**
+     * List of Java keywords according to its specification
+     */
+    public static final String[] keywords = { "abstract", "continue", "for", "new", "switch", "assert", "default", "if",
+            "package", "synchronized", "boolean", "do", "goto", "private", "this", "break", "double", "implements",
+            "protected", "throw", "byte", "else", "import", "public", "throws", "case", "enum", "instanceof", "return",
+            "transient", "catch", "extends", "int", "short", "try", "char", "final", "interface", "static", "void",
+            "class", "finally", "long", "strictfp", "volatile", "const", "float", "native", "super", "while" };
+
+    static {
+        // Final array can be sorted (in-place sort)
+        Arrays.sort(keywords);
+    }
+
+    /**
+     * Checks if the given name is a Java keyword
+     *
+     * @param name Name to test
+     * @return True if the given name is a Java keyword
+     */
+    public static boolean isJavaKeyword(final String name) {
+        return Arrays.binarySearch(keywords, name) >= 0;
+    }
+
+    /**
+     * Ensures that the given name is only based on ASCII letters, digits and the
+     * underscore
+     *
+     * @param name   Input name
+     * @param isPath Flag to allow slashes (<code>/</code>) in the name
+     * @return A name that contains only ASCII letters, digits or underscore, or
+     *         null if the input is empty or null
+     */
+    public static String asciiSanitizeName(final String name, final boolean isPath) {
+        if (name == null || name.isBlank()) {
             return null;
         }
 
-        final String rejectedPattern;
         if (isPath) {
-            // Allow slash in path
-            rejectedPattern = "[^-A-Za-z0-9/]";
+            // Treat each part separately then join everything
+            return Arrays.stream(name.split("/")).map(p -> asciiSanitizeName(p, false))
+                    .collect(Collectors.joining("/"));
         } else {
-            rejectedPattern = "[^-A-Za-z0-9]";
+            // Normalize diacritics
+            final String normalized = Normalizer.normalize(name.strip(), Normalizer.Form.NFKD).replaceAll("\\p{M}", "");
+            final String sanitized;
+            if (normalized.isEmpty()) {
+                // All characters were invalid, create a name with as many underscores as input
+                // characters
+                sanitized = name.replaceAll(".", "_");
+            } else {
+                // Replace all non acceptable characters with an underscore
+                sanitized = normalized.replaceAll("[^_A-Za-z0-9]", "_");
+            }
+
+            if (sanitized.isEmpty()) {
+                return "_";
+            } else if (!Character.isJavaIdentifierStart(sanitized.charAt(0)) || isJavaKeyword(name)) {
+                // Make sure we don't start with an invalid character
+                return "_" + sanitized;
+            } else {
+                return sanitized;
+            }
+        }
+    }
+
+    /**
+     * Ensures the given name is accepted as a Java identifier
+     *
+     * @param name   Input name
+     * @param isPath Flag to allow slashes (<code>/</code>) in the name
+     * @return A name that can be used as Java identifier, or null if the input is
+     *         empty or null
+     */
+    public static String sanitizeName(final String name, final boolean isPath) {
+        if (name == null || name.isBlank()) {
+            return null;
         }
 
-        return name.replaceAll(rejectedPattern, "-");
+        if (isPath) {
+            // Treat each part separately then join everything
+            return Arrays.stream(name.split("/")).map(p -> sanitizeName(p, false)).collect(Collectors.joining("/"));
+        } else {
+            // Replace invalid Java identifier letters
+            final String sanitized = name.strip().chars().mapToObj(
+                    c -> Character.isJavaIdentifierPart(c) || (isPath && c == '/') ? Character.toString((char) c) : "_")
+                    .collect(Collectors.joining());
+            if (sanitized.isEmpty()) {
+                return "_";
+            } else if (!Character.isJavaIdentifierStart(sanitized.charAt(0)) || isJavaKeyword(name)) {
+                // Make sure we don't start with an invalid character
+                return "_" + sanitized;
+            } else {
+                return sanitized;
+            }
+        }
     }
 }

--- a/southbound/device-factory/device-factory-core/src/test/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/RecordHandlingTest.java
+++ b/southbound/device-factory/device-factory-core/src/test/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/RecordHandlingTest.java
@@ -378,4 +378,29 @@ public class RecordHandlingTest {
         assertEquals(value, getResourceValue(provider, "_Greek", "________", Integer.class));
         assertEquals(value, getResourceValue(provider, "_int", "_finally", Integer.class));
     }
+
+    @Test
+    void testRawModel() throws Exception {
+        final String rawModel = "http://user:test@some.emf.model:8080/model.xml?format=emf#";
+        final String provider = "provider";
+        parser.setRecords(Map.of("m", rawModel, "p", provider));
+
+        // Test with an escaped model
+        final DeviceMappingConfigurationDTO config = prepareConfig();
+        config.mappingOptions.useRawModel = false;
+        config.mapping.put("@model", "m");
+        config.mapping.put("@provider", "p");
+        config.mapping.put("@name", "p");
+        deviceMapper.handle(config, Map.of(), new byte[0]);
+
+        GenericDto dto = getResourceValue(provider, "admin", "friendlyName");
+        assertEquals("http___user_test_some_emf_model_8080_model_xml_format_emf_", dto.model);
+
+        // Test with a raw model
+        bulks.clear();
+        config.mappingOptions.useRawModel = true;
+        deviceMapper.handle(config, Map.of(), new byte[0]);
+        dto = getResourceValue(provider, "admin", "friendlyName");
+        assertEquals(rawModel, dto.model);
+    }
 }

--- a/southbound/device-factory/parser-csv/src/test/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/CSVParserTest.java
+++ b/southbound/device-factory/parser-csv/src/test/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/CSVParserTest.java
@@ -141,8 +141,8 @@ public class CSVParserTest {
     @Test
     void testNoHeader() throws Exception {
         // Excepted providers
-        final String provider1 = "no-header-provider1";
-        final String provider2 = "no-header-provider2";
+        final String provider1 = "no_header_provider1";
+        final String provider2 = "no_header_provider2";
 
         // Read the configuration
         DeviceMappingConfigurationDTO config = readConfiguration("csv/csv-no-header-mapping.json");
@@ -188,8 +188,8 @@ public class CSVParserTest {
     @Test
     void testWithHeader() throws Exception {
         // Excepted providers
-        final String provider1 = "header-provider1";
-        final String provider2 = "header-provider2";
+        final String provider1 = "header_provider1";
+        final String provider2 = "header_provider2";
 
         // Read the configuration
         DeviceMappingConfigurationDTO config = readConfiguration("csv/csv-header-mapping.json");
@@ -235,8 +235,8 @@ public class CSVParserTest {
     @Test
     void testTyped() throws Exception {
         // Excepted providers
-        final String provider1 = "typed-provider1";
-        final String provider2 = "typed-provider2";
+        final String provider1 = "typed_provider1";
+        final String provider2 = "typed_provider2";
 
         // Read the configuration
         DeviceMappingConfigurationDTO config = readConfiguration("csv/csv-header-typed-mapping.json");
@@ -282,9 +282,9 @@ public class CSVParserTest {
     @Test
     void testLiteral() throws Exception {
         // Excepted providers
-        final String provider1 = "literal-provider1";
-        final String provider2 = "literal-provider2";
-        final String literalProvider = "literal-provider";
+        final String provider1 = "literal_provider1";
+        final String provider2 = "literal_provider2";
+        final String literalProvider = "literal_provider";
 
         // Read the configuration
         DeviceMappingConfigurationDTO config = readConfiguration("csv/csv-literal-typed-mapping.json");
@@ -323,7 +323,7 @@ public class CSVParserTest {
     @Test
     void testIsolatedValue() throws Exception {
         // Excepted provider
-        final String provider = "isolated-value-" + String.valueOf(new Random().nextInt());
+        final String provider = "isolated_value_" + String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
 
         // Read the configuration
         DeviceMappingConfigurationDTO config = readConfiguration("csv/isolated-value-mapping.json");
@@ -345,7 +345,7 @@ public class CSVParserTest {
     @Test
     void testIsolatedValueTyped() throws Exception {
         // Excepted provider
-        final String provider = "isolated-value-" + String.valueOf(new Random().nextInt());
+        final String provider = "isolated_value_" + String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
 
         // Read the configuration
         DeviceMappingConfigurationDTO config = readConfiguration("csv/isolated-value-mapping-typed.json");
@@ -366,9 +366,9 @@ public class CSVParserTest {
     @Test
     void testVariables() throws Exception {
         // Excepted resource
-        final String provider = "provider-vars-" + String.valueOf(new Random().nextInt());
-        final String service = "svc-vars-" + String.valueOf(new Random().nextInt());
-        final String resource = "rc-vars-" + String.valueOf(new Random().nextInt());
+        final String provider = "provider_vars_" + String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
+        final String service = "svc_vars_" + String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
+        final String resource = "rc_vars_" + String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
 
         // Read the configuration
         DeviceMappingConfigurationDTO config = readConfiguration("csv/csv-no-header-vars-mapping.json");

--- a/southbound/device-factory/parser-json/src/test/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/JSONParserTest.java
+++ b/southbound/device-factory/parser-json/src/test/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/JSONParserTest.java
@@ -220,7 +220,7 @@ public class JSONParserTest {
         // Excepted providers
         final String provider1 = "JsonSubArray1";
         final String provider2 = "JsonSubArray2";
-        final String ignoredProvider = "JsonSubArray-Ignore";
+        final String ignoredProvider = "JsonSubArray_Ignore";
 
         // Read the configuration
         DeviceMappingConfigurationDTO config = readConfiguration("json/sub-array-mapping.json");
@@ -286,7 +286,7 @@ public class JSONParserTest {
 
         // Ensure value and type
         assertEquals(15, getResourceValue(provider, "data", "value", Integer.class));
-        assertEquals(1691587953000L, getResourceValue(provider, "data", "long-value", Long.class));
+        assertEquals(1691587953000L, getResourceValue(provider, "data", "long_value", Long.class));
 
         // Ensure timestamp
         Instant timestamp = Instant.from(LocalDateTime.of(2022, 12, 7, 15, 17, 0).atOffset(ZoneOffset.UTC));
@@ -328,9 +328,9 @@ public class JSONParserTest {
     void testDeepObjects() throws Exception {
 
         // Expected providers
-        final String provider1 = "1452";
+        final String provider1 = "_1452";
         final String type1 = "GOOSE";
-        final String provider2 = "1851";
+        final String provider2 = "_1851";
         final String type2 = "DUCK";
 
         // Read the configuration
@@ -343,11 +343,11 @@ public class JSONParserTest {
         deviceMapper.handle(config, Map.of(), fileContent);
 
         // Check first provider
-        assertEquals(0, getResourceValue(provider1, "data", type1 + "-value", Integer.class));
+        assertEquals(0, getResourceValue(provider1, "data", type1 + "_value", Integer.class));
 
         // Ensure timestamp
         Instant timestamp = Instant.from(LocalDateTime.of(2021, 10, 26, 15, 28, 0).atOffset(ZoneOffset.UTC));
-        assertEquals(timestamp, getResourceValue(provider1, "data", type1 + "-value").timestamp);
+        assertEquals(timestamp, getResourceValue(provider1, "data", type1 + "_value").timestamp);
 
         // Ensure location update (and its timestamp)
         GenericDto location = getResourceValue(provider1, "admin", "location");
@@ -360,11 +360,11 @@ public class JSONParserTest {
         assertTrue(Double.isNaN(geoPoint.coordinates.elevation));
 
         // Check 2nd provider
-        assertEquals(7, getResourceValue(provider2, "data", type2 + "-value", Integer.class));
+        assertEquals(7, getResourceValue(provider2, "data", type2 + "_value", Integer.class));
 
         // Ensure timestamp
         timestamp = Instant.from(LocalDateTime.of(2021, 10, 26, 15, 27, 0).atOffset(ZoneOffset.UTC));
-        assertEquals(timestamp, getResourceValue(provider2, "data", type2 + "-value").timestamp);
+        assertEquals(timestamp, getResourceValue(provider2, "data", type2 + "_value").timestamp);
 
         // Ensure location update (and its timestamp)
         location = getResourceValue(provider2, "admin", "location");

--- a/southbound/http/http-device-factory/integration-test.bndrun
+++ b/southbound/http/http-device-factory/integration-test.bndrun
@@ -59,7 +59,6 @@
 	org.gecko.emf.osgi.api;version='[5.0.0,5.0.1)',\
 	org.gecko.emf.osgi.component;version='[5.0.0,5.0.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
-	org.osgi.service.cm;version='[1.6.1,1.6.2)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	org.osgi.service.typedevent;version='[1.0.0,1.0.1)',\
 	org.osgi.test.common;version='[1.2.1,1.2.2)',\

--- a/southbound/http/http-device-factory/src/test/java/org/eclipse/sensinact/gateway/southbound/http/factory/integration/HttpDeviceFactoryAuthTest.java
+++ b/southbound/http/http-device-factory/src/test/java/org/eclipse/sensinact/gateway/southbound/http/factory/integration/HttpDeviceFactoryAuthTest.java
@@ -130,7 +130,7 @@ public class HttpDeviceFactoryAuthTest {
     @Test
     void testCombined() throws Exception {
         // Excepted providers
-        final String providerBase = "auth-station";
+        final String providerBase = "auth_station";
         final String provider1 = providerBase + "1";
         final String provider2 = providerBase + "2";
 

--- a/southbound/http/http-device-factory/src/test/java/org/eclipse/sensinact/gateway/southbound/http/factory/integration/HttpDeviceFactoryParallelQueries.java
+++ b/southbound/http/http-device-factory/src/test/java/org/eclipse/sensinact/gateway/southbound/http/factory/integration/HttpDeviceFactoryParallelQueries.java
@@ -131,8 +131,8 @@ public class HttpDeviceFactoryParallelQueries {
     @Test
     void testParallelQuery() throws Exception {
         // Setup server
-        final String provider1 = "http-parallel-query1";
-        final String provider2 = "http-parallel-query2";
+        final String provider1 = "http_parallel_query1";
+        final String provider2 = "http_parallel_query2";
         final int value1 = 42;
         final int value2 = 21;
 

--- a/southbound/http/http-device-factory/src/test/java/org/eclipse/sensinact/gateway/southbound/http/factory/integration/HttpDeviceFactorySSLTest.java
+++ b/southbound/http/http-device-factory/src/test/java/org/eclipse/sensinact/gateway/southbound/http/factory/integration/HttpDeviceFactorySSLTest.java
@@ -228,7 +228,7 @@ public class HttpDeviceFactorySSLTest {
         startServer(false);
 
         // Excepted providers
-        final String provider1 = "ssl-reject-provider1";
+        final String provider1 = "ssl_reject_provider1";
 
         // Register listener
         session.addListener(List.of(provider1 + "/*"), (t, e) -> queue.offer(e), null, null, null);
@@ -263,7 +263,7 @@ public class HttpDeviceFactorySSLTest {
         startServer(false);
 
         // Excepted providers
-        final String provider1 = "ssl-allowed-provider1";
+        final String provider1 = "ssl_allowed_provider1";
 
         // Register listener
         session.addListener(List.of(provider1 + "/*"), (t, e) -> queue.offer(e), null, null, null);
@@ -302,7 +302,7 @@ public class HttpDeviceFactorySSLTest {
         startServer(false);
 
         // Excepted providers
-        final String provider1 = "ssl-trusted-provider1";
+        final String provider1 = "ssl_trusted_provider1";
 
         // Register listener
         session.addListener(List.of(provider1 + "/*"), (t, e) -> queue.offer(e), null, null, null);
@@ -344,7 +344,7 @@ public class HttpDeviceFactorySSLTest {
         startServer(true);
 
         // Excepted providers
-        final String provider1 = "ssl-client-auth-fail-provider1";
+        final String provider1 = "ssl_client_auth_fail_provider1";
 
         // Register listener
         session.addListener(List.of(provider1 + "/*"), (t, e) -> queue.offer(e), null, null, null);
@@ -382,7 +382,7 @@ public class HttpDeviceFactorySSLTest {
         startServer(true);
 
         // Excepted providers
-        final String provider1 = "ssl-client-auth-valid-provider1";
+        final String provider1 = "ssl_client_auth_valid_provider1";
 
         // Register listener
         session.addListener(List.of(provider1 + "/*"), (t, e) -> queue.offer(e), null, null, null);

--- a/southbound/http/http-device-factory/src/test/java/org/eclipse/sensinact/gateway/southbound/http/factory/integration/HttpDeviceFactoryTest.java
+++ b/southbound/http/http-device-factory/src/test/java/org/eclipse/sensinact/gateway/southbound/http/factory/integration/HttpDeviceFactoryTest.java
@@ -168,8 +168,8 @@ public class HttpDeviceFactoryTest {
     @Test
     void testSimpleTask() throws Exception {
         // Excepted providers
-        final String provider1 = "typed-provider1";
-        final String provider2 = "typed-provider2";
+        final String provider1 = "typed_provider1";
+        final String provider2 = "typed_provider2";
 
         // Register listener
         setupProvidersHandling(provider1, provider2);
@@ -225,8 +225,8 @@ public class HttpDeviceFactoryTest {
     @Test
     void testPeriodicTask() throws Exception {
         // Excepted providers
-        final String provider1 = "dynamic-provider1";
-        final String provider2 = "dynamic-provider2";
+        final String provider1 = "dynamic_provider1";
+        final String provider2 = "dynamic_provider2";
 
         // Register listener
         setupProvidersHandling(provider1, provider2);

--- a/southbound/mqtt/mqtt-device-factory/integration-test.bndrun
+++ b/southbound/mqtt/mqtt-device-factory/integration-test.bndrun
@@ -65,7 +65,6 @@
 	org.gecko.emf.osgi.api;version='[5.0.0,5.0.1)',\
 	org.gecko.emf.osgi.component;version='[5.0.0,5.0.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
-	org.osgi.service.cm;version='[1.6.1,1.6.2)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	org.osgi.service.typedevent;version='[1.0.0,1.0.1)',\
 	org.osgi.test.common;version='[1.2.1,1.2.2)',\

--- a/southbound/mqtt/mqtt-device-factory/src/test/java/org/eclipse/sensinact/gateway/southbound/mqtt/factory/integration/MqttDeviceFactoryTest.java
+++ b/southbound/mqtt/mqtt-device-factory/src/test/java/org/eclipse/sensinact/gateway/southbound/mqtt/factory/integration/MqttDeviceFactoryTest.java
@@ -127,8 +127,8 @@ public class MqttDeviceFactoryTest {
     @Test
     void testWorking() throws Exception {
         // Excepted providers
-        final String provider1 = "typed-provider1";
-        final String provider2 = "typed-provider2";
+        final String provider1 = "typed_provider1";
+        final String provider2 = "typed_provider2";
 
         // Register listener
         session.addListener(List.of(provider1 + "/*"), (t, e) -> queue.offer(e), null, null, null);
@@ -192,7 +192,7 @@ public class MqttDeviceFactoryTest {
     @Test
     void testHandlerFilter() throws Exception {
         // Excepted providers
-        final String provider1 = "handler-provider1";
+        final String provider1 = "handler_provider1";
 
         // Register listener
         session.addListener(List.of(provider1 + "/*"), (t, e) -> queue.offer(e), null, null, null);


### PR DESCRIPTION
This PR provides two changes decided after discussions with @juergen-albert about a better integration of the Device Factory with EMF:
* **BREAKING:** Model/Provider/Service/Resource names now follow the Java identifiers specification
  * As names are integrated into EMF, they must be valid Java identifiers
  * Invalid characters are now replaced by an underscore (`_`) instead of a hyphen (`-`)
  * A new mapping option has been added: `names.ascii`
    * If true, names are ensured to be only ASCII letters, digits or underscores. Diacritics are normalized first.
    * If false (*default*), names are Java identifier characters (see [`Character.isJavaIdentifierPart`](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/Character.html#isJavaIdentifierPart(char))) or underscores
  * If a name is a Java reserved keyword or if it starts with a digit, it is then prefixed by an underscore.
* *NEW*: Added a `model.raw` mapping option, that disables the normalization of the `@model` content. This allows to use URLs as models.

*Note:* this is currently a draft PR, the documentation has to be updated