### PR TITLE
Implement model deletion in the Model Manager

### DIFF
--- a/core/impl/src/main/java/org/eclipse/sensinact/core/model/impl/ModelImpl.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/model/impl/ModelImpl.java
@@ -105,4 +105,11 @@ public class ModelImpl extends CommandScopedImpl implements EMFModel {
         return eClass;
     }
 
+    @Override
+    protected void checkValid() {
+        super.checkValid();
+        if(!nexusImpl.registered(eClass)) {
+            throw new IllegalStateException("This model has been deleted");
+        }
+    }
 }

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/model/impl/SensinactModelManagerImpl.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/model/impl/SensinactModelManagerImpl.java
@@ -76,7 +76,7 @@ public class SensinactModelManagerImpl extends CommandScopedImpl implements Sens
     @Override
     public void deleteModel(String packageUri, String model) {
         checkValid();
-        throw new RuntimeException("Not implemented");
+        nexusImpl.deleteModel(packageUri, model);
     }
 
     @Override

--- a/core/impl/src/test/java/org/eclipse/sensinact/core/model/impl/ModelBuildingTest.java
+++ b/core/impl/src/test/java/org/eclipse/sensinact/core/model/impl/ModelBuildingTest.java
@@ -15,6 +15,7 @@ package org.eclipse.sensinact.core.model.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.AbstractMap.SimpleEntry;
@@ -120,5 +121,19 @@ public class ModelBuildingTest {
             assertEquals(parameters, resource.getArguments());
         }
 
+        @Test
+        void testDeleteModel() {
+            Model model = manager.createModel(TEST_MODEL).build();
+            String packageUri = model.getPackageUri();
+            String name = model.getName();
+
+            assertTrue(nexus.getModel(packageUri, name).isPresent());
+
+            manager.deleteModel(packageUri, name);
+
+            assertFalse(nexus.getModel(packageUri, name).isPresent());
+
+            assertThrows(IllegalStateException.class, () -> model.getPackageUri());
+        }
     }
 }


### PR DESCRIPTION
The model manager API provides a deletion method, but this was not implemented. This commit implements deletion logic, which delegates to the Model Nexus. The Model Nexus:

1. Finds the Model
2. If found it deletes any and all providers using the model, then it deletes the model from its owning EPackage
3. If the EPackage is now empty of models then the EPackage is removed from the Model Nexus

The ModelImpl has also been updated to check the the model is still registered before allowing any action. This prevents deleted models from being used after they are deleted.