### PR TITLE
Bump slf4j to v2.0.11 (Issue #328)

### DIFF
--- a/core/impl/integration-test.bndrun
+++ b/core/impl/integration-test.bndrun
@@ -33,6 +33,7 @@
 	net.bytebuddy.byte-buddy;version='[1.14.11,1.14.12)',\
 	net.bytebuddy.byte-buddy-agent;version='[1.14.11,1.14.12)',\
 	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
+	org.apache.aries.spifly.dynamic.framework.extension;version='[1.3.7,1.3.8)',\
 	org.apache.aries.typedevent.bus;version='[0.0.2,0.0.3)',\
 	org.apache.felix.configadmin;version='[1.9.24,1.9.25)',\
 	org.apache.felix.scr;version='[2.2.2,2.2.3)',\
@@ -61,5 +62,5 @@
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
 	org.osgi.util.promise;version='[1.3.0,1.3.1)',\
 	org.osgi.util.pushstream;version='[1.0.2,1.0.3)',\
-	slf4j.api;version='[1.7.36,1.7.37)',\
-	slf4j.simple;version='[1.7.36,1.7.37)'
+	slf4j.api;version='[2.0.11,2.0.12)',\
+	slf4j.simple;version='[2.0.11,2.0.12)'

--- a/core/impl/pom.xml
+++ b/core/impl/pom.xml
@@ -79,11 +79,6 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>log4j-over-slf4j</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
         <groupId>org.eclipse.sensinact.gateway.core.models</groupId>
         <artifactId>metadata</artifactId>
         <version>0.0.2-SNAPSHOT</version>

--- a/distribution/features/core-feature/pom.xml
+++ b/distribution/features/core-feature/pom.xml
@@ -101,10 +101,6 @@
       <artifactId>org.eclipse.emf.ecore.xmi</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>log4j-over-slf4j</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.geckoprojects.emf</groupId>
       <artifactId>org.gecko.emf.osgi.api</artifactId>
     </dependency>

--- a/distribution/features/core-feature/src/main/resources/core-feature.json
+++ b/distribution/features/core-feature/src/main/resources/core-feature.json
@@ -16,7 +16,6 @@
     { "id": "org.eclipse.emf:org.eclipse.emf.common:2.29.0" },
     { "id": "org.eclipse.emf:org.eclipse.emf.ecore:2.35.0" },
     { "id": "org.eclipse.emf:org.eclipse.emf.ecore.xmi:2.36.0" },
-    { "id": "org.slf4j:log4j-over-slf4j:1.7.36" },
     { "id": "org.geckoprojects.emf:org.gecko.emf.osgi.component.minimal:6.1.0" },
     { "id": "org.apache.aries.component-dsl:org.apache.aries.component-dsl.component-dsl:1.2.2" },
     { "id": "org.apache.aries.typedevent:org.apache.aries.typedevent.bus:0.0.2-SNAPSHOT" },

--- a/distribution/features/core-feature/src/test/java/org/eclipse/sensinact/gateway/feature/integration/core/CoreFeatureTest.java
+++ b/distribution/features/core-feature/src/test/java/org/eclipse/sensinact/gateway/feature/integration/core/CoreFeatureTest.java
@@ -68,7 +68,7 @@ public class CoreFeatureTest {
 
         // There should be 44 lines (40 bundles, 2 header lines and 2 trailing lines)
         try (BufferedReader br = new BufferedReader(new StringReader(bundles))) {
-            assertEquals(43, br.lines().count());
+            assertEquals(42, br.lines().count());
         }
     }
 }

--- a/distribution/launcher/export.bndrun
+++ b/distribution/launcher/export.bndrun
@@ -29,5 +29,5 @@
 	org.osgi.util.converter;version='[1.0.9,1.0.10)', \
 	org.osgi.util.function;version='[1.1.0,1.1.1)', \
 	org.osgi.util.promise;version='[1.3.0,1.3.1)', \
-	slf4j.api;version='[1.7.36,1.7.37)', \
-	slf4j.simple;version='[1.7.36,1.7.37)'
+	slf4j.api;version='[2.0.11,2.0.12)', \
+	slf4j.simple;version='[2.0.11,2.0.12)'

--- a/northbound/filters/ldap/integration-test.bndrun
+++ b/northbound/filters/ldap/integration-test.bndrun
@@ -30,6 +30,7 @@
 	junit-platform-launcher;version='[1.10.1,1.10.2)',\
 	org.antlr.antlr4-runtime;version='[4.12.0,4.12.1)',\
 	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
+	org.apache.aries.spifly.dynamic.framework.extension;version='[1.3.7,1.3.8)',\
 	org.apache.aries.typedevent.bus;version='[0.0.2,0.0.3)',\
 	org.apache.felix.configadmin;version='[1.9.24,1.9.25)',\
 	org.apache.felix.scr;version='[2.2.2,2.2.3)',\
@@ -56,5 +57,5 @@
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
 	org.osgi.util.promise;version='[1.3.0,1.3.1)',\
 	org.osgi.util.pushstream;version='[1.0.2,1.0.3)',\
-	slf4j.api;version='[1.7.36,1.7.37)',\
-	slf4j.simple;version='[1.7.36,1.7.37)'
+	slf4j.api;version='[2.0.11,2.0.12)',\
+	slf4j.simple;version='[2.0.11,2.0.12)'

--- a/northbound/query-handler/integration-test.bndrun
+++ b/northbound/query-handler/integration-test.bndrun
@@ -29,6 +29,7 @@
 	junit-platform-engine;version='[1.10.1,1.10.2)',\
 	junit-platform-launcher;version='[1.10.1,1.10.2)',\
 	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
+	org.apache.aries.spifly.dynamic.framework.extension;version='[1.3.7,1.3.8)',\
 	org.apache.aries.typedevent.bus;version='[0.0.2,0.0.3)',\
 	org.apache.felix.configadmin;version='[1.9.24,1.9.25)',\
 	org.apache.felix.scr;version='[2.2.2,2.2.3)',\
@@ -55,5 +56,5 @@
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
 	org.osgi.util.promise;version='[1.3.0,1.3.1)',\
 	org.osgi.util.pushstream;version='[1.0.2,1.0.3)',\
-	slf4j.api;version='[1.7.36,1.7.37)',\
-	slf4j.simple;version='[1.7.36,1.7.37)'
+	slf4j.api;version='[2.0.11,2.0.12)',\
+	slf4j.simple;version='[2.0.11,2.0.12)'

--- a/northbound/rest/integration-test.bndrun
+++ b/northbound/rest/integration-test.bndrun
@@ -105,5 +105,5 @@
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
 	org.osgi.util.promise;version='[1.3.0,1.3.1)',\
 	org.osgi.util.pushstream;version='[1.0.2,1.0.3)',\
-	slf4j.api;version='[1.7.36,1.7.37)',\
-	slf4j.simple;version='[1.7.36,1.7.37)'
+	slf4j.api;version='[2.0.11,2.0.12)',\
+	slf4j.simple;version='[2.0.11,2.0.12)'

--- a/northbound/security/openid-connect/integration-test.bndrun
+++ b/northbound/security/openid-connect/integration-test.bndrun
@@ -35,6 +35,7 @@
 	junit-platform-launcher;version='[1.10.1,1.10.2)',\
 	net.bytebuddy.byte-buddy;version='[1.14.11,1.14.12)',\
 	net.bytebuddy.byte-buddy-agent;version='[1.14.11,1.14.12)',\
+	org.apache.aries.spifly.dynamic.framework.extension;version='[1.3.7,1.3.8)',\
 	org.apache.felix.configadmin;version='[1.9.24,1.9.25)',\
 	org.apache.felix.scr;version='[2.2.2,2.2.3)',\
 	org.eclipse.jetty.alpn.client;version='[11.0.13,11.0.14)',\
@@ -57,5 +58,5 @@
 	org.osgi.test.junit5;version='[1.3.0,1.3.1)',\
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
 	org.osgi.util.promise;version='[1.3.0,1.3.1)',\
-	slf4j.api;version='[1.7.36,1.7.37)',\
-	slf4j.simple;version='[1.7.36,1.7.37)'
+	slf4j.api;version='[2.0.11,2.0.12)',\
+	slf4j.simple;version='[2.0.11,2.0.12)'

--- a/northbound/sensorthings/mqtt/integration-test.bndrun
+++ b/northbound/sensorthings/mqtt/integration-test.bndrun
@@ -43,6 +43,7 @@
 	junit-platform-engine;version='[1.10.1,1.10.2)',\
 	junit-platform-launcher;version='[1.10.1,1.10.2)',\
 	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
+	org.apache.aries.spifly.dynamic.framework.extension;version='[1.3.7,1.3.8)',\
 	org.apache.aries.typedevent.bus;version='[0.0.2,0.0.3)',\
 	org.apache.felix.configadmin;version='[1.9.24,1.9.25)',\
 	org.apache.felix.scr;version='[2.2.2,2.2.3)',\
@@ -70,5 +71,5 @@
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
 	org.osgi.util.promise;version='[1.3.0,1.3.1)',\
 	org.osgi.util.pushstream;version='[1.0.2,1.0.3)',\
-	slf4j.api;version='[1.7.36,1.7.37)',\
-	slf4j.simple;version='[1.7.36,1.7.37)'
+	slf4j.api;version='[2.0.11,2.0.12)',\
+	slf4j.simple;version='[2.0.11,2.0.12)'

--- a/northbound/sensorthings/rest.gateway/integration-test.bndrun
+++ b/northbound/sensorthings/rest.gateway/integration-test.bndrun
@@ -111,8 +111,8 @@
 	org.osgi.util.promise;version='[1.3.0,1.3.1)',\
 	org.osgi.util.pushstream;version='[1.0.2,1.0.3)',\
 	org.postgresql.jdbc;version='[42.5.1,42.5.2)',\
-	slf4j.api;version='[1.7.36,1.7.37)',\
-	slf4j.simple;version='[1.7.36,1.7.37)',\
+	slf4j.api;version='[2.0.11,2.0.12)',\
+	slf4j.simple;version='[2.0.11,2.0.12)',\
 	tx-control-provider-jdbc-local;version='[1.0.1,1.0.2)',\
 	tx-control-service-local;version='[1.0.1,1.0.2)'
 	org.objectweb.asm;version='[9.3.0,9.3.1)'

--- a/northbound/websocket/integration-test.bndrun
+++ b/northbound/websocket/integration-test.bndrun
@@ -55,12 +55,8 @@
 	org.eclipse.emf.ecore.xmi;version='[2.36.0,2.36.1)',\
 	org.eclipse.jetty.alpn.client;version='[11.0.13,11.0.14)',\
 	org.eclipse.jetty.client;version='[11.0.13,11.0.14)',\
-	org.eclipse.jetty.io;version='[11.0.13,11.0.14)',\
 	org.eclipse.jetty.jndi;version='[11.0.13,11.0.14)',\
 	org.eclipse.jetty.plus;version='[11.0.13,11.0.14)',\
-	org.eclipse.jetty.security;version='[11.0.13,11.0.14)',\
-	org.eclipse.jetty.server;version='[11.0.13,11.0.14)',\
-	org.eclipse.jetty.servlet;version='[11.0.13,11.0.14)',\
 	org.eclipse.jetty.util;version='[11.0.13,11.0.14)',\
 	org.eclipse.jetty.webapp;version='[11.0.13,11.0.14)',\
 	org.eclipse.jetty.websocket.api;version='[11.0.13,11.0.14)',\
@@ -98,5 +94,5 @@
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
 	org.osgi.util.promise;version='[1.3.0,1.3.1)',\
 	org.osgi.util.pushstream;version='[1.0.2,1.0.3)',\
-	slf4j.api;version='[1.7.36,1.7.37)',\
-	slf4j.simple;version='[1.7.36,1.7.37)'
+	slf4j.api;version='[2.0.11,2.0.12)',\
+	slf4j.simple;version='[2.0.11,2.0.12)'

--- a/pom.xml
+++ b/pom.xml
@@ -320,11 +320,6 @@
         <version>${slf4j.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>log4j-over-slf4j</artifactId>
-        <version>${slf4j.version}</version>
-      </dependency>
-      <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
         <version>${jackson.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
     <emf.common.version>2.29.0</emf.common.version>
     <emf.ecore.version>2.35.0</emf.ecore.version>
     <emf.ecore.xmi.version>2.36.0</emf.ecore.xmi.version>
-    <slf4j.version>1.7.36</slf4j.version>
+    <slf4j.version>2.0.11</slf4j.version>
     <jackson.version>2.16.1</jackson.version>
     <jjwt.version>0.11.5</jjwt.version>
 

--- a/southbound/history/timescale-provider/integration-test.bndrun
+++ b/southbound/history/timescale-provider/integration-test.bndrun
@@ -31,6 +31,7 @@
 	junit-platform-engine;version='[1.10.1,1.10.2)',\
 	junit-platform-launcher;version='[1.10.1,1.10.2)',\
 	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
+	org.apache.aries.spifly.dynamic.framework.extension;version='[1.3.7,1.3.8)',\
 	org.apache.aries.typedevent.bus;version='[0.0.2,0.0.3)',\
 	org.apache.commons.commons-compress;version='[1.24.0,1.24.1)',\
 	org.apache.felix.configadmin;version='[1.9.24,1.9.25)',\
@@ -61,7 +62,7 @@
 	org.osgi.util.promise;version='[1.3.0,1.3.1)',\
 	org.osgi.util.pushstream;version='[1.0.2,1.0.3)',\
 	org.postgresql.jdbc;version='[42.5.1,42.5.2)',\
-	slf4j.api;version='[1.7.36,1.7.37)',\
-	slf4j.simple;version='[1.7.36,1.7.37)',\
+	slf4j.api;version='[2.0.11,2.0.12)',\
+	slf4j.simple;version='[2.0.11,2.0.12)',\
 	tx-control-provider-jdbc-local;version='[1.0.1,1.0.2)',\
 	tx-control-service-local;version='[1.0.1,1.0.2)'

--- a/southbound/http/http-callback-whiteboard/integration-test.bndrun
+++ b/southbound/http/http-callback-whiteboard/integration-test.bndrun
@@ -22,6 +22,7 @@
 	order=sortbynameversion,\
 	begin=-1
 -runbundles: \
+	jakarta.servlet-api;version='[5.0.0,5.0.1)',\
 	junit-jupiter-api;version='[5.10.1,5.10.2)',\
 	junit-jupiter-engine;version='[5.10.1,5.10.2)',\
 	junit-jupiter-params;version='[5.10.1,5.10.2)',\
@@ -30,6 +31,7 @@
 	junit-platform-launcher;version='[1.10.1,1.10.2)',\
 	net.bytebuddy.byte-buddy;version='[1.14.11,1.14.12)',\
 	net.bytebuddy.byte-buddy-agent;version='[1.14.11,1.14.12)',\
+	org.apache.aries.spifly.dynamic.framework.extension;version='[1.3.7,1.3.8)',\
 	org.apache.felix.configadmin;version='[1.9.24,1.9.25)',\
 	org.apache.felix.http.jetty;version='[5.0.0,5.0.1)',\
 	org.apache.felix.http.servlet-api;version='[2.1.0,2.1.1)',\
@@ -48,5 +50,5 @@
 	org.osgi.test.junit5.cm;version='[1.3.0,1.3.1)',\
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
 	org.osgi.util.promise;version='[1.3.0,1.3.1)',\
-	slf4j.api;version='[1.7.36,1.7.37)',\
-	slf4j.simple;version='[1.7.36,1.7.37)'
+	slf4j.api;version='[2.0.11,2.0.12)',\
+	slf4j.simple;version='[2.0.11,2.0.12)'

--- a/southbound/http/http-device-factory/integration-test.bndrun
+++ b/southbound/http/http-device-factory/integration-test.bndrun
@@ -35,6 +35,7 @@
 	junit-platform-engine;version='[1.10.1,1.10.2)',\
 	junit-platform-launcher;version='[1.10.1,1.10.2)',\
 	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
+	org.apache.aries.spifly.dynamic.framework.extension;version='[1.3.7,1.3.8)',\
 	org.apache.aries.typedevent.bus;version='[0.0.2,0.0.3)',\
 	org.apache.commons.commons-csv;version='[1.9.0,1.9.1)',\
 	org.apache.felix.configadmin;version='[1.9.24,1.9.25)',\
@@ -71,5 +72,5 @@
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
 	org.osgi.util.promise;version='[1.3.0,1.3.1)',\
 	org.osgi.util.pushstream;version='[1.0.2,1.0.3)',\
-	slf4j.api;version='[1.7.36,1.7.37)',\
-	slf4j.simple;version='[1.7.36,1.7.37)'
+	slf4j.api;version='[2.0.11,2.0.12)',\
+	slf4j.simple;version='[2.0.11,2.0.12)'

--- a/southbound/mqtt/mqtt-device-factory/integration-test.bndrun
+++ b/southbound/mqtt/mqtt-device-factory/integration-test.bndrun
@@ -15,8 +15,6 @@
 # These packages are also provided by the gecko.emf.osgi.component project
 # so we blacklist the API for resolve consistency
 -runblacklist: bnd.identity;id='org.gecko.emf.osgi.api',\
-	bnd.identity;id='slf4j.log4j12',\
-	bnd.identity;id='log4j.over.slf4j',\
 	bnd.identity;id='org.osgi.service.cm'
 
 # This will help us keep -runbundles sorted

--- a/southbound/mqtt/mqtt-device-factory/integration-test.bndrun
+++ b/southbound/mqtt/mqtt-device-factory/integration-test.bndrun
@@ -47,6 +47,7 @@
 	junit-platform-engine;version='[1.10.1,1.10.2)',\
 	junit-platform-launcher;version='[1.10.1,1.10.2)',\
 	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
+	org.apache.aries.spifly.dynamic.framework.extension;version='[1.3.7,1.3.8)',\
 	org.apache.aries.typedevent.bus;version='[0.0.2,0.0.3)',\
 	org.apache.commons.codec;version='[1.10.0,1.10.1)',\
 	org.apache.commons.commons-csv;version='[1.9.0,1.9.1)',\
@@ -79,5 +80,5 @@
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
 	org.osgi.util.promise;version='[1.3.0,1.3.1)',\
 	org.osgi.util.pushstream;version='[1.0.2,1.0.3)',\
-	slf4j.api;version='[1.7.36,1.7.37)',\
-	slf4j.simple;version='[1.7.36,1.7.37)'
+	slf4j.api;version='[2.0.11,2.0.12)',\
+	slf4j.simple;version='[2.0.11,2.0.12)'

--- a/southbound/virtual/virtual-temperature-sensor/integration-test.bndrun
+++ b/southbound/virtual/virtual-temperature-sensor/integration-test.bndrun
@@ -29,6 +29,7 @@
 	junit-platform-engine;version='[1.10.1,1.10.2)',\
 	junit-platform-launcher;version='[1.10.1,1.10.2)',\
 	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
+	org.apache.aries.spifly.dynamic.framework.extension;version='[1.3.7,1.3.8)',\
 	org.apache.aries.typedevent.bus;version='[0.0.2,0.0.3)',\
 	org.apache.felix.configadmin;version='[1.9.24,1.9.25)',\
 	org.apache.felix.scr;version='[2.2.2,2.2.3)',\
@@ -54,5 +55,5 @@
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
 	org.osgi.util.promise;version='[1.3.0,1.3.1)',\
 	org.osgi.util.pushstream;version='[1.0.2,1.0.3)',\
-	slf4j.api;version='[1.7.36,1.7.37)',\
-	slf4j.simple;version='[1.7.36,1.7.37)'
+	slf4j.api;version='[2.0.11,2.0.12)',\
+	slf4j.simple;version='[2.0.11,2.0.12)'


### PR DESCRIPTION
Updating to a more recent version of slf4j, as the current version is an older version.