### PR TITLE
Add support for nullable data which should not create a resource

### DIFF
--- a/core/annotation/src/main/java/org/eclipse/sensinact/core/annotation/dto/NullAction.java
+++ b/core/annotation/src/main/java/org/eclipse/sensinact/core/annotation/dto/NullAction.java
@@ -23,5 +23,13 @@ public enum NullAction {
     /**
      * If the data field is null then set null as the value
      */
-    UPDATE
+    UPDATE,
+    /**
+     * If the data field is null then:
+     * <ul>
+     *   <li>If the resource has previously been set then set it to <code>null</code></li>
+     *   <li>If the resource has never been set then ignore this field and do not update the value</li>
+     * </ul>
+     */
+    UPDATE_IF_PRESENT
 }

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/dto/impl/AbstractUpdateDto.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/dto/impl/AbstractUpdateDto.java
@@ -16,6 +16,7 @@ import java.time.Instant;
 
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EReference;
+import org.eclipse.sensinact.core.annotation.dto.NullAction;
 import org.eclipse.sensinact.model.core.provider.Provider;
 
 public abstract class AbstractUpdateDto {
@@ -67,4 +68,9 @@ public abstract class AbstractUpdateDto {
      * The services {@link EReference} on the {@link Provider} model, optional
      */
     public EReference serviceReference;
+
+    /**
+     * The action to take on a null update
+     */
+    public NullAction actionOnNull;
 }

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/extract/impl/AnnotationMapping.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/extract/impl/AnnotationMapping.java
@@ -179,6 +179,8 @@ public class AnnotationMapping {
 
             if (dto.data == null && data.onNull() == NullAction.IGNORE && firstFailure == null) {
                 return null;
+            } else {
+                dto.actionOnNull = data.onNull();
             }
 
             try {
@@ -286,7 +288,10 @@ public class AnnotationMapping {
 
             if (md == null && metadata.onNull() == NullAction.IGNORE && firstFailure == null) {
                 return null;
+            } else {
+                dto.actionOnNull = metadata.onNull();
             }
+
             String key = NOT_SET.equals(metadata.value()) ? fieldName : metadata.value();
 
             Map<String, Object> processedMd;

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/extract/impl/EMFGenericDtoDataExtractor.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/extract/impl/EMFGenericDtoDataExtractor.java
@@ -63,7 +63,7 @@ public class EMFGenericDtoDataExtractor implements DataExtractor {
         List<AbstractUpdateDto> list = new ArrayList<>();
 
         // Accept a null value if this is not a metadata update
-        if (dto.value != null || dto.nullAction == NullAction.UPDATE) {
+        if (dto.value != null || dto.nullAction != NullAction.IGNORE) {
             DataUpdateDto dud = copyCommonFields(dto, instant, new DataUpdateDto());
             if (dto.type != null)
                 dud.type = dto.type;
@@ -96,6 +96,7 @@ public class EMFGenericDtoDataExtractor implements DataExtractor {
         dud.service = dto.service;
         dud.resource = dto.resource;
         dud.timestamp = instant;
+        dud.actionOnNull = dto.nullAction;
         dud.originalDto = dto;
         if (dto instanceof EMFGenericDto) {
             EMFGenericDto edto = (EMFGenericDto) dto;

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/extract/impl/GenericDtoDataExtractor.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/extract/impl/GenericDtoDataExtractor.java
@@ -56,8 +56,8 @@ public class GenericDtoDataExtractor implements DataExtractor {
 
         List<AbstractUpdateDto> list = new ArrayList<>();
 
-        // Accept a null value if this is not a metadata update
-        if (dto.value != null || dto.nullAction == NullAction.UPDATE) {
+        // Accept a null value if this is not a pure metadata update
+        if (dto.value != null || dto.nullAction != NullAction.IGNORE) {
             DataUpdateDto dud = copyCommonFields(dto, instant, new DataUpdateDto());
             if (dto.type != null)
                 dud.type = dto.type;
@@ -89,6 +89,7 @@ public class GenericDtoDataExtractor implements DataExtractor {
         dud.service = dto.service;
         dud.resource = dto.resource;
         dud.timestamp = instant;
+        dud.actionOnNull = dto.nullAction;
         dud.originalDto = dto;
         return dud;
     }

--- a/core/impl/src/test/java/org/eclipse/sensinact/core/extract/impl/CustomBaseValueDtoExtractorTest.java
+++ b/core/impl/src/test/java/org/eclipse/sensinact/core/extract/impl/CustomBaseValueDtoExtractorTest.java
@@ -30,10 +30,10 @@ import org.eclipse.sensinact.core.annotation.dto.Provider;
 import org.eclipse.sensinact.core.annotation.dto.Resource;
 import org.eclipse.sensinact.core.annotation.dto.Service;
 import org.eclipse.sensinact.core.annotation.dto.Timestamp;
-import org.eclipse.sensinact.core.push.dto.BaseValueDto;
 import org.eclipse.sensinact.core.dto.impl.AbstractUpdateDto;
 import org.eclipse.sensinact.core.dto.impl.DataUpdateDto;
 import org.eclipse.sensinact.core.dto.impl.MetadataUpdateDto;
+import org.eclipse.sensinact.core.push.dto.BaseValueDto;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -79,6 +79,9 @@ public class CustomBaseValueDtoExtractorTest {
         @Resource("null")
         @Data(onNull = NullAction.UPDATE)
         public String nullable;
+        @Resource("null2")
+        @Data(onNull = NullAction.UPDATE_IF_PRESENT)
+        public String nullable2;
 
         @Timestamp(ChronoUnit.SECONDS)
         public Long time;
@@ -266,7 +269,7 @@ public class CustomBaseValueDtoExtractorTest {
 
             List<? extends AbstractUpdateDto> updates = extractor(ExtendedDto.class).getUpdates(dto);
 
-            assertEquals(4, updates.size());
+            assertEquals(5, updates.size());
 
             AbstractUpdateDto extracted = updates.stream().filter(DataUpdateDto.class::isInstance)
                     .filter(d -> RESOURCE.equals(d.resource)).findFirst().get();
@@ -296,6 +299,15 @@ public class CustomBaseValueDtoExtractorTest {
                     .findFirst().get();
 
             checkCommonFields(extracted, "null", time);
+            assertEquals(NullAction.UPDATE, extracted.actionOnNull);
+
+            assertTrue(extracted instanceof DataUpdateDto, "Not a data update dto " + extracted.getClass());
+
+            extracted = updates.stream().filter(DataUpdateDto.class::isInstance).filter(d -> "null2".equals(d.resource))
+                    .findFirst().get();
+
+            checkCommonFields(extracted, "null2", time);
+            assertEquals(NullAction.UPDATE_IF_PRESENT, extracted.actionOnNull);
 
             assertTrue(extracted instanceof DataUpdateDto, "Not a data update dto " + extracted.getClass());
 


### PR DESCRIPTION
In some cases null is a valid value to return, but should not be used to initialize a resource. For example if a DTO contains some optional resources which may never be set for some providers, but will be set for others, and those resources may be null, then this was not previously possible