### PR TITLE
Reinstate final modifier for GenericDto

### DIFF
--- a/core/api/src/main/java/org/eclipse/sensinact/core/push/dto/GenericDto.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/push/dto/GenericDto.java
@@ -23,7 +23,7 @@ import org.eclipse.sensinact.core.annotation.dto.NullAction;
  * Used to define a schema for generic device access with no model (e.g. driven
  * by configuration)
  */
-public class GenericDto extends BaseValueDto {
+public final class GenericDto extends BaseValueDto {
 
     public Class<?> type;
 

--- a/core/emf-api/src/main/java/org/eclipse/sensinact/core/emf/dto/EMFGenericDto.java
+++ b/core/emf-api/src/main/java/org/eclipse/sensinact/core/emf/dto/EMFGenericDto.java
@@ -12,34 +12,46 @@
 **********************************************************************/
 package org.eclipse.sensinact.core.emf.dto;
 
+import java.time.Instant;
+
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EReference;
-import org.eclipse.sensinact.core.annotation.dto.Model;
-import org.eclipse.sensinact.core.annotation.dto.Service;
-import org.eclipse.sensinact.core.push.dto.GenericDto;
+import org.eclipse.sensinact.core.annotation.dto.NullAction;
+import org.eclipse.sensinact.core.push.dto.BaseValueDto;
 import org.eclipse.sensinact.model.core.provider.DynamicProvider;
 
 /**
  * A special update dto type. This is for the export mode, where you can work
  * directly with known EMF Models
  */
-public final class EMFGenericDto extends GenericDto {
+public final class EMFGenericDto extends BaseValueDto {
 
     /** The {@link EClass} of the provider */
-    @Model
     public EClass modelEClass;
 
     /**
      * The {@link EClass} of a service. This must be set, when updating a
      * {@link DynamicProvider}, where a service might not be available yet.
      */
-    @Service
     public EClass serviceEClass;
 
     /**
      * The {@link EReference} to the service to set. Can be null if service is
      * available.
      */
-    @Service
     public EReference serviceReference;
+
+    public Class<?> type;
+
+    public Object value;
+
+    /**
+     * The timestamp for the data. If null then Instant.now will be used.
+     */
+    public Instant timestamp;
+
+    /**
+     * Action to apply if value is null
+     */
+    public NullAction nullAction = NullAction.IGNORE;
 }

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/extract/impl/EMFGenericDtoDataExtractor.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/extract/impl/EMFGenericDtoDataExtractor.java
@@ -22,7 +22,6 @@ import org.eclipse.sensinact.core.dto.impl.DataUpdateDto;
 import org.eclipse.sensinact.core.dto.impl.FailedMappingDto;
 import org.eclipse.sensinact.core.dto.impl.MetadataUpdateDto;
 import org.eclipse.sensinact.core.emf.dto.EMFGenericDto;
-import org.eclipse.sensinact.core.push.dto.GenericDto;
 
 public class EMFGenericDtoDataExtractor implements DataExtractor {
 
@@ -89,7 +88,7 @@ public class EMFGenericDtoDataExtractor implements DataExtractor {
         return fmd;
     }
 
-    private <T extends AbstractUpdateDto> T copyCommonFields(GenericDto dto, Instant instant, T dud) {
+    private <T extends AbstractUpdateDto> T copyCommonFields(EMFGenericDto dto, Instant instant, T dud) {
         dud.modelPackageUri = dto.modelPackageUri;
         dud.model = dto.model;
         dud.provider = dto.provider;
@@ -98,12 +97,9 @@ public class EMFGenericDtoDataExtractor implements DataExtractor {
         dud.timestamp = instant;
         dud.actionOnNull = dto.nullAction;
         dud.originalDto = dto;
-        if (dto instanceof EMFGenericDto) {
-            EMFGenericDto edto = (EMFGenericDto) dto;
-            dud.modelEClass = edto.modelEClass;
-            dud.serviceEClass = edto.serviceEClass;
-            dud.serviceReference = edto.serviceReference;
-        }
+        dud.modelEClass = dto.modelEClass;
+        dud.serviceEClass = dto.serviceEClass;
+        dud.serviceReference = dto.serviceReference;
         return dud;
     }
 


### PR DESCRIPTION
The EMF dto altered the GenericDto so that it could extend it. The GenericDto was intentionally final to prevent usage mistakes in the API. There are few fields and we should copy them.