### PR TITLE
Fix for null values handling in configuration

### DIFF
--- a/distribution/launcher/src/main/java/org/eclipse/sensinact/gateway/launcher/ConfigurationManager.java
+++ b/distribution/launcher/src/main/java/org/eclipse/sensinact/gateway/launcher/ConfigurationManager.java
@@ -34,7 +34,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Hashtable;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -46,6 +48,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Predicate;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonValue;
+import javax.json.JsonValue.ValueType;
+import javax.json.stream.JsonParser;
 
 import org.apache.felix.cm.json.ConfigurationReader;
 import org.apache.felix.cm.json.ConfigurationResource;
@@ -169,19 +177,58 @@ public class ConfigurationManager {
         }
     }
 
+    private List<String> cleanupJson(final JsonObject raw, final int depth) {
+        return cleanupJson(raw, depth, null);
+    }
+
+    private List<String> cleanupJson(final JsonObject raw, final int depth, final String prefix) {
+        if (depth < 0) {
+            return List.of();
+        }
+
+        final List<String> invalid = new LinkedList<String>();
+        Iterator<Entry<String, JsonValue>> iterator = raw.entrySet().iterator();
+        while (iterator.hasNext()) {
+            final Map.Entry<String, JsonValue> entry = iterator.next();
+            final JsonValue value = entry.getValue();
+            if (value == JsonValue.NULL) {
+                if (prefix == null) {
+                    invalid.add(entry.getKey());
+                } else {
+                    invalid.add(prefix + "/" + entry.getKey());
+                }
+                iterator.remove();
+            } else if (value.getValueType() == ValueType.OBJECT && depth != 0) {
+                final List<String> subInvalid = cleanupJson(value.asJsonObject(), depth - 1, entry.getKey());
+                if (subInvalid != null) {
+                    invalid.addAll(subInvalid);
+                }
+            }
+        }
+
+        return invalid;
+    }
+
     private ConfigurationResource loadConfigFile() throws IOException {
         final ConfigurationResource config;
         if (Files.exists(configFile)) {
+            final JsonObject root;
             try (Reader reader = Files.newBufferedReader(configFile)) {
-                ConfigurationReader configReader = Configurations.buildReader()
-                        .withConfiguratorPropertyHandler((a, b, c) -> {
-                        }).build(reader);
-
-                config = configReader.readConfigurationResource();
-
-                for (String warning : configReader.getIgnoredErrors()) {
-                    LOGGER.warn("Configuration file parsing warning. Error was\n{}", warning);
+                final JsonParser parser = Json.createParser(Configurations.jsonCommentAwareReader(reader));
+                root = parser.getObject();
+                final List<String> invalidKeys = cleanupJson(root, 1);
+                for (String invalidKey : invalidKeys) {
+                    LOGGER.warn("Configuration file parsing warning. Ignoring configuration key {}", invalidKey);
                 }
+            }
+
+            ConfigurationReader configReader = Configurations.buildReader()
+                    .withConfiguratorPropertyHandler((a, b, c) -> {
+                    }).build(root);
+            config = configReader.readConfigurationResource();
+
+            for (String warning : configReader.getIgnoredErrors()) {
+                LOGGER.warn("Configuration file parsing warning. Error was\n{}", warning);
             }
         } else {
             config = new ConfigurationResource();

--- a/distribution/launcher/src/test/resources/configs/invalid/configuration-null.json
+++ b/distribution/launcher/src/test/resources/configs/invalid/configuration-null.json
@@ -1,0 +1,15 @@
+{
+  ":configurator:resource-version": 1,
+  ":configurator:symbolic-name": "org.eclipse.sensinact.gateway.feature.null.test",
+  ":configurator:version": "0.0.1",
+  "test.null": {
+    "foo": null,
+    "valid": 42,
+    "test": {
+      "titi": null
+    }
+  },
+  "test.valid": {
+    "valid": 1
+  }
+}

--- a/docs/source/distribution/Launcher.md
+++ b/docs/source/distribution/Launcher.md
@@ -134,6 +134,29 @@ Here is an example of configuration in a feature:
   }
 ```
 
+:::{important}
+Null values are not accepted in first level configuration values.
+
+For example, in the following snippet, the configuration key `invalid` will be ignored while `valid/key` will be kept.
+A warning will be logged to indicate this key was ignored.
+
+```json
+{
+  "feature-resource-version": "1.0",
+  "id": "org.example:feature_id:1.0.0",
+  "configurations": {
+    "pid1": {
+      "text": "Some string value",
+      "value": 42,
+      "invalid": null,
+      "valid": {
+        "key": null
+      }
+    },
+}
+```
+:::
+
 ### Adding your own features
 
 Adding your own features can be achieved by writing a valid feature document and including it in the `features` directory, or installing it into the `repository`. It is also necessary to make sure that any bundles used in your feature are also installed into the `repository`.


### PR DESCRIPTION
This PR filters out invalid configuration values before letting the Configurator load them.

See #304 for more details