### PR TITLE
Update build plugin configuration to improve bndrun management

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -20,7 +20,7 @@ jobs:
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven
-      run: mvn -B verify --file pom.xml
+      run: mvn -P ci-build -B verify --file pom.xml
 
     # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
     - name: Update dependency graph

--- a/core/impl/integration-test.bndrun
+++ b/core/impl/integration-test.bndrun
@@ -8,6 +8,10 @@
 -runee: JavaSE-11
 -runfw: org.apache.felix.framework
 
+# These packages are also provided by the gecko.emf.osgi.component project
+# so we blacklist the API for resolve consistency
+-runblacklist: bnd.identity;id='org.gecko.emf.osgi.api'
+
 # This will help us keep -runbundles sorted
 -runstartlevel: \
 	order=sortbynameversion,\
@@ -40,34 +44,16 @@
 	org.eclipse.sensinact.gateway.core.impl-tests;version='[0.0.2,0.0.3)',\
 	org.eclipse.sensinact.gateway.core.models.metadata;version='[0.0.2,0.0.3)',\
 	org.eclipse.sensinact.gateway.core.models.provider;version='[0.0.2,0.0.3)',\
-	org.gecko.emf.osgi.api;version='[5.0.0,5.0.1)',\
 	org.gecko.emf.osgi.component;version='[5.0.0,5.0.1)',\
 	org.mockito.junit-jupiter;version='[4.7.0,4.7.1)',\
 	org.mockito.mockito-core;version='[4.7.0,4.7.1)',\
 	org.objenesis;version='[3.2.0,3.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
-	org.osgi.service.cm;version='[1.6.1,1.6.2)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	org.osgi.service.typedevent;version='[1.0.0,1.0.1)',\
 	org.osgi.test.common;version='[1.2.1,1.2.2)',\
 	org.osgi.test.junit5;version='[1.2.1,1.2.2)',\
 	org.osgi.test.junit5.cm;version='[1.2.1,1.2.2)',\
-	org.osgi.util.converter;version='[1.0.9,1.0.10)',\
-	org.osgi.util.function;version='[1.1.0,1.1.1)',\
-	org.osgi.util.promise;version='[1.3.0,1.3.1)',\
-	org.osgi.util.pushstream;version='[1.0.2,1.0.3)',\
-	slf4j.api;version='[1.7.36,1.7.37)',\
-	slf4j.simple;version='[1.7.36,1.7.37)'
-	org.gecko.emf.osgi.api;version='[4.6.0,4.6.1)',\
-	org.gecko.emf.osgi.component;version='[4.6.0,4.6.1)',\
-	org.mockito.junit-jupiter;version='[4.7.0,4.7.1)',\
-	org.mockito.mockito-core;version='[4.7.0,4.7.1)',\
-	org.objenesis;version='[3.2.0,3.2.1)',\
-	org.opentest4j;version='[1.2.0,1.2.1)',\
-	org.osgi.service.component;version='[1.5.0,1.5.1)',\
-	org.osgi.service.typedevent;version='[1.0.0,1.0.1)',\
-	org.osgi.test.common;version='[1.2.1,1.2.2)',\
-	org.osgi.test.junit5;version='[1.2.1,1.2.2)',\
 	org.osgi.util.converter;version='[1.0.9,1.0.10)',\
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
 	org.osgi.util.promise;version='[1.3.0,1.3.1)',\

--- a/northbound/filters/ldap/integration-test.bndrun
+++ b/northbound/filters/ldap/integration-test.bndrun
@@ -2,6 +2,7 @@
 
 -runrequires: \
 	bnd.identity;id='${project.groupId}.${project.artifactId}-tests',\
+	bnd.identity;id='org.osgi.service.cm',\
 	bnd.identity;id='slf4j.simple',\
 	bnd.identity;id='org.eclipse.sensinact.gateway.core.api',\
 	bnd.identity;id='org.eclipse.sensinact.gateway.core.impl'
@@ -9,6 +10,10 @@
 
 -runee: JavaSE-11
 -runfw: org.apache.felix.framework
+
+# These packages are also provided by the gecko.emf.osgi.component project
+# so we blacklist the API for resolve consistency
+-runblacklist: bnd.identity;id='org.gecko.emf.osgi.api'
 
 # This will help us keep -runbundles sorted
 -runstartlevel: \
@@ -43,7 +48,6 @@
 	org.eclipse.sensinact.gateway.northbound.filters.filters.core;version='[0.0.2,0.0.3)',\
 	org.eclipse.sensinact.gateway.northbound.filters.ldap;version='[0.0.2,0.0.3)',\
 	org.eclipse.sensinact.gateway.northbound.filters.ldap-tests;version='[0.0.2,0.0.3)',\
-	org.gecko.emf.osgi.api;version='[5.0.0,5.0.1)',\
 	org.gecko.emf.osgi.component;version='[5.0.0,5.0.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	org.osgi.service.cm;version='[1.6.1,1.6.2)',\

--- a/northbound/query-handler/integration-test.bndrun
+++ b/northbound/query-handler/integration-test.bndrun
@@ -2,11 +2,16 @@
 
 -runrequires: \
 	bnd.identity;id='${project.groupId}.${project.artifactId}-tests',\
+	bnd.identity;id='org.osgi.service.cm',\
 	bnd.identity;id='slf4j.simple'
 -resolve.effective: active
 
 -runee: JavaSE-11
 -runfw: org.apache.felix.framework
+
+# These packages are also provided by the gecko.emf.osgi.component project
+# so we blacklist the API for resolve consistency
+-runblacklist: bnd.identity;id='org.gecko.emf.osgi.api'
 
 # This will help us keep -runbundles sorted
 -runstartlevel: \
@@ -40,7 +45,6 @@
 	org.eclipse.sensinact.gateway.northbound.filters.filters.core;version='[0.0.2,0.0.3)',\
 	org.eclipse.sensinact.gateway.northbound.query-handler;version='[0.0.2,0.0.3)',\
 	org.eclipse.sensinact.gateway.northbound.query-handler-tests;version='[0.0.2,0.0.3)',\
-	org.gecko.emf.osgi.api;version='[5.0.0,5.0.1)',\
 	org.gecko.emf.osgi.component;version='[5.0.0,5.0.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	org.osgi.service.cm;version='[1.6.1,1.6.2)',\

--- a/northbound/rest/integration-test.bndrun
+++ b/northbound/rest/integration-test.bndrun
@@ -18,6 +18,10 @@
 -runee: JavaSE-11
 -runfw: org.apache.felix.framework
 
+# These packages are also provided by the gecko.emf.osgi.component project
+# so we blacklist the API for resolve consistency
+-runblacklist: bnd.identity;id='org.gecko.emf.osgi.api'
+
 # This will help us keep -runbundles sorted
 -runstartlevel: \
 	order=sortbynameversion,\
@@ -75,7 +79,6 @@
 	org.eclipse.sensinact.gateway.northbound.rest;version='[0.0.2,0.0.3)',\
 	org.eclipse.sensinact.gateway.northbound.rest-tests;version='[0.0.2,0.0.3)',\
 	org.eclipse.sensinact.gateway.northbound.security.authentication-api;version='[0.0.2,0.0.3)',\
-	org.gecko.emf.osgi.api;version='[5.0.0,5.0.1)',\
 	org.gecko.emf.osgi.component;version='[5.0.0,5.0.1)',\
 	org.gecko.rest.jersey;version='[6.0.0,6.0.1)',\
 	org.gecko.rest.jersey.config;version='[6.0.0,6.0.1)',\
@@ -96,7 +99,6 @@
 	org.glassfish.jersey.media.jersey-media-sse;version='[3.0.8,3.0.9)',\
 	org.objectweb.asm;version='[9.3.0,9.3.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
-	org.osgi.service.cm;version='[1.6.1,1.6.2)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	org.osgi.service.jakartars;version='[2.0.0,2.0.1)',\
 	org.osgi.service.typedevent;version='[1.0.0,1.0.1)',\

--- a/northbound/security/openid-connect/integration-test.bndrun
+++ b/northbound/security/openid-connect/integration-test.bndrun
@@ -2,6 +2,7 @@
 
 -runrequires: \
 	bnd.identity;id='${project.groupId}.${project.artifactId}-tests',\
+	bnd.identity;id='org.osgi.service.cm',\
 	bnd.identity;id='slf4j.simple',\
 	bnd.identity;id='io.jsonwebtoken.jjwt-impl'
 -resolve.effective: active

--- a/northbound/sensorthings/mqtt/integration-test.bndrun
+++ b/northbound/sensorthings/mqtt/integration-test.bndrun
@@ -9,6 +9,11 @@
 -runee: JavaSE-11
 -runfw: org.apache.felix.framework
 
+# These packages are also provided by the gecko.emf.osgi.component project
+# so we blacklist the API for resolve consistency
+-runblacklist: bnd.identity;id='org.gecko.emf.osgi.api',\
+	bnd.identity;id='slf4j.reload4k'
+
 # This will help us keep -runbundles sorted
 -runstartlevel: \
 	order=sortbynameversion,\
@@ -54,10 +59,8 @@
 	org.eclipse.sensinact.gateway.northbound.sensorthings.dto;version='[0.0.2,0.0.3)',\
 	org.eclipse.sensinact.gateway.northbound.sensorthings.mqtt;version='[0.0.2,0.0.3)',\
 	org.eclipse.sensinact.gateway.northbound.sensorthings.mqtt-tests;version='[0.0.2,0.0.3)',\
-	org.gecko.emf.osgi.api;version='[5.0.0,5.0.1)',\
 	org.gecko.emf.osgi.component;version='[5.0.0,5.0.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
-	org.osgi.service.cm;version='[1.6.1,1.6.2)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	org.osgi.service.typedevent;version='[1.0.0,1.0.1)',\
 	org.osgi.test.common;version='[1.2.1,1.2.2)',\
@@ -68,4 +71,3 @@
 	org.osgi.util.pushstream;version='[1.0.2,1.0.3)',\
 	slf4j.api;version='[1.7.36,1.7.37)',\
 	slf4j.simple;version='[1.7.36,1.7.37)'
--runblacklist: bnd.identity;id='slf4j.reload4k'

--- a/northbound/sensorthings/rest.gateway/integration-test.bndrun
+++ b/northbound/sensorthings/rest.gateway/integration-test.bndrun
@@ -16,6 +16,10 @@
 -runee: JavaSE-11
 -runfw: org.apache.felix.framework
 
+# These packages are also provided by the gecko.emf.osgi.component project
+# so we blacklist the API for resolve consistency
+-runblacklist: bnd.identity;id='org.gecko.emf.osgi.api'
+
 # This will help us keep -runbundles sorted
 -runstartlevel: \
 	order=sortbynameversion,\
@@ -80,7 +84,6 @@
 	org.eclipse.sensinact.gateway.northbound.sensorthings.rest.gateway-tests;version='[0.0.2,0.0.3)',\
 	org.eclipse.sensinact.gateway.southbound.history.history-api;version='[0.0.2,0.0.3)',\
 	org.eclipse.sensinact.gateway.southbound.history.timescale-provider;version='[0.0.2,0.0.3)',\
-	org.gecko.emf.osgi.api;version='[5.0.0,5.0.1)',\
 	org.gecko.emf.osgi.component;version='[5.0.0,5.0.1)',\
 	org.gecko.rest.jersey;version='[6.0.0,6.0.1)',\
 	org.gecko.rest.jersey.config;version='[6.0.0,6.0.1)',\

--- a/northbound/websocket/integration-test.bndrun
+++ b/northbound/websocket/integration-test.bndrun
@@ -9,8 +9,20 @@
 	bnd.identity;id='org.eclipse.parsson.jakarta.json'
 -resolve.effective: active
 
--runee: JavaSE-11
+-runee: JavaSE-21
 -runfw: org.apache.felix.framework
+
+# These packages are also provided by the gecko.emf.osgi.component project
+# so we blacklist the API for resolve consistency
+-runblacklist: \
+	bnd.identity;id='org.gecko.emf.osgi.api',\
+	bnd.identity;id='org.eclipse.jetty.annotations',\
+	bnd.identity;id='org.eclipse.jetty.http',\
+	bnd.identity;id='org.eclipse.jetty.plus',\
+	bnd.identity;id='org.eclipse.jetty.security',\
+	bnd.identity;id='org.eclipse.jetty.server',\
+	bnd.identity;id='org.eclipse.jetty.servlet',\
+	bnd.identity;id='org.eclipse.jetty.util'
 
 # This will help us keep -runbundles sorted
 -runstartlevel: \
@@ -22,12 +34,6 @@
 	com.fasterxml.jackson.core.jackson-databind;version='[2.14.0,2.14.1)',\
 	com.fasterxml.jackson.datatype.jackson-datatype-jsr310;version='[2.14.0,2.14.1)',\
 	io.dropwizard.metrics.core;version='[4.2.19,4.2.20)',\
-	jakarta.annotation-api;version='[2.1.1,2.1.2)',\
-	jakarta.el-api;version='[4.0.0,4.0.1)',\
-	jakarta.enterprise.cdi-api;version='[3.0.0,3.0.1)',\
-	jakarta.inject.jakarta.inject-api;version='[2.0.1,2.0.2)',\
-	jakarta.interceptor-api;version='[2.0.0,2.0.1)',\
-	jakarta.transaction-api;version='[2.0.0,2.0.1)',\
 	junit-jupiter-api;version='[5.9.0,5.9.1)',\
 	junit-jupiter-engine;version='[5.9.0,5.9.1)',\
 	junit-jupiter-params;version='[5.9.0,5.9.1)',\
@@ -49,10 +55,6 @@
 	org.eclipse.emf.ecore.xmi;version='[2.18.0,2.18.1)',\
 	org.eclipse.jetty.alpn.client;version='[11.0.13,11.0.14)',\
 	org.eclipse.jetty.client;version='[11.0.13,11.0.14)',\
-	org.eclipse.jetty.http;version='[11.0.13,11.0.14)',\
-	org.eclipse.jetty.jndi;version='[11.0.13,11.0.14)',\
-	org.eclipse.jetty.plus;version='[11.0.13,11.0.14)',\
-	org.eclipse.jetty.util;version='[11.0.13,11.0.14)',\
 	org.eclipse.jetty.webapp;version='[11.0.13,11.0.14)',\
 	org.eclipse.jetty.websocket.api;version='[11.0.13,11.0.14)',\
 	org.eclipse.jetty.websocket.client;version='[11.0.13,11.0.14)',\
@@ -77,11 +79,8 @@
 	org.eclipse.sensinact.gateway.northbound.security.authentication-api;version='[0.0.2,0.0.3)',\
 	org.eclipse.sensinact.gateway.northbound.websocket;version='[0.0.2,0.0.3)',\
 	org.eclipse.sensinact.gateway.northbound.websocket-tests;version='[0.0.2,0.0.3)',\
-	org.gecko.emf.osgi.api;version='[5.0.0,5.0.1)',\
 	org.gecko.emf.osgi.component;version='[5.0.0,5.0.1)',\
-	org.objectweb.asm;version='[9.4.0,9.4.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
-	org.osgi.service.cm;version='[1.6.1,1.6.2)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	org.osgi.service.typedevent;version='[1.0.0,1.0.1)',\
 	org.osgi.test.common;version='[1.2.1,1.2.2)',\

--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,11 @@
 
     <!-- plugin dependency versions -->
     <bnd.version>7.0.0-SNAPSHOT</bnd.version>
+
+    <!-- Default properties for resolver setup in development -->
+    <save.test.bndrun.changes>true</save.test.bndrun.changes>
+    <verify.test.bndruns>false</verify.test.bndruns>
+
   </properties>
 
   <repositories>
@@ -586,8 +591,8 @@
                 <goal>resolve</goal>
               </goals>
               <configuration>
-                <writeOnChanges>true</writeOnChanges>
-                <failOnChanges>false</failOnChanges>
+                <writeOnChanges>${save.test.bndrun.changes}</writeOnChanges>
+                <failOnChanges>${verify.test.bndruns}</failOnChanges>
                 <includeDependencyManagement>true</includeDependencyManagement>
                 <scopes>
                   <scope>compile</scope>
@@ -668,6 +673,31 @@
 
 
   <profiles>
+    <!-- Used in CI to treat bndruns as immutable source -->
+    <profile>
+      <id>ci-build</id>
+      <properties>
+        <save.test.bndrun.changes>false</save.test.bndrun.changes>
+        <verify.test.bndruns>true</verify.test.bndruns>
+      </properties>
+    </profile>
+    <!-- Used by developers to quickly update bndruns for dependabot updates -->
+    <profile>
+      <id>dependabot</id>
+      <properties>
+        <save.test.bndrun.changes>true</save.test.bndrun.changes>
+        <verify.test.bndruns>false</verify.test.bndruns>
+        <skipTests>true</skipTests>
+      </properties>
+    </profile>
+    <!-- Used by developers for normal development (restating the default)  -->
+    <profile>
+      <id>dev</id>
+      <properties>
+        <save.test.bndrun.changes>true</save.test.bndrun.changes>
+        <verify.test.bndruns>false</verify.test.bndruns>
+      </properties>
+    </profile>
     <profile>
       <id>eclipse-licenses-check</id>
       <activation>

--- a/southbound/history/timescale-provider/integration-test.bndrun
+++ b/southbound/history/timescale-provider/integration-test.bndrun
@@ -9,6 +9,10 @@
 -runee: JavaSE-11
 -runfw: org.apache.felix.framework
 
+# These packages are also provided by the gecko.emf.osgi.component project
+# so we blacklist the API for resolve consistency
+-runblacklist: bnd.identity;id='org.gecko.emf.osgi.api'
+
 # This will help us keep -runbundles sorted
 -runstartlevel: \
 	order=sortbynameversion,\
@@ -46,13 +50,11 @@
 	org.eclipse.sensinact.gateway.southbound.history.history-api;version='[0.0.2,0.0.3)',\
 	org.eclipse.sensinact.gateway.southbound.history.timescale-provider;version='[0.0.2,0.0.3)',\
 	org.eclipse.sensinact.gateway.southbound.history.timescale-provider-tests;version='[0.0.2,0.0.3)',\
-	org.gecko.emf.osgi.api;version='[5.0.0,5.0.1)',\
 	org.gecko.emf.osgi.component;version='[5.0.0,5.0.1)',\
 	org.mockito.junit-jupiter;version='[4.7.0,4.7.1)',\
 	org.mockito.mockito-core;version='[4.7.0,4.7.1)',\
 	org.objenesis;version='[3.2.0,3.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
-	org.osgi.service.cm;version='[1.6.1,1.6.2)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	org.osgi.service.typedevent;version='[1.0.0,1.0.1)',\
 	org.osgi.test.common;version='[1.2.1,1.2.2)',\

--- a/southbound/history/timescale-provider/tests.bnd
+++ b/southbound/history/timescale-provider/tests.bnd
@@ -19,3 +19,31 @@ Import-Package: \
     !org.conscrypt, \
     !org.testcontainers.r2dbc.*, \
     *
+# Remove warnings about annotation dependencies from repackaged code
+-fixupmessages: \
+    "While traversing the type tree for com.github.dockerjava.* cannot find class javax.annotation.*"; \
+    restrict:=warning; is:=ignore,\
+    "While traversing the type tree for com.github.dockerjava.* cannot find class org.immutables.*"; \
+    restrict:=warning; is:=ignore,\
+    "While traversing the type tree for org.jboss.resteasy.* cannot find class jakarta.servlet.*"; \
+    restrict:=warning; is:=ignore,\
+    "While traversing the type tree for org.jboss.resteasy.* cannot find class org.jboss.logging.annotations.*"; \
+    restrict:=warning; is:=ignore,\
+    "While traversing the type tree for org.jboss.resteasy.* cannot find class org.jboss.resteasy.tracing.api.*"; \
+    restrict:=warning; is:=ignore,\
+    "While traversing the type tree for org.jboss.resteasy.* cannot find class org.apache.http.*"; \
+    restrict:=warning; is:=ignore,\
+    "While traversing the type tree for org.keycloak.representations.* cannot find class org.eclipse.microprofile.openapi.annotations.*"; \
+    restrict:=warning; is:=ignore,\
+    "While traversing the type tree for org.testcontainers.* cannot find class com.google.j2objc.annotations.*"; \
+    restrict:=warning; is:=ignore,\
+    "While traversing the type tree for org.testcontainers.* cannot find class lombok.*"; \
+    restrict:=warning; is:=ignore,\
+    "While traversing the type tree for org.testcontainers.* cannot find class javax.annotation.*"; \
+    restrict:=warning; is:=ignore,\
+    "While traversing the type tree for org.testcontainers.* cannot find class org.codehaus.mojo.animal_sniffer.*"; \
+    restrict:=warning; is:=ignore,\
+    "While traversing the type tree for org.testcontainers.* cannot find class org.jetbrains.annotations.VisibleForTesting"; \
+    restrict:=warning; is:=ignore,\
+    "While traversing the type tree for * cannot find class edu.umd.cs.findbugs.annotations.SuppressFBWarnings"; \
+    restrict:=warning; is:=ignore

--- a/southbound/http/http-device-factory/integration-test.bndrun
+++ b/southbound/http/http-device-factory/integration-test.bndrun
@@ -14,6 +14,10 @@
 -runee: JavaSE-11
 -runfw: org.apache.felix.framework
 
+# These packages are also provided by the gecko.emf.osgi.component project
+# so we blacklist the API for resolve consistency
+-runblacklist: bnd.identity;id='org.gecko.emf.osgi.api'
+
 # This will help us keep -runbundles sorted
 -runstartlevel: \
 	order=sortbynameversion,\
@@ -56,10 +60,8 @@
 	org.eclipse.sensinact.gateway.southbound.device-factory.parser-csv;version='[0.0.2,0.0.3)',\
 	org.eclipse.sensinact.gateway.southbound.http.http-device-factory;version='[0.0.2,0.0.3)',\
 	org.eclipse.sensinact.gateway.southbound.http.http-device-factory-tests;version='[0.0.2,0.0.3)',\
-	org.gecko.emf.osgi.api;version='[5.0.0,5.0.1)',\
 	org.gecko.emf.osgi.component;version='[5.0.0,5.0.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
-	org.osgi.service.cm;version='[1.6.1,1.6.2)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	org.osgi.service.typedevent;version='[1.0.0,1.0.1)',\
 	org.osgi.test.common;version='[1.2.1,1.2.2)',\
@@ -70,5 +72,3 @@
 	org.osgi.util.pushstream;version='[1.0.2,1.0.3)',\
 	slf4j.api;version='[1.7.36,1.7.37)',\
 	slf4j.simple;version='[1.7.36,1.7.37)'
-	org.gecko.emf.osgi.api;version='[4.6.0,4.6.1)',\
-	org.gecko.emf.osgi.component;version='[4.6.0,4.6.1)'

--- a/southbound/mqtt/mqtt-device-factory/integration-test.bndrun
+++ b/southbound/mqtt/mqtt-device-factory/integration-test.bndrun
@@ -12,6 +12,10 @@
 -runee: JavaSE-11
 -runfw: org.apache.felix.framework
 
+# These packages are also provided by the gecko.emf.osgi.component project
+# so we blacklist the API for resolve consistency
+-runblacklist: bnd.identity;id='org.gecko.emf.osgi.api', bnd.identity;id='slf4j.log4j12', bnd.identity;id='log4j.over.slf4j'
+
 # This will help us keep -runbundles sorted
 -runstartlevel: \
 	order=sortbynameversion,\
@@ -39,7 +43,6 @@
 	junit-platform-commons;version='[1.9.0,1.9.1)',\
 	junit-platform-engine;version='[1.9.0,1.9.1)',\
 	junit-platform-launcher;version='[1.9.0,1.9.1)',\
-	log4j.over.slf4j;version='[1.7.36,1.7.37)',\
 	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
 	org.apache.aries.typedevent.bus;version='[0.0.2,0.0.3)',\
 	org.apache.commons.codec;version='[1.10.0,1.10.1)',\
@@ -62,10 +65,8 @@
 	org.eclipse.sensinact.gateway.southbound.mqtt.mqtt-client;version='[0.0.2,0.0.3)',\
 	org.eclipse.sensinact.gateway.southbound.mqtt.mqtt-device-factory;version='[0.0.2,0.0.3)',\
 	org.eclipse.sensinact.gateway.southbound.mqtt.mqtt-device-factory-tests;version='[0.0.2,0.0.3)',\
-	org.gecko.emf.osgi.api;version='[5.0.0,5.0.1)',\
 	org.gecko.emf.osgi.component;version='[5.0.0,5.0.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
-	org.osgi.service.cm;version='[1.6.1,1.6.2)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	org.osgi.service.typedevent;version='[1.0.0,1.0.1)',\
 	org.osgi.test.common;version='[1.2.1,1.2.2)',\

--- a/southbound/virtual/virtual-temperature-sensor/integration-test.bndrun
+++ b/southbound/virtual/virtual-temperature-sensor/integration-test.bndrun
@@ -2,11 +2,16 @@
 
 -runrequires: \
 	bnd.identity;id='${project.groupId}.${project.artifactId}-tests',\
+	bnd.identity;id='org.osgi.service.cm',\
 	bnd.identity;id='slf4j.simple'
 -resolve.effective: active
 
 -runee: JavaSE-11
 -runfw: org.apache.felix.framework
+
+# These packages are also provided by the gecko.emf.osgi.component project
+# so we blacklist the API for resolve consistency
+-runblacklist: bnd.identity;id='org.gecko.emf.osgi.api'
 
 # This will help us keep -runbundles sorted
 -runstartlevel: \
@@ -39,7 +44,6 @@
 	org.eclipse.sensinact.gateway.core.models.provider;version='[0.0.2,0.0.3)',\
 	org.eclipse.sensinact.gateway.southbound.virtual.virtual-temperature-sensor;version='[0.0.2,0.0.3)',\
 	org.eclipse.sensinact.gateway.southbound.virtual.virtual-temperature-sensor-tests;version='[0.0.2,0.0.3)',\
-	org.gecko.emf.osgi.api;version='[5.0.0,5.0.1)',\
 	org.gecko.emf.osgi.component;version='[5.0.0,5.0.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	org.osgi.service.cm;version='[1.6.1,1.6.2)',\


### PR DESCRIPTION
Fixes #301

Introduces build profiles for sensiNact to enforce consistent bndrun resolutions in CI and a profile for rapid turnaround of dependabot updates


Note that the first commit is expected to fail the build because the bndruns aren't yet updated.