### PR TITLE
Device factory updates

### DIFF
--- a/docs/source/southbound/device-factory/core.md
+++ b/docs/source/southbound/device-factory/core.md
@@ -194,11 +194,22 @@ We would a provider `ABC` with the following mapped resources in the `sensor` se
 The available types are:
 * `any`: use the value as it was parsed (default)
 * `string`: convert the value to a string
+* `char`: convert the value to a Java character (2 bytes unsigned integer)
+* `byte`: convert the value to a Java byte (1 byte signed integer)
+* `short`: convert the value to a Java short integer (2 bytes signed)
 * `int`, `long`: convert the value to an integer
 * `float`, `double`: convert the value to floating point number
+* `boolean`: convert the value to a boolean, truth being any number other than 0 or a string equal to `true` (case ignored)
+* `any[]`: convert the value to an array of objects
 * `string[]`: convert the value to an array of strings
+* `char[]`: convert the value to an array of Java characters
+* `byte[]`: convert the value to an array of bytes
+* `short[]`: convert the value to an array of short integers
 * `int[]`, `long[]`: convert to an array of integers
 * `float[]`, `double[]`: convert to an array of floating point numbers
+* `boolean[]`: convert to an array of booleans
+
+**Note:** Arrays can contain null values.
 
 ##### Default value
 
@@ -207,7 +218,7 @@ The default value will be treated as if it was read by the parser and will there
 
 ```json
 {
-    "vehicle/count" {
+    "vehicle/count": {
         "path": "nbVehicles",
         "type": "int",
         "default": 0

--- a/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/LocaleUtils.java
+++ b/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/LocaleUtils.java
@@ -1,0 +1,59 @@
+/*********************************************************************
+* Copyright (c) 2024 Kentyou.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Thomas Calmant (Kentyou) - initial implementation
+**********************************************************************/
+package org.eclipse.sensinact.gateway.southbound.device.factory;
+
+import java.util.Locale;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utility methods to find a locale
+ */
+public class LocaleUtils {
+
+    private static final Logger logger = LoggerFactory.getLogger(LocaleUtils.class);
+
+    /**
+     * Try to find the locale from the given string.
+     *
+     * The string can be a language code, a language code and a country code or a
+     * language code, a country code and a variant.
+     * Parts are separated by an underscore character, for example: <code>fr_FR</code>
+     *
+     * @param strLocale Locale string
+     * @return
+     */
+    public static Locale fromString(final String strLocale) {
+        if (strLocale == null || strLocale.isBlank()) {
+            return null;
+        }
+
+        final String[] parts = strLocale.split("_");
+        switch (parts.length) {
+        case 1:
+            return new Locale(parts[0]);
+
+        case 2:
+            return new Locale(parts[0], parts[1]);
+
+        case 3:
+            return new Locale(parts[0], parts[1], parts[2]);
+
+        default:
+            // Invalid locale string
+            logger.warn("Unhandled number locale {}", strLocale);
+            return null;
+        }
+    }
+}

--- a/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/RecordPath.java
+++ b/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/RecordPath.java
@@ -206,6 +206,13 @@ public class RecordPath {
     }
 
     /**
+     * Returns the value type associated to the path
+     */
+    public ValueType getValueType() {
+        return valueType;
+    }
+
+    /**
      * Returns a new instance of the record path with resolved variables
      *
      * @param variables Resolved variables

--- a/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/ValueType.java
+++ b/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/ValueType.java
@@ -35,9 +35,9 @@ public enum ValueType {
         if (v instanceof Character) {
             return (Character) v;
         } else if (v instanceof CharSequence) {
-            final String str = v.toString();
-            if (!str.isEmpty()) {
-                return str.charAt(0);
+            final CharSequence cs = (CharSequence) v;
+            if (cs.length() != 0) {
+                return cs.charAt(0);
             } else {
                 return null;
             }
@@ -253,7 +253,7 @@ public enum ValueType {
             stream = stream.map(v -> itemType.converter.apply(v, options));
         }
 
-        return stream.collect(Collectors.toList());
+        return stream.collect(Collectors.toUnmodifiableList());
     }
 
     /**

--- a/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/ValueType.java
+++ b/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/ValueType.java
@@ -35,6 +35,27 @@ public enum ValueType {
      */
     AS_IS("any", null),
     STRING("string", (v, o) -> String.valueOf(v)),
+    CHAR("char", (v, o) -> {
+        if (v instanceof Character) {
+            return v;
+        } else if (v instanceof CharSequence) {
+            final String str = v.toString();
+            if (!str.isEmpty()) {
+                return str.charAt(0);
+            } else {
+                return null;
+            }
+        } else if (v instanceof Number) {
+            int value = ((Number) v).intValue();
+            if (value > Character.MAX_VALUE || value < Character.MIN_VALUE) {
+                return null;
+            } else {
+                return (char) value;
+            }
+        } else {
+            return null;
+        }
+    }),
     BOOLEAN("boolean", (v, o) -> {
         if (v instanceof Boolean) {
             return v;
@@ -72,6 +93,7 @@ public enum ValueType {
     }),
     ANY_ARRAY("any[]", (v, o) -> asList(v, o, AS_IS.converter)),
     STRING_ARRAY("string[]", (v, o) -> asList(v, o, STRING.converter)),
+    CHAR_ARRAY("char[]", (v, o) -> asList(v, o, CHAR.converter)),
     BOOLEAN_ARRAY("boolean[]", (v, o) -> asList(v, o, BOOLEAN.converter)),
     BYTE_ARRAY("byte[]", (v, o) -> asList(v, o, BYTE.converter)),
     SHORT_ARRAY("short[]", (v, o) -> asList(v, o, SHORT.converter)),

--- a/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/ValueType.java
+++ b/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/ValueType.java
@@ -26,16 +26,12 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.eclipse.sensinact.gateway.southbound.device.factory.dto.DeviceMappingOptionsDTO;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public enum ValueType {
     /**
      * Represent available types
      */
-    AS_IS("any", null, null),
-    STRING("string", (v, o) -> String.valueOf(v), String.class),
-    CHAR("char", (v, o) -> {
+    AS_IS("any", null, null), STRING("string", (v, o) -> String.valueOf(v), String.class), CHAR("char", (v, o) -> {
         if (v instanceof Character) {
             return (Character) v;
         } else if (v instanceof CharSequence) {
@@ -55,8 +51,7 @@ public enum ValueType {
         } else {
             return null;
         }
-    }, Character.class),
-    BOOLEAN("boolean", (v, o) -> {
+    }, Character.class), BOOLEAN("boolean", (v, o) -> {
         if (v instanceof Boolean) {
             return (Boolean) v;
         } else if (v instanceof Number) {
@@ -66,32 +61,25 @@ public enum ValueType {
         } else {
             return null;
         }
-    }, Boolean.class),
-    BYTE("byte", (v, o) -> {
+    }, Boolean.class), BYTE("byte", (v, o) -> {
         final Number parsed = parseNumber(v, true, o);
         return parsed != null ? parsed.byteValue() : null;
-    }, Byte.class),
-    SHORT("short", (v, o) -> {
+    }, Byte.class), SHORT("short", (v, o) -> {
         final Number parsed = parseNumber(v, true, o);
         return parsed != null ? parsed.shortValue() : null;
-    }, Short.class),
-    INT("int", (v, o) -> {
+    }, Short.class), INT("int", (v, o) -> {
         final Number parsed = parseNumber(v, true, o);
         return parsed != null ? parsed.intValue() : null;
-    }, Integer.class),
-    LONG("long", (v, o) -> {
+    }, Integer.class), LONG("long", (v, o) -> {
         final Number parsed = parseNumber(v, true, o);
         return parsed != null ? parsed.longValue() : null;
-    }, Long.class),
-    FLOAT("float", (v, o) -> {
+    }, Long.class), FLOAT("float", (v, o) -> {
         final Number parsed = parseNumber(v, false, o);
         return parsed != null ? parsed.floatValue() : null;
-    }, Float.class),
-    DOUBLE("double", (v, o) -> {
+    }, Float.class), DOUBLE("double", (v, o) -> {
         final Number parsed = parseNumber(v, false, o);
         return parsed != null ? parsed.doubleValue() : null;
-    }, Double.class),
-    ANY_ARRAY("any[]", (v, o) -> asList(v, o, AS_IS), List.class),
+    }, Double.class), ANY_ARRAY("any[]", (v, o) -> asList(v, o, AS_IS), List.class),
     STRING_ARRAY("string[]", (v, o) -> asList(v, o, STRING), List.class),
     CHAR_ARRAY("char[]", (v, o) -> asList(v, o, CHAR), List.class),
     BOOLEAN_ARRAY("boolean[]", (v, o) -> asList(v, o, BOOLEAN), List.class),
@@ -101,8 +89,6 @@ public enum ValueType {
     LONG_ARRAY("long[]", (v, o) -> asList(v, o, LONG), List.class),
     FLOAT_ARRAY("float[]", (v, o) -> asList(v, o, FLOAT), List.class),
     DOUBLE_ARRAY("double[]", (v, o) -> asList(v, o, DOUBLE), List.class);
-
-    private static final Logger logger = LoggerFactory.getLogger(ValueType.class);
 
     /**
      * String representation
@@ -126,28 +112,8 @@ public enum ValueType {
      * @return The number format for the given locale or null
      */
     private static NumberFormat getNumberFormat(final DeviceMappingOptionsDTO options, boolean integers) {
-        final String strLocale = options.numbersLocale;
-        if (strLocale == null || strLocale.isBlank()) {
-            return null;
-        }
-
-        final String[] parts = strLocale.split("_");
-        final Locale locale;
-        switch (parts.length) {
-        case 1:
-            locale = new Locale(parts[0]);
-            break;
-
-        case 2:
-            locale = new Locale(parts[0], parts[1]);
-            break;
-
-        case 3:
-            locale = new Locale(parts[0], parts[1], parts[2]);
-            break;
-
-        default:
-            logger.warn("Unhandled number locale {}", strLocale);
+        final Locale locale = LocaleUtils.fromString(options.numbersLocale);
+        if (locale == null) {
             return null;
         }
 
@@ -220,7 +186,8 @@ public enum ValueType {
      * @param converter Function to convert any input to the value type
      * @param javaClass Java class represented by the value type
      */
-    <T> ValueType(final String strRepr, final BiFunction<Object, DeviceMappingOptionsDTO, T> converter, final Class<T> javaClass) {
+    <T> ValueType(final String strRepr, final BiFunction<Object, DeviceMappingOptionsDTO, T> converter,
+            final Class<T> javaClass) {
         this.repr = strRepr;
         this.converter = converter;
         this.javaClass = javaClass != null ? javaClass : Object.class;

--- a/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/dto/DeviceMappingOptionsDTO.java
+++ b/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/dto/DeviceMappingOptionsDTO.java
@@ -38,4 +38,7 @@ public class DeviceMappingOptionsDTO {
 
     @JsonProperty("null.action")
     public NullAction nullAction = NullAction.UPDATE;
+
+    @JsonProperty("log.errors")
+    public boolean logErrors = false;
 }

--- a/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/dto/DeviceMappingOptionsDTO.java
+++ b/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/dto/DeviceMappingOptionsDTO.java
@@ -30,6 +30,15 @@ public class DeviceMappingOptionsDTO {
     @JsonProperty("format.datetime")
     public String formatDateTime;
 
+    @JsonProperty("format.datetime.locale")
+    public String formatDateTimeLocale;
+
+    @JsonProperty("format.date.style")
+    public String formatDateStyle;
+
+    @JsonProperty("format.time.style")
+    public String formatTimeStyle;
+
     @JsonProperty("datetime.timezone")
     public String dateTimezone;
 

--- a/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/FactoryParserHandler.java
+++ b/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/FactoryParserHandler.java
@@ -32,6 +32,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
@@ -342,12 +343,9 @@ public class FactoryParserHandler implements IDeviceMappingHandler, IPlaceHolder
                     final ValueType valueType = rcMapping.getRecordPath().getValueType();
                     if (rcMapping.isMetadata()) {
                         logger.warn("Metadata update not supported.");
-                    } else if (value != null || valueType != ValueType.AS_IS) {
+                    } else {
                         bulk.add(makeDto(modelPackageUri, model, provider, service, rcName, value,
                                 valueType.toJavaClass(), timestamp));
-                    } else if (options.logErrors) {
-                        logger.debug("Rejected update of {}/{}/{}: null value without explicit type", provider, service,
-                                rcName);
                     }
                 }
             } catch (Exception e) {
@@ -374,6 +372,9 @@ public class FactoryParserHandler implements IDeviceMappingHandler, IPlaceHolder
                 logger.warn("Error reading mapping for {}/{}/{}: {}", provider, service, rcName, e.getMessage());
             }
         }
+
+        // Remove null entries
+        bulk.removeIf(Objects::isNull);
 
         // Set the null action to all DTOs
         bulk.stream().forEach(dto -> {

--- a/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/FactoryParserHandler.java
+++ b/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/FactoryParserHandler.java
@@ -1030,16 +1030,14 @@ public class FactoryParserHandler implements IDeviceMappingHandler, IPlaceHolder
         int log10ms = (int) Math.log10(System.currentTimeMillis());
         int timestampLog = (int) Math.log10(timestamp);
 
-        if (timestampLog == log10ms) {
-            return Instant.ofEpochMilli(timestamp);
-        } else if (timestampLog == log10ms - 3) {
-            return Instant.ofEpochSecond(timestamp);
-        } else if (timestampLog == log10ms + 6) {
+        if (timestampLog > (log10ms + 2)) {
+            // Over 500 years in the future - guess nanos
             return Instant.EPOCH.plusNanos(timestamp);
+        } else if (timestampLog < (log10ms - 1)) {
+            // Over 45 years in the past, guess seconds
+            return Instant.ofEpochSecond(timestamp);
         } else {
-            logger.warn("Can't parse timestamp {} for provider {}", timestamp, provider);
+            return Instant.ofEpochMilli(timestamp);
         }
-
-        return Instant.now();
     }
 }

--- a/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/ResourceMappingHandler.java
+++ b/southbound/device-factory/device-factory-core/src/main/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/ResourceMappingHandler.java
@@ -56,7 +56,10 @@ public class ResourceMappingHandler {
     public IResourceMapping parseMapping(final String key, final Object rawMapping)
             throws InvalidResourcePathException, IllegalArgumentException {
 
-        if (rawMapping instanceof String) {
+        if (rawMapping == null) {
+            // Null mapping: consider a null value for an object
+            return new ResourceLiteralMapping(key, ValueType.AS_IS, null);
+        } else if (rawMapping instanceof String) {
             // String path (JSON path or CSV column name)
             return new ResourceRecordMapping(key, new RecordPath((String) rawMapping));
         } else if (rawMapping instanceof Integer) {

--- a/southbound/device-factory/device-factory-core/src/test/java/org/eclipse/sensinact/gateway/southbound/device/factory/ValueTypeTest.java
+++ b/southbound/device-factory/device-factory-core/src/test/java/org/eclipse/sensinact/gateway/southbound/device/factory/ValueTypeTest.java
@@ -146,4 +146,15 @@ public class ValueTypeTest {
         assertEquals(List.of("1", "2", "3"), ValueType.STRING_ARRAY.convert(strArray, options));
         assertEquals(List.of("1", "2", "3"), ValueType.ANY_ARRAY.convert(strArray, options));
     }
+
+    @Test
+    void testChar() {
+        final DeviceMappingOptionsDTO options = new DeviceMappingOptionsDTO();
+
+        assertEquals('a', ValueType.CHAR.convert('a', options));
+        assertEquals('a', ValueType.CHAR.convert("a", options));
+        assertEquals('a', ValueType.CHAR.convert(0x61, options));
+
+        assertEquals(List.of('a', 'b', 'c'), ValueType.CHAR_ARRAY.convert("a, b, c", options));
+    }
 }

--- a/southbound/device-factory/device-factory-core/src/test/java/org/eclipse/sensinact/gateway/southbound/device/factory/ValueTypeTest.java
+++ b/southbound/device-factory/device-factory-core/src/test/java/org/eclipse/sensinact/gateway/southbound/device/factory/ValueTypeTest.java
@@ -17,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
+import java.util.List;
 
 import org.eclipse.sensinact.gateway.southbound.device.factory.dto.DeviceMappingOptionsDTO;
 import org.junit.jupiter.api.Test;
@@ -32,15 +33,27 @@ public class ValueTypeTest {
         for (String nan : Arrays.asList("nan", "NaN")) {
             assertTrue(Double.isNaN((Float) ValueType.FLOAT.convert(nan, options)));
             assertTrue(Double.isNaN((Double) ValueType.DOUBLE.convert(nan, options)));
+
+            assertNull(ValueType.BYTE.convert(nan, options));
+            assertNull(ValueType.SHORT.convert(nan, options));
             assertNull(ValueType.INT.convert(nan, options));
             assertNull(ValueType.LONG.convert(nan, options));
+
+            assertEquals(nan, ValueType.AS_IS.convert(nan, options));
+            assertEquals(nan, ValueType.STRING.convert(nan, options));
         }
 
         for (String inf : Arrays.asList("inf", "Inf", "+inf", "+Inf", "-Inf", "-inf")) {
             assertTrue(Double.isInfinite((Float) ValueType.FLOAT.convert(inf, options)));
             assertTrue(Double.isInfinite((Double) ValueType.DOUBLE.convert(inf, options)));
+
+            assertNull(ValueType.BYTE.convert(inf, options));
+            assertNull(ValueType.SHORT.convert(inf, options));
             assertNull(ValueType.INT.convert(inf, options));
             assertNull(ValueType.LONG.convert(inf, options));
+
+            assertEquals(inf, ValueType.AS_IS.convert(inf, options));
+            assertEquals(inf, ValueType.STRING.convert(inf, options));
         }
     }
 
@@ -117,5 +130,20 @@ public class ValueTypeTest {
             assertEquals(strValue, ValueType.AS_IS.convert(strValue, options));
             assertEquals(doubleNegativeValue, ValueType.DOUBLE.convert(strValue, options));
         }
+    }
+
+    @Test
+    void testArray() {
+        final DeviceMappingOptionsDTO options = new DeviceMappingOptionsDTO();
+
+        final String strArray = "1, 2, 3";
+        assertEquals(List.of((byte) 1, (byte) 2, (byte) 3), ValueType.BYTE_ARRAY.convert(strArray, options));
+        assertEquals(List.of((short) 1, (short) 2, (short) 3), ValueType.SHORT_ARRAY.convert(strArray, options));
+        assertEquals(List.of(1, 2, 3), ValueType.INT_ARRAY.convert(strArray, options));
+        assertEquals(List.of(1L, 2L, 3L), ValueType.LONG_ARRAY.convert(strArray, options));
+        assertEquals(List.of(1f, 2f, 3f), ValueType.FLOAT_ARRAY.convert(strArray, options));
+        assertEquals(List.of(1d, 2d, 3d), ValueType.DOUBLE_ARRAY.convert(strArray, options));
+        assertEquals(List.of("1", "2", "3"), ValueType.STRING_ARRAY.convert(strArray, options));
+        assertEquals(List.of("1", "2", "3"), ValueType.ANY_ARRAY.convert(strArray, options));
     }
 }

--- a/southbound/device-factory/device-factory-core/src/test/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/RecordHandlingTest.java
+++ b/southbound/device-factory/device-factory-core/src/test/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/RecordHandlingTest.java
@@ -258,14 +258,27 @@ public class RecordHandlingTest {
         // Test default configuration (update)
         config.mapping.put("@provider", "p");
         config.mapping.put("data/val", "nonNullVal");
+        config.mapping.put("data/nullVal", "nullVal");
         final Map<String, Object> mappingNullVal = new HashMap<>();
         mappingNullVal.put("path", "nullVal");
         mappingNullVal.put("type", "string");
         config.mapping.put("data/null", mappingNullVal);
+        config.mapping.put("data/nullMapping", null);
         deviceMapper.handle(config, Map.of(), new byte[0]);
 
         GenericDto dto = getResourceValue("provider", "data", "null");
         assertEquals(NullAction.UPDATE, dto.nullAction);
+        assertEquals(String.class, dto.type);
+        assertNull(dto.value);
+
+        dto = getResourceValue("provider", "data", "nullVal");
+        assertEquals(NullAction.UPDATE, dto.nullAction);
+        assertEquals(Object.class, dto.type);
+        assertNull(dto.value);
+
+        dto = getResourceValue("provider", "data", "nullMapping");
+        assertEquals(NullAction.UPDATE, dto.nullAction);
+        assertEquals(Object.class, dto.type);
         assertNull(dto.value);
 
         dto = getResourceValue("provider", "data", "val");

--- a/southbound/device-factory/device-factory-core/src/test/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/RecordHandlingTest.java
+++ b/southbound/device-factory/device-factory-core/src/test/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/RecordHandlingTest.java
@@ -258,7 +258,10 @@ public class RecordHandlingTest {
         // Test default configuration (update)
         config.mapping.put("@provider", "p");
         config.mapping.put("data/val", "nonNullVal");
-        config.mapping.put("data/null", "nullVal");
+        final Map<String, Object> mappingNullVal = new HashMap<>();
+        mappingNullVal.put("path", "nullVal");
+        mappingNullVal.put("type", "string");
+        config.mapping.put("data/null", mappingNullVal);
         deviceMapper.handle(config, Map.of(), new byte[0]);
 
         GenericDto dto = getResourceValue("provider", "data", "null");

--- a/southbound/device-factory/device-factory-core/src/test/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/RecordHandlingTest.java
+++ b/southbound/device-factory/device-factory-core/src/test/java/org/eclipse/sensinact/gateway/southbound/device/factory/impl/RecordHandlingTest.java
@@ -16,10 +16,18 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.sensinact.core.annotation.dto.NullAction;
 import org.eclipse.sensinact.core.push.DataUpdate;
@@ -325,5 +333,95 @@ public class RecordHandlingTest {
 
         // Test values
         assertEquals(42, getResourceValue("provider", "svc", "rc").value);
+    }
+
+    @Test
+    void testTimestamp() throws Exception {
+        final DeviceMappingConfigurationDTO config = prepareConfig();
+
+        // Set a record
+        final Instant now = Instant.now();
+        final Map<String, Object> record = new HashMap<>();
+        record.put("provider", "provider");
+        record.put("timestamp_s", now.getEpochSecond());
+        record.put("timestamp_ms", now.toEpochMilli());
+        final long timestampNs = TimeUnit.SECONDS.toNanos(now.getEpochSecond()) + now.getNano();
+        record.put("timestamp_ns", timestampNs);
+        parser.setRecords(record);
+
+        // Auto-compute timestamp format: seconds
+        config.mapping.put("@provider", "provider");
+        config.mapping.put("data/val", null);
+        config.mapping.put("@timestamp", "timestamp_s");
+        deviceMapper.handle(config, Map.of(), new byte[0]);
+        GenericDto dto = getResourceValue("provider", "data", "val");
+        assertEquals(Instant.ofEpochSecond(now.getEpochSecond()), dto.timestamp);
+
+        // Auto-compute timestamp format: milliseconds
+        bulks.clear();
+        config.mapping.put("@timestamp", "timestamp_ms");
+        deviceMapper.handle(config, Map.of(), new byte[0]);
+        dto = getResourceValue("provider", "data", "val");
+        assertEquals(Instant.ofEpochMilli(now.toEpochMilli()), dto.timestamp);
+
+        // Auto-compute timestamp format: nanoseconds
+        bulks.clear();
+        config.mapping.put("@timestamp", "timestamp_ns");
+        deviceMapper.handle(config, Map.of(), new byte[0]);
+        dto = getResourceValue("provider", "data", "val");
+        assertEquals(now, dto.timestamp);
+    }
+
+    @Test
+    void testDateTime() throws Exception {
+        final DeviceMappingConfigurationDTO config = prepareConfig();
+
+        // Set a record
+        final Instant now = Instant.now();
+        final OffsetDateTime date = now.atOffset(ZoneOffset.ofHours(1));
+        final DateTimeFormatter formatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.LONG, FormatStyle.MEDIUM);
+        final String strPattern = "MM dd, yyyy - Q - hh:mm a - s.n - X";
+
+        final Map<String, Object> record = new HashMap<>();
+        record.put("provider", "provider");
+        record.put("iso", date.toString());
+        record.put("custom", date.format(DateTimeFormatter.ofPattern(strPattern)));
+        record.put("locale_fr", date.format(formatter.withLocale(Locale.FRANCE)));
+        record.put("locale_de", date.format(formatter.withLocale(Locale.GERMAN)));
+        record.put("locale_en", date.format(formatter.withLocale(Locale.UK)));
+        record.put("locale_zh", date.format(formatter.withLocale(Locale.SIMPLIFIED_CHINESE)));
+        parser.setRecords(record);
+
+        // ISO format
+        config.mapping.put("@provider", "provider");
+        config.mapping.put("data/val", null);
+        config.mapping.put("@datetime", "iso");
+        config.mappingOptions.formatDateTime = null;
+        config.mappingOptions.dateTimezone = null;
+        deviceMapper.handle(config, Map.of(), new byte[0]);
+        GenericDto dto = getResourceValue("provider", "data", "val");
+        assertEquals(now, dto.timestamp);
+
+        // Custom pattern
+        bulks.clear();
+        config.mapping.put("@datetime", "custom");
+        config.mappingOptions.formatDateTime = strPattern;
+        deviceMapper.handle(config, Map.of(), new byte[0]);
+        dto = getResourceValue("provider", "data", "val");
+        assertEquals(now, dto.timestamp);
+
+        // Locale-based date (mix of country and language codes)
+        for (Locale locale : List.of(Locale.FRANCE, Locale.GERMAN, Locale.UK, Locale.SIMPLIFIED_CHINESE)) {
+            bulks.clear();
+            config.mapping.put("@datetime", "locale_" + locale.getLanguage());
+            config.mappingOptions.formatDateTime = null;
+            config.mappingOptions.formatDateTimeLocale = locale.toString();
+            config.mappingOptions.formatDateStyle = "long";
+            config.mappingOptions.formatTimeStyle = "medium";
+            config.mappingOptions.dateTimezone = "+01";
+            deviceMapper.handle(config, Map.of(), new byte[0]);
+            dto = getResourceValue("provider", "data", "val");
+            assertEquals(now.truncatedTo(ChronoUnit.SECONDS), dto.timestamp);
+        }
     }
 }

--- a/southbound/http/http-device-factory/src/main/java/org/eclipse/sensinact/gateway/southbound/http/factory/HttpDeviceFactory.java
+++ b/southbound/http/http-device-factory/src/main/java/org/eclipse/sensinact/gateway/southbound/http/factory/HttpDeviceFactory.java
@@ -183,15 +183,21 @@ public class HttpDeviceFactory {
 
                 @Override
                 public void onFailure(final Response response, final Throwable failure) {
-                    logger.error("Error {} requesting {}: {}", response.getStatus(), task.url, failure);
+                    logger.error("Error accessing {}: {} ({})", task.url, failure.getMessage(),
+                            failure.getClass().getName(), failure);
                 }
 
                 @Override
                 public void onSuccess(final Response response) {
-                    try {
-                        mappingHandler.handle(task.mapping, headers.get(), getContent());
-                    } catch (DeviceFactoryException e) {
-                        logger.error("Error parsing input from {}", task.url, e);
+                    final int status = response.getStatus();
+                    if (status >= 200 && status < 300) {
+                        try {
+                            mappingHandler.handle(task.mapping, headers.get(), getContent());
+                        } catch (DeviceFactoryException e) {
+                            logger.error("Error parsing input from {}: {}", task.url, e.getMessage(), e);
+                        }
+                    } else {
+                        logger.error("HTTP error {} accessing {}", status, task.url);
                     }
                 }
 


### PR DESCRIPTION
This PR enhance the usability of the Device Factory:

* Added support for other primitive types: bytes, char, short and boolean
* Parsed arrays (`byte[]`) are now stored as immutable lists
* Enhanced date time parsing options (added support for locale-based long string, documentation was updated)
* Added a `log.errors` flag to the mapping options to ease debugging by tracing parsing, mapping and digital twin update errors
* The HTTP device factory now logs exceptions encountered, as some SSL connection errors were just indicating "status code 0" with no other details.