### PR TITLE
Added tests for null parsed filter when creating a predicate

### DIFF
--- a/northbound/websocket/src/main/java/org/eclipse/sensinact/northbound/ws/impl/WebSocketEndpoint.java
+++ b/northbound/websocket/src/main/java/org/eclipse/sensinact/northbound/ws/impl/WebSocketEndpoint.java
@@ -340,7 +340,12 @@ public class WebSocketEndpoint {
 
         final Predicate<AbstractResourceNotification> p;
         if (query.filter != null && !query.filter.isBlank()) {
-            p = eventPredicate.and(prepareFilter(query));
+            Predicate<AbstractResourceNotification> queryFilter = prepareFilter(query);
+            if (queryFilter != null) {
+                p = eventPredicate.and(queryFilter);
+            } else {
+                p = eventPredicate;
+            }
         } else {
             p = eventPredicate;
         }


### PR DESCRIPTION
`prepareFilter()` can return null if the query filter string wasn't blank but the filter does nothing (empty filter in LDAP, ...).
This PR avoids an Exception to be thrown as `Predicate.and()` fails when the given predicate is null.
