### PR TITLE
use real eClass from service not from reference

### DIFF
--- a/core/impl/src/test/java/org/eclipse/sensinact/core/integration/EMFUpdateServiceTest.java
+++ b/core/impl/src/test/java/org/eclipse/sensinact/core/integration/EMFUpdateServiceTest.java
@@ -38,7 +38,9 @@ import org.eclipse.sensinact.core.push.DataUpdate;
 import org.eclipse.sensinact.core.twin.SensinactDigitalTwin;
 import org.eclipse.sensinact.core.twin.SensinactProvider;
 import org.eclipse.sensinact.core.twin.SensinactResource;
+import org.eclipse.sensinact.gateway.geojson.Point;
 import org.eclipse.sensinact.model.core.testdata.DynamicTestSensor;
+import org.eclipse.sensinact.model.core.testdata.TestAdmin;
 import org.eclipse.sensinact.model.core.testdata.TestSensor;
 import org.eclipse.sensinact.model.core.testdata.TestTemperatur;
 import org.eclipse.sensinact.model.core.testdata.TestdataFactory;
@@ -116,6 +118,24 @@ public class EMFUpdateServiceTest {
             update = push.pushUpdate(temp2);
             assertNull(update.getFailure());
             assertEquals("14 °C", getResourceValue("TestSensor", PROVIDER, SERVICE, RESOURCE));
+        }
+        @Test
+        void admin() throws Exception {
+            TestSensor sensor = TestdataFactory.eINSTANCE.createTestSensor();
+            TestTemperatur temp = TestdataFactory.eINSTANCE.createTestTemperatur();
+            TestAdmin admin = TestdataFactory.eINSTANCE.createTestAdmin();
+            temp.setV1("14 °C");
+            sensor.setTemp(temp);
+            sensor.setId(PROVIDER);
+            sensor.setAdmin(admin);
+            admin.setTestAdmin("blub");
+            Point p = new Point();
+            admin.setLocation(p);
+
+            Promise<?> update = push.pushUpdate(sensor);
+            assertNull(update.getFailure());
+            assertEquals(p, getResourceValue("TestSensor", PROVIDER, "admin", "location"));
+            assertEquals("blub", getResourceValue("TestSensor", PROVIDER, "admin", "testAdmin"));
         }
 
     }

--- a/core/models/provider/src/main/resources/model/sensinact.ecore
+++ b/core/models/provider/src/main/resources/model/sensinact.ecore
@@ -14,7 +14,7 @@
     </eOperations>
     <eOperations name="getServiceEClass" eType="ecore:EClass http://www.eclipse.org/emf/2002/Ecore#//EClass">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
-        <details key="body" value="&lt;%org.eclipse.emf.ecore.EStructuralFeature%> serviceFeature = eClass().getEStructuralFeature(serviceName);&#xA;if (serviceFeature instanceof &lt;%org.eclipse.emf.ecore.EReference%>) {&#xA;&#x9;&lt;%org.eclipse.emf.ecore.EClass%> refEClass = ((EReference) serviceFeature).getEReferenceType();&#xA;&#x9;return ProviderPackage.Literals.SERVICE.isSuperTypeOf(refEClass) ? refEClass : null;&#xA;}&#xA;return null;"/>
+        <details key="body" value="&lt;%org.eclipse.emf.ecore.EStructuralFeature%>  serviceFeature = eClass().getEStructuralFeature(serviceName);&#xA;if (serviceFeature instanceof &lt;%org.eclipse.emf.ecore.EReference%>) {&#xA;    Object service = eGet(serviceFeature);&#xA;    &lt;%org.eclipse.emf.ecore.EClass%> refEClass;&#xA;    if (service instanceof &lt;%org.eclipse.emf.ecore.EObject%>) {&#xA;        refEClass = ((EObject) service).eClass();&#xA;    } else {&#xA;        refEClass = ((EReference) serviceFeature).getEReferenceType();&#xA;    }&#xA;    return ProviderPackage.Literals.SERVICE.isSuperTypeOf(refEClass) ? refEClass : null;&#xA;}&#xA;return null;&#xA;"/>
       </eAnnotations>
       <eParameters name="serviceName" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     </eOperations>

--- a/core/models/provider/src/main/resources/model/sensinact.genmodel
+++ b/core/models/provider/src/main/resources/model/sensinact.genmodel
@@ -34,7 +34,7 @@
         <genParameters ecoreParameter="sensinact.ecore#//Provider/getService/serviceName"/>
       </genOperations>
       <genOperations ecoreOperation="sensinact.ecore#//Provider/getServiceEClass"
-          body="&lt;%org.eclipse.emf.ecore.EStructuralFeature%> serviceFeature = eClass().getEStructuralFeature(serviceName);&#xA;if (serviceFeature instanceof &lt;%org.eclipse.emf.ecore.EReference%>) {&#xA;&#x9;&lt;%org.eclipse.emf.ecore.EClass%> refEClass = ((EReference) serviceFeature).getEReferenceType();&#xA;&#x9;return ProviderPackage.Literals.SERVICE.isSuperTypeOf(refEClass) ? refEClass : null;&#xA;}&#xA;return null;">
+          body="&lt;%org.eclipse.emf.ecore.EStructuralFeature%>  serviceFeature = eClass().getEStructuralFeature(serviceName);&#xA;if (serviceFeature instanceof &lt;%org.eclipse.emf.ecore.EReference%>) {&#xA;    Object service = eGet(serviceFeature);&#xA;    &lt;%org.eclipse.emf.ecore.EClass%> refEClass;&#xA;    if (service instanceof &lt;%org.eclipse.emf.ecore.EObject%>) {&#xA;        refEClass = ((EObject) service).eClass();&#xA;    } else {&#xA;        refEClass = ((EReference) serviceFeature).getEReferenceType();&#xA;    }&#xA;    return ProviderPackage.Literals.SERVICE.isSuperTypeOf(refEClass) ? refEClass : null;&#xA;}&#xA;return null;&#xA;">
         <genParameters ecoreParameter="sensinact.ecore#//Provider/getServiceEClass/serviceName"/>
       </genOperations>
     </genClasses>


### PR DESCRIPTION
A custom admin service with resources don't work as the admin service eClass is resolved by the eReferenceType and ends  up with the default Admin eClass.