### PR TITLE
Better error handling for pushed updates

### DIFF
--- a/core/api/src/main/java/org/eclipse/sensinact/core/push/DataMappingException.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/push/DataMappingException.java
@@ -1,0 +1,24 @@
+/*********************************************************************
+* Copyright (c) 2024 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Kentyou - initial implementation
+**********************************************************************/
+package org.eclipse.sensinact.core.push;
+
+public class DataMappingException extends DataUpdateException {
+
+    private static final long serialVersionUID = -1312692222440022024L;
+
+    public DataMappingException(String modelPackageUri, String model, String provider, String service, String resource,
+            Object originalDto, Throwable cause) {
+        super(modelPackageUri, model, provider, service, resource, originalDto,
+                "Unable to map DTO data into an update " + cause.getMessage(), cause);
+    }
+}

--- a/core/api/src/main/java/org/eclipse/sensinact/core/push/DataUpdate.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/push/DataUpdate.java
@@ -1,5 +1,5 @@
 /*********************************************************************
-* Copyright (c) 2022 Contributors to the Eclipse Foundation.
+* Copyright (c) 2024 Contributors to the Eclipse Foundation.
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0
@@ -16,6 +16,18 @@ import org.osgi.util.promise.Promise;
 
 public interface DataUpdate {
 
+    /**
+     * Push an update into the sensiNact Digital Twin
+     * @param o - the update data
+     * @return a Promise representing the status of the update.
+     * <p> This promise will resolve successfully if the update(s)
+     * all complete normally. If any updates fail then the promise
+     * will fail with a {@link FailedUpdatesException} indicating
+     * which update(s) failed.</p>
+     * <p><strong>N.B.</strong> A failed promise does not indicate
+     * that no updates were successfully processed, only that
+     * at least one update failed to be applied.</p>
+     */
     Promise<?> pushUpdate(Object o);
 
 }

--- a/core/api/src/main/java/org/eclipse/sensinact/core/push/DataUpdateException.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/push/DataUpdateException.java
@@ -1,0 +1,92 @@
+/*********************************************************************
+* Copyright (c) 2024 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Kentyou - initial implementation
+**********************************************************************/
+package org.eclipse.sensinact.core.push;
+
+import java.util.Objects;
+
+public class DataUpdateException extends Exception {
+
+    private static final long serialVersionUID = -3948871450647637647L;
+    private final String modelPackageUri;
+    private final String model;
+    private final String provider;
+    private final String service;
+    private final String resource;
+
+    private final Object originalDto;
+
+    public DataUpdateException(String modelPackageUri, String model, String provider, String service, String resource,
+            Object originalDto, Throwable cause) {
+        this(modelPackageUri, model, provider, service, resource, originalDto,
+                cause == null ? getDefaultMessage(provider, service, resource) : cause.getMessage(), cause);
+    }
+
+    private static String getDefaultMessage(String provider, String service, String resource) {
+        return String.format("Data update failed for %s/%s/%s", provider, service, resource);
+    }
+
+    protected DataUpdateException(String modelPackageUri, String model, String provider, String service, String resource,
+            Object originalDto, String message, Throwable cause) {
+        super(message, cause);
+        Objects.requireNonNull(originalDto);
+        this.modelPackageUri = modelPackageUri;
+        this.model = model;
+        this.provider = provider;
+        this.service = service;
+        this.resource = resource;
+        this.originalDto = originalDto;
+    }
+
+    /**
+     * @return The discovered modelPackageUri, or null
+     */
+    public String getModelPackageUri() {
+        return modelPackageUri;
+    }
+
+    /**
+     * @return The discovered model, or null
+     */
+    public String getModel() {
+        return model;
+    }
+
+    /**
+     * @return The discovered provider, or null
+     */
+    public String getProvider() {
+        return provider;
+    }
+
+    /**
+     * @return The discovered service, or null
+     */
+    public String getService() {
+        return service;
+    }
+
+    /**
+     * @return The discovered resource, or null
+     */
+    public String getResource() {
+        return resource;
+    }
+
+    /**
+     * @return The DTO that was being mapped
+     */
+    public Object getOriginalDto() {
+        return originalDto;
+    }
+
+}

--- a/core/api/src/main/java/org/eclipse/sensinact/core/push/FailedUpdatesException.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/push/FailedUpdatesException.java
@@ -1,0 +1,42 @@
+/*********************************************************************
+* Copyright (c) 2024 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Kentyou - initial implementation
+**********************************************************************/
+package org.eclipse.sensinact.core.push;
+
+import static java.util.stream.Collectors.toUnmodifiableList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+public class FailedUpdatesException extends Exception {
+
+    private static final long serialVersionUID = 558905737809687311L;
+
+    private final List<DataUpdateException> failedUpdates;
+
+    public FailedUpdatesException(DataUpdateException failedUpdate) {
+        Objects.requireNonNull(failedUpdate);
+        failedUpdates = List.of(failedUpdate);
+        addSuppressed(failedUpdate);
+    }
+
+    public FailedUpdatesException(Stream<? extends DataUpdateException> failedUpdates) {
+        Objects.requireNonNull(failedUpdates);
+        this.failedUpdates = failedUpdates.collect(toUnmodifiableList());
+        this.failedUpdates.forEach(this::addSuppressed);
+    }
+
+    public List<DataUpdateException> getFailedUpdates() {
+        return failedUpdates;
+    }
+}

--- a/core/impl/integration-test.bndrun
+++ b/core/impl/integration-test.bndrun
@@ -5,7 +5,7 @@
 	bnd.identity;id='ch.qos.logback.classic'
 -resolve.effective: active
 
--runee: JavaSE-11
+-runee: JavaSE-17
 -runfw: org.apache.felix.framework
 -runproperties: \
 	org.osgi.framework.bootdelegation=org.mockito.internal.creation.bytebuddy.inject,\

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/dto/impl/AbstractUpdateDto.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/dto/impl/AbstractUpdateDto.java
@@ -45,4 +45,9 @@ public abstract class AbstractUpdateDto {
      * The timestamp for this update. If not set then the current time is used.
      */
     public Instant timestamp;
+
+    /**
+     * The original object which this update is derived from
+     */
+    public Object originalDto;
 }

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/dto/impl/FailedMappingDto.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/dto/impl/FailedMappingDto.java
@@ -1,0 +1,19 @@
+/*********************************************************************
+* Copyright (c) 2024 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Kentyou - initial implementation
+**********************************************************************/
+package org.eclipse.sensinact.core.dto.impl;
+
+public class FailedMappingDto extends AbstractUpdateDto {
+
+    public Throwable mappingFailure;
+
+}

--- a/core/impl/src/test/java/org/eclipse/sensinact/core/extract/impl/AnnotationBasedDtoExtractorTest.java
+++ b/core/impl/src/test/java/org/eclipse/sensinact/core/extract/impl/AnnotationBasedDtoExtractorTest.java
@@ -15,7 +15,8 @@ package org.eclipse.sensinact.core.extract.impl;
 import static java.util.Collections.singletonMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
@@ -34,6 +35,7 @@ import org.eclipse.sensinact.core.annotation.dto.Service;
 import org.eclipse.sensinact.core.annotation.dto.Timestamp;
 import org.eclipse.sensinact.core.dto.impl.AbstractUpdateDto;
 import org.eclipse.sensinact.core.dto.impl.DataUpdateDto;
+import org.eclipse.sensinact.core.dto.impl.FailedMappingDto;
 import org.eclipse.sensinact.core.dto.impl.MetadataUpdateDto;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -132,23 +134,41 @@ public class AnnotationBasedDtoExtractorTest {
         @Test
         void missingProviderName() {
 
-            Exception thrown = assertThrows(IllegalArgumentException.class, () -> {
-                extractor(BasicDtoClassLevelError.class);
-            });
+            DataExtractor extractor = extractor(BasicDtoClassLevelError.class);
+            List<? extends AbstractUpdateDto> updates = extractor.getUpdates(new BasicDtoClassLevel());
 
-            assertTrue(thrown.getMessage().contains("annotated with Provider but that annotation has no value"),
-                    "Wrong message: " + thrown.getMessage());
+            assertNotNull(updates);
+            assertEquals(1, updates.size());
+            AbstractUpdateDto aud = updates.get(0);
+            assertNotNull(aud);
+            assertInstanceOf(FailedMappingDto.class, aud);
+            FailedMappingDto fmd = (FailedMappingDto) aud;
+            assertNotNull(fmd.mappingFailure);
+
+            assertTrue(fmd.mappingFailure.getMessage().contains("not properly defined"),
+                    "Wrong message: " + fmd.mappingFailure.getMessage());
+            assertTrue(fmd.mappingFailure.getCause().getMessage().contains("annotated with Provider but that annotation has no value"),
+                    "Wrong message: " + fmd.mappingFailure.getCause().getMessage());
         }
 
         @Test
         void missingServiceName() {
 
-            Exception thrown = assertThrows(IllegalArgumentException.class, () -> {
-                extractor(BasicDtoClassLevelError2.class);
-            });
+            DataExtractor extractor = extractor(BasicDtoClassLevelError2.class);
+            List<? extends AbstractUpdateDto> updates = extractor.getUpdates(new BasicDtoClassLevelError2());
 
-            assertTrue(thrown.getMessage().contains("annotated with Service but that annotation has no value"),
-                    "Wrong message: " + thrown.getMessage());
+            assertNotNull(updates);
+            assertEquals(1, updates.size());
+            AbstractUpdateDto aud = updates.get(0);
+            assertNotNull(aud);
+            assertInstanceOf(FailedMappingDto.class, aud);
+            FailedMappingDto fmd = (FailedMappingDto) aud;
+            assertNotNull(fmd.mappingFailure);
+
+            assertTrue(fmd.mappingFailure.getMessage().contains("not properly defined"),
+                    "Wrong message: " + fmd.mappingFailure.getMessage());
+            assertTrue(fmd.mappingFailure.getCause().getMessage().contains("annotated with Service but that annotation has no value"),
+                    "Wrong message: " + fmd.mappingFailure.getCause().getMessage());
         }
 
         @Test

--- a/core/impl/src/test/java/org/eclipse/sensinact/core/extract/impl/GenericDtoExtractorTest.java
+++ b/core/impl/src/test/java/org/eclipse/sensinact/core/extract/impl/GenericDtoExtractorTest.java
@@ -15,8 +15,9 @@ package org.eclipse.sensinact.core.extract.impl;
 import static java.util.Collections.singletonMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
@@ -24,11 +25,12 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
-import org.eclipse.sensinact.core.push.dto.BulkGenericDto;
-import org.eclipse.sensinact.core.push.dto.GenericDto;
 import org.eclipse.sensinact.core.dto.impl.AbstractUpdateDto;
 import org.eclipse.sensinact.core.dto.impl.DataUpdateDto;
+import org.eclipse.sensinact.core.dto.impl.FailedMappingDto;
 import org.eclipse.sensinact.core.dto.impl.MetadataUpdateDto;
+import org.eclipse.sensinact.core.push.dto.BulkGenericDto;
+import org.eclipse.sensinact.core.push.dto.GenericDto;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -57,29 +59,47 @@ public class GenericDtoExtractorTest {
     class MissingIdentity {
         @Test
         void missingProvider() {
-            Exception thrown = assertThrows(IllegalArgumentException.class, () -> {
-                extractor().getUpdates(makeTestDto(null, SERVICE, RESOURCE, VALUE, null, null));
-            });
+            List<? extends AbstractUpdateDto> updates = extractor().getUpdates(makeTestDto(null, SERVICE, RESOURCE, VALUE, null, null));
+            assertEquals(1, updates.size());
+            AbstractUpdateDto aud = updates.get(0);
+            assertNull(aud.provider);
+            assertEquals(SERVICE, aud.service);
+            assertEquals(RESOURCE, aud.resource);
 
-            assertTrue(thrown.getMessage().contains("provider"), "Wrong message: " + thrown.getMessage());
+            assertInstanceOf(FailedMappingDto.class, aud);
+            FailedMappingDto fmd = (FailedMappingDto) aud;
+            assertNotNull(fmd.mappingFailure);
+            assertTrue(fmd.mappingFailure.getMessage().contains("provider"), "Wrong message: " + fmd.mappingFailure.getMessage());
         }
 
         @Test
         void missingService() {
-            Exception thrown = assertThrows(IllegalArgumentException.class, () -> {
-                extractor().getUpdates(makeTestDto(PROVIDER, null, RESOURCE, VALUE, null, null));
-            });
+            List<? extends AbstractUpdateDto> updates = extractor().getUpdates(makeTestDto(PROVIDER, null, RESOURCE, VALUE, null, null));
+            assertEquals(1, updates.size());
+            AbstractUpdateDto aud = updates.get(0);
+            assertEquals(PROVIDER, aud.provider);
+            assertNull(aud.service);
+            assertEquals(RESOURCE, aud.resource);
 
-            assertTrue(thrown.getMessage().contains("service"), "Wrong message: " + thrown.getMessage());
+            assertInstanceOf(FailedMappingDto.class, aud);
+            FailedMappingDto fmd = (FailedMappingDto) aud;
+            assertNotNull(fmd.mappingFailure);
+            assertTrue(fmd.mappingFailure.getMessage().contains("service"), "Wrong message: " + fmd.mappingFailure.getMessage());
         }
 
         @Test
         void missingResource() {
-            Exception thrown = assertThrows(IllegalArgumentException.class, () -> {
-                extractor().getUpdates(makeTestDto(PROVIDER, SERVICE, null, VALUE, null, null));
-            });
+            List<? extends AbstractUpdateDto> updates = extractor().getUpdates(makeTestDto(PROVIDER, SERVICE, null, VALUE, null, null));
+            assertEquals(1, updates.size());
+            AbstractUpdateDto aud = updates.get(0);
+            assertEquals(PROVIDER, aud.provider);
+            assertEquals(SERVICE, aud.service);
+            assertNull(aud.resource);
 
-            assertTrue(thrown.getMessage().contains("resource"), "Wrong message: " + thrown.getMessage());
+            assertInstanceOf(FailedMappingDto.class, aud);
+            FailedMappingDto fmd = (FailedMappingDto) aud;
+            assertNotNull(fmd.mappingFailure);
+            assertTrue(fmd.mappingFailure.getMessage().contains("resource"), "Wrong message: " + fmd.mappingFailure.getMessage());
         }
     }
 

--- a/core/impl/src/test/java/org/eclipse/sensinact/core/integration/DataUpdateServiceTest.java
+++ b/core/impl/src/test/java/org/eclipse/sensinact/core/integration/DataUpdateServiceTest.java
@@ -1,0 +1,452 @@
+/*********************************************************************
+* Copyright (c) 2024 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Kentyou - initial implementation
+**********************************************************************/
+package org.eclipse.sensinact.core.integration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.lang.reflect.InvocationTargetException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import org.eclipse.sensinact.core.annotation.dto.Data;
+import org.eclipse.sensinact.core.annotation.dto.Provider;
+import org.eclipse.sensinact.core.annotation.dto.Resource;
+import org.eclipse.sensinact.core.annotation.dto.Service;
+import org.eclipse.sensinact.core.annotation.dto.Timestamp;
+import org.eclipse.sensinact.core.command.AbstractTwinCommand;
+import org.eclipse.sensinact.core.command.GatewayThread;
+import org.eclipse.sensinact.core.push.DataUpdate;
+import org.eclipse.sensinact.core.push.DataUpdateException;
+import org.eclipse.sensinact.core.push.FailedUpdatesException;
+import org.eclipse.sensinact.core.push.dto.BulkGenericDto;
+import org.eclipse.sensinact.core.push.dto.GenericDto;
+import org.eclipse.sensinact.core.security.UserInfo;
+import org.eclipse.sensinact.core.session.SensiNactSession;
+import org.eclipse.sensinact.core.session.SensiNactSessionManager;
+import org.eclipse.sensinact.core.twin.SensinactDigitalTwin;
+import org.eclipse.sensinact.core.twin.SensinactProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.osgi.test.common.annotation.InjectService;
+import org.osgi.util.promise.Promise;
+import org.osgi.util.promise.PromiseFactory;
+
+/**
+ * Tests the error behavior of the {@link DataUpdate} service
+ */
+public class DataUpdateServiceTest {
+
+    private static final UserInfo USER = UserInfo.ANONYMOUS;
+
+    private static final String PROVIDER = "DataUpdateServiceTestProvider";
+    private static final String SERVICE = "service";
+    private static final String RESOURCE = "resource";
+
+    @InjectService
+    DataUpdate push;
+    @InjectService
+    SensiNactSessionManager sessionManager;
+    SensiNactSession session;
+
+    @BeforeEach
+    void start() {
+        session = sessionManager.getDefaultSession(USER);
+    }
+
+    @AfterEach
+    void stop(@InjectService GatewayThread gt) throws InvocationTargetException, InterruptedException {
+        session.expire();
+        gt.execute(new AbstractTwinCommand<Void>() {
+            @Override
+            protected Promise<Void> call(SensinactDigitalTwin twin, PromiseFactory pf) {
+                Optional.ofNullable(twin.getProvider(PROVIDER))
+                    .ifPresent(SensinactProvider::delete);
+                return pf.resolved(null);
+            }
+        }).getValue();
+    }
+
+    public static class AnnotatedDTO {
+        @Provider
+        public String provider;
+
+        @Service
+        public String service;
+
+        @Resource
+        public String resource;
+
+        @Timestamp
+        public String time;
+
+        @Data(type = Integer.class)
+        public String data;
+    }
+
+    /**
+     * Tests valid admin resource creation with provider and update
+     */
+    @Nested
+    class ValidPushes {
+        @Test
+        void testSimplePush() throws Exception {
+            final Instant timestamp = Instant.now();
+
+            // Create resource & provider using a push
+            GenericDto dto = new GenericDto();
+            dto.provider = PROVIDER;
+            dto.service = SERVICE;
+            dto.resource = RESOURCE;
+            dto.value = 42;
+            dto.type = Integer.class;
+            dto.timestamp = timestamp;
+            push.pushUpdate(dto).getValue();
+
+            assertEquals(42, session.getResourceValue(PROVIDER, SERVICE, RESOURCE, Integer.class));
+        }
+
+        @Test
+        void testSimplePushAnnotated() throws Exception {
+            final Instant timestamp = Instant.now();
+
+            // Create resource & provider using a push
+            AnnotatedDTO dto = new AnnotatedDTO();
+            dto.provider = PROVIDER;
+            dto.service = SERVICE;
+            dto.resource = RESOURCE;
+            dto.data = "42";
+            dto.time = String.valueOf(timestamp.toEpochMilli());
+            push.pushUpdate(dto).getValue();
+
+            assertEquals(42, session.getResourceValue(PROVIDER, SERVICE, RESOURCE, Integer.class));
+        }
+    }
+
+    @Nested
+    class FailingGenericPushes {
+        @Test
+        void testProvider() throws Exception {
+            final Instant timestamp = Instant.now();
+
+            // Create resource & provider using a push
+            GenericDto dto = new GenericDto();
+            dto.provider = null;
+            dto.service = SERVICE;
+            dto.resource = RESOURCE;
+            dto.value = 42;
+            dto.type = Integer.class;
+            dto.timestamp = timestamp;
+            Throwable t = push.pushUpdate(dto).getFailure();
+
+            assertNotNull(t);
+            assertInstanceOf(FailedUpdatesException.class, t);
+            FailedUpdatesException fue = (FailedUpdatesException) t;
+            List<DataUpdateException> failedUpdates = fue.getFailedUpdates();
+            assertNotNull(failedUpdates);
+            assertEquals(1, failedUpdates.size());
+            DataUpdateException due = failedUpdates.get(0);
+            assertNotNull(due);
+            assertSame(dto, due.getOriginalDto());
+            assertEquals(SERVICE, due.getService());
+            assertEquals(RESOURCE, due.getResource());
+        }
+
+        @Test
+        void testService() throws Exception {
+            final Instant timestamp = Instant.now();
+
+            // Create resource & provider using a push
+            GenericDto dto = new GenericDto();
+            dto.provider = PROVIDER;
+            dto.service = null;
+            dto.resource = RESOURCE;
+            dto.value = 42;
+            dto.type = Integer.class;
+            dto.timestamp = timestamp;
+            Throwable t = push.pushUpdate(dto).getFailure();
+
+            assertNotNull(t);
+            assertInstanceOf(FailedUpdatesException.class, t);
+            FailedUpdatesException fue = (FailedUpdatesException) t;
+            List<DataUpdateException> failedUpdates = fue.getFailedUpdates();
+            assertNotNull(failedUpdates);
+            assertEquals(1, failedUpdates.size());
+            DataUpdateException due = failedUpdates.get(0);
+            assertNotNull(due);
+            assertSame(dto, due.getOriginalDto());
+            assertEquals(PROVIDER, due.getProvider());
+            assertEquals(RESOURCE, due.getResource());
+        }
+
+        @Test
+        void testResource() throws Exception {
+            final Instant timestamp = Instant.now();
+
+            // Create resource & provider using a push
+            GenericDto dto = new GenericDto();
+            dto.provider = PROVIDER;
+            dto.service = SERVICE;
+            dto.resource = null;
+            dto.value = 42;
+            dto.type = Integer.class;
+            dto.timestamp = timestamp;
+            Throwable t = push.pushUpdate(dto).getFailure();
+
+            assertNotNull(t);
+            assertInstanceOf(FailedUpdatesException.class, t);
+            FailedUpdatesException fue = (FailedUpdatesException) t;
+            List<DataUpdateException> failedUpdates = fue.getFailedUpdates();
+            assertNotNull(failedUpdates);
+            assertEquals(1, failedUpdates.size());
+            DataUpdateException due = failedUpdates.get(0);
+            assertNotNull(due);
+            assertSame(dto, due.getOriginalDto());
+            assertEquals(PROVIDER, due.getProvider());
+            assertEquals(SERVICE, due.getService());
+        }
+
+        @Test
+        void testValue() throws Exception {
+            final Instant timestamp = Instant.now();
+
+            // Create resource & provider using a push
+            GenericDto dto = new GenericDto();
+            dto.provider = PROVIDER;
+            dto.service = SERVICE;
+            dto.resource = RESOURCE;
+            dto.value = "0xCAFEBABE";
+            dto.type = Integer.class;
+            dto.timestamp = timestamp;
+            Throwable t = push.pushUpdate(dto).getFailure();
+
+            assertNotNull(t);
+            assertInstanceOf(FailedUpdatesException.class, t);
+            FailedUpdatesException fue = (FailedUpdatesException) t;
+            List<DataUpdateException> failedUpdates = fue.getFailedUpdates();
+            assertNotNull(failedUpdates);
+            assertEquals(1, failedUpdates.size());
+            DataUpdateException due = failedUpdates.get(0);
+            assertNotNull(due);
+            assertSame(dto, due.getOriginalDto());
+            assertEquals(PROVIDER, due.getProvider());
+            assertEquals(SERVICE, due.getService());
+            assertEquals(RESOURCE, due.getResource());
+        }
+    }
+
+    @Nested
+    class FailingAnnotatedPushes {
+        @Test
+        void testProvider() throws Exception {
+            final Instant timestamp = Instant.now();
+
+            // Create resource & provider using a push
+            AnnotatedDTO dto = new AnnotatedDTO();
+            dto.provider = null;
+            dto.service = SERVICE;
+            dto.resource = RESOURCE;
+            dto.data = "42";
+            dto.time = String.valueOf(timestamp.toEpochMilli());
+            Throwable t = push.pushUpdate(dto).getFailure();
+
+            assertNotNull(t);
+            assertInstanceOf(FailedUpdatesException.class, t);
+            FailedUpdatesException fue = (FailedUpdatesException) t;
+            List<DataUpdateException> failedUpdates = fue.getFailedUpdates();
+            assertNotNull(failedUpdates);
+            assertEquals(1, failedUpdates.size());
+            DataUpdateException due = failedUpdates.get(0);
+            assertNotNull(due);
+            assertSame(dto, due.getOriginalDto());
+            assertEquals(SERVICE, due.getService());
+            assertEquals(RESOURCE, due.getResource());
+        }
+
+        @Test
+        void testService() throws Exception {
+            final Instant timestamp = Instant.now();
+
+            // Create resource & provider using a push
+            AnnotatedDTO dto = new AnnotatedDTO();
+            dto.provider = PROVIDER;
+            dto.service = null;
+            dto.resource = RESOURCE;
+            dto.data = "42";
+            dto.time = String.valueOf(timestamp.toEpochMilli());
+            Throwable t = push.pushUpdate(dto).getFailure();
+
+            assertNotNull(t);
+            assertInstanceOf(FailedUpdatesException.class, t);
+            FailedUpdatesException fue = (FailedUpdatesException) t;
+            List<DataUpdateException> failedUpdates = fue.getFailedUpdates();
+            assertNotNull(failedUpdates);
+            assertEquals(1, failedUpdates.size());
+            DataUpdateException due = failedUpdates.get(0);
+            assertNotNull(due);
+            assertSame(dto, due.getOriginalDto());
+            assertEquals(PROVIDER, due.getProvider());
+            assertEquals(RESOURCE, due.getResource());
+        }
+
+        @Test
+        void testResource() throws Exception {
+            final Instant timestamp = Instant.now();
+
+            // Create resource & provider using a push
+            AnnotatedDTO dto = new AnnotatedDTO();
+            dto.provider = PROVIDER;
+            dto.service = SERVICE;
+            dto.resource = null;
+            dto.data = "42";
+            dto.time = String.valueOf(timestamp.toEpochMilli());
+            Throwable t = push.pushUpdate(dto).getFailure();
+
+            assertNotNull(t);
+            assertInstanceOf(FailedUpdatesException.class, t);
+            FailedUpdatesException fue = (FailedUpdatesException) t;
+            List<DataUpdateException> failedUpdates = fue.getFailedUpdates();
+            assertNotNull(failedUpdates);
+            assertEquals(1, failedUpdates.size());
+            DataUpdateException due = failedUpdates.get(0);
+            assertNotNull(due);
+            assertSame(dto, due.getOriginalDto());
+            assertEquals(PROVIDER, due.getProvider());
+            assertEquals(SERVICE, due.getService());
+        }
+
+        @Test
+        void testValue() throws Exception {
+            final Instant timestamp = Instant.now();
+
+            // Create resource & provider using a push
+            AnnotatedDTO dto = new AnnotatedDTO();
+            dto.provider = PROVIDER;
+            dto.service = SERVICE;
+            dto.resource = RESOURCE;
+            dto.data = "Forty-two";
+            dto.time = String.valueOf(timestamp.toEpochMilli());
+            Throwable t = push.pushUpdate(dto).getFailure();
+
+            assertNotNull(t);
+            assertInstanceOf(FailedUpdatesException.class, t);
+            FailedUpdatesException fue = (FailedUpdatesException) t;
+            List<DataUpdateException> failedUpdates = fue.getFailedUpdates();
+            assertNotNull(failedUpdates);
+            assertEquals(1, failedUpdates.size());
+            DataUpdateException due = failedUpdates.get(0);
+            assertNotNull(due);
+            assertSame(dto, due.getOriginalDto());
+            assertEquals(PROVIDER, due.getProvider());
+            assertEquals(SERVICE, due.getService());
+            assertEquals(RESOURCE, due.getResource());
+        }
+
+        @Test
+        void testTimestamp() throws Exception {
+            // Create resource & provider using a push
+            AnnotatedDTO dto = new AnnotatedDTO();
+            dto.provider = PROVIDER;
+            dto.service = SERVICE;
+            dto.resource = RESOURCE;
+            dto.data = "42";
+            dto.time = "Tomorrow";
+            Throwable t = push.pushUpdate(dto).getFailure();
+
+            assertNotNull(t);
+            assertInstanceOf(FailedUpdatesException.class, t);
+            FailedUpdatesException fue = (FailedUpdatesException) t;
+            List<DataUpdateException> failedUpdates = fue.getFailedUpdates();
+            assertNotNull(failedUpdates);
+            assertEquals(1, failedUpdates.size());
+            DataUpdateException due = failedUpdates.get(0);
+            assertNotNull(due);
+            assertSame(dto, due.getOriginalDto());
+            assertEquals(PROVIDER, due.getProvider());
+            assertEquals(SERVICE, due.getService());
+            assertEquals(RESOURCE, due.getResource());
+        }
+    }
+
+    @Nested
+    class FailingBulkPushes {
+        @Test
+        void testMiddleFails() throws Exception {
+            final Instant timestamp = Instant.now();
+
+            // Create resource & provider using a push
+            GenericDto dto = new GenericDto();
+            dto.provider = PROVIDER;
+            dto.service = SERVICE;
+            dto.resource = RESOURCE;
+            dto.value = 42;
+            dto.type = Integer.class;
+            dto.timestamp = timestamp;
+
+            GenericDto dto2 = new GenericDto();
+            dto2.provider = PROVIDER;
+            dto2.service = SERVICE;
+            dto2.resource = RESOURCE;
+            dto2.value = "Forty-three";
+            dto2.type = Integer.class;
+            dto2.timestamp = timestamp;
+
+            GenericDto dto3 = new GenericDto();
+            dto3.provider = PROVIDER;
+            dto3.service = SERVICE;
+            dto3.resource = RESOURCE;
+            dto3.value = "Forty-four";
+            dto3.type = Integer.class;
+            dto3.timestamp = timestamp;
+
+            GenericDto dto4 = new GenericDto();
+            dto4.provider = PROVIDER;
+            dto4.service = SERVICE;
+            dto4.resource = RESOURCE;
+            dto4.value = "45";
+            dto4.type = Integer.class;
+            dto4.timestamp = timestamp;
+
+            BulkGenericDto bulk = new BulkGenericDto();
+            bulk.dtos = List.of(dto, dto2, dto3, dto4);
+
+            Throwable t = push.pushUpdate(bulk).getFailure();
+
+            assertEquals(45, session.getResourceValue(PROVIDER, SERVICE, RESOURCE, Integer.class));
+
+            assertNotNull(t);
+            assertInstanceOf(FailedUpdatesException.class, t);
+            FailedUpdatesException fue = (FailedUpdatesException) t;
+            List<DataUpdateException> failedUpdates = fue.getFailedUpdates();
+            assertNotNull(failedUpdates);
+            assertEquals(2, failedUpdates.size());
+            DataUpdateException due = failedUpdates.get(0);
+            assertNotNull(due);
+            assertSame(dto2, due.getOriginalDto());
+            assertEquals(PROVIDER, due.getProvider());
+            assertEquals(SERVICE, due.getService());
+            assertEquals(RESOURCE, due.getResource());
+            due = failedUpdates.get(1);
+            assertNotNull(due);
+            assertSame(dto3, due.getOriginalDto());
+            assertEquals(PROVIDER, due.getProvider());
+            assertEquals(SERVICE, due.getService());
+            assertEquals(RESOURCE, due.getResource());
+        }
+    }
+}


### PR DESCRIPTION
This commit defines the exceptions that will be used to fail pushed updates, including bulk updates, and will be used to fail the returned promise. These exceptions return the error, and the original DTO so that users can attempt to work out what they did wrong.


Fixes #340 