### PR TITLE
Expose #getProviders(String modelPackageUri, String model) from the twin

### DIFF
--- a/core/api/src/main/java/org/eclipse/sensinact/core/twin/SensinactDigitalTwin.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/twin/SensinactDigitalTwin.java
@@ -47,6 +47,14 @@ public interface SensinactDigitalTwin extends CommandScoped {
     List<? extends SensinactProvider> getProviders(String model);
 
     /**
+     * List all providers for the named model
+     *
+     * @param model
+     * @return
+     */
+    List<? extends SensinactProvider> getProviders(String modelPackageUri, String model);
+
+    /**
      * Get a provider by name
      *
      * @param providerName


### PR DESCRIPTION
The method getProviders(String, String) existed in the EMF Twin, but not the base twin. As we already use the model package uri extensively in that interface we should expose it here as well.