### PR TITLE
Extend whiteboard capabilities

### DIFF
--- a/core/api/src/main/java/org/eclipse/sensinact/core/whiteboard/AbstractDescriptiveAct.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/whiteboard/AbstractDescriptiveAct.java
@@ -1,0 +1,41 @@
+/*********************************************************************
+* Copyright (c) 2024 Kentyou.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Thomas Calmant (Kentyou) - initial implementation
+**********************************************************************/
+package org.eclipse.sensinact.core.whiteboard;
+
+import java.lang.reflect.ParameterizedType;
+import java.util.Map;
+
+import org.osgi.util.promise.Promise;
+import org.osgi.util.promise.PromiseFactory;
+
+public abstract class AbstractDescriptiveAct<T> implements WhiteboardAct<T>, WhiteboardActDescription<T> {
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Class<T> getReturnType() {
+        return (Class<T>) ((ParameterizedType) getClass().getGenericSuperclass()).getActualTypeArguments()[0];
+    }
+
+    @Override
+    public Promise<T> act(PromiseFactory pf, String modelPackageUri, String model, String provider, String service,
+            String resource, Map<String, Object> arguments) {
+        Promise<T> p = doAct(pf, modelPackageUri, model, provider, service, resource, arguments);
+        if (p == null) {
+            return pf.failed(new NullPointerException(getClass().getName() + " returned a null promise"));
+        }
+        return p;
+    }
+
+    protected abstract Promise<T> doAct(PromiseFactory promiseFactory, String modelPackageUri, String model,
+            String provider, String service, String resource, Map<String, Object> arguments);
+}

--- a/core/api/src/main/java/org/eclipse/sensinact/core/whiteboard/AbstractDescriptiveReadOnly.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/whiteboard/AbstractDescriptiveReadOnly.java
@@ -1,0 +1,48 @@
+/*********************************************************************
+* Copyright (c) 2024 Kentyou.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Thomas Calmant (Kentyou) - initial implementation
+**********************************************************************/
+package org.eclipse.sensinact.core.whiteboard;
+
+import java.lang.reflect.ParameterizedType;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
+import org.eclipse.sensinact.core.twin.TimedValue;
+import org.osgi.util.promise.Promise;
+import org.osgi.util.promise.PromiseFactory;
+
+public abstract class AbstractDescriptiveReadOnly<T> implements WhiteboardGet<T>, WhiteboardResourceDescription<T> {
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Class<T> getResourceType() {
+        return (Class<T>) ((ParameterizedType) getClass().getGenericSuperclass()).getActualTypeArguments()[0];
+    }
+
+    @Override
+    public Duration getCacheDuration() {
+        return Duration.of(30, ChronoUnit.SECONDS);
+    }
+
+    @Override
+    public Promise<TimedValue<T>> pullValue(PromiseFactory pf, String modelPackageUri, String model, String provider,
+            String service, String resource, Class<T> resourceType, TimedValue<T> cachedValue) {
+        Promise<TimedValue<T>> p = doPullValue(pf, modelPackageUri, model, provider, service, resource, cachedValue);
+        if (p == null) {
+            return pf.failed(new NullPointerException(getClass().getName() + " returned a null promise"));
+        }
+        return p;
+    }
+
+    protected abstract Promise<TimedValue<T>> doPullValue(PromiseFactory promiseFactory, String modelPackageUri,
+            String model, String provider, String service, String resource, TimedValue<T> cachedValue);
+}

--- a/core/api/src/main/java/org/eclipse/sensinact/core/whiteboard/AbstractDescriptiveReadWrite.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/whiteboard/AbstractDescriptiveReadWrite.java
@@ -1,0 +1,37 @@
+/*********************************************************************
+* Copyright (c) 2024 Kentyou.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Thomas Calmant (Kentyou) - initial implementation
+**********************************************************************/
+package org.eclipse.sensinact.core.whiteboard;
+
+import org.eclipse.sensinact.core.twin.TimedValue;
+import org.osgi.util.promise.Promise;
+import org.osgi.util.promise.PromiseFactory;
+
+public abstract class AbstractDescriptiveReadWrite<T> extends AbstractDescriptiveReadOnly<T>
+        implements WhiteboardSet<T> {
+
+    @Override
+    public Promise<TimedValue<T>> pushValue(PromiseFactory pf, String modelPackageUri, String model, String provider,
+            String service, String resource, Class<T> resourceType, TimedValue<T> cachedValue, TimedValue<T> newValue) {
+
+        Promise<TimedValue<T>> p = doPushValue(pf, modelPackageUri, model, provider, service, resource, cachedValue,
+                newValue);
+        if (p == null) {
+            return pf.failed(new NullPointerException(getClass().getName() + " returned a null promise"));
+        }
+        return p;
+    }
+
+    protected abstract Promise<TimedValue<T>> doPushValue(PromiseFactory promiseFactory, String modelPackageUri,
+            String model, String provider, String service, String resource, TimedValue<T> cachedValue,
+            TimedValue<T> newValue);
+}

--- a/core/api/src/main/java/org/eclipse/sensinact/core/whiteboard/WhiteboardAct.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/whiteboard/WhiteboardAct.java
@@ -1,0 +1,39 @@
+/*********************************************************************
+* Copyright (c) 2024 Kentyou.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Thomas Calmant (Kentyou) - initial implementation
+**********************************************************************/
+package org.eclipse.sensinact.core.whiteboard;
+
+import java.util.Map;
+
+import org.osgi.util.promise.Promise;
+import org.osgi.util.promise.PromiseFactory;
+
+/**
+ * Whiteboard service to handle resource act operations
+ */
+public interface WhiteboardAct<T> extends WhiteboardHandler<T> {
+
+    /**
+     * Whiteboard is called to get the resource value as a promise
+     *
+     * @param promiseFactory  Promise factory
+     * @param modelPackageUri Package URI of the provider model
+     * @param model           Provider model name
+     * @param provider        Provider name
+     * @param service         Service name
+     * @param resource        Resource name
+     * @param arguments       Map of given arguments
+     * @return A promise, created with the promise factory
+     */
+    Promise<T> act(PromiseFactory promiseFactory, String modelPackageUri, String model, String provider,
+            String service, String resource, Map<String, Object> arguments);
+}

--- a/core/api/src/main/java/org/eclipse/sensinact/core/whiteboard/WhiteboardAct.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/whiteboard/WhiteboardAct.java
@@ -20,7 +20,7 @@ import org.osgi.util.promise.PromiseFactory;
 /**
  * Whiteboard service to handle resource act operations
  */
-public interface WhiteboardAct<T> extends WhiteboardHandler<T> {
+public interface WhiteboardAct<T> extends WhiteboardHandler {
 
     /**
      * Whiteboard is called to get the resource value as a promise

--- a/core/api/src/main/java/org/eclipse/sensinact/core/whiteboard/WhiteboardActDescription.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/whiteboard/WhiteboardActDescription.java
@@ -15,9 +15,21 @@ package org.eclipse.sensinact.core.whiteboard;
 import java.util.List;
 import java.util.Map.Entry;
 
+/**
+ * Interface that an auto-descriptive action resource handler must implement if
+ * it expects the whiteboard to create its resource automatically
+ *
+ * @param <T> Type of action result
+ */
 public interface WhiteboardActDescription<T> {
 
+    /**
+     * Type of the result returns by the action
+     */
     Class<T> getReturnType();
 
+    /**
+     * List of parameters: argument name -&gt; argument type
+     */
     List<Entry<String, Class<?>>> getNamedParameterTypes();
 }

--- a/core/api/src/main/java/org/eclipse/sensinact/core/whiteboard/WhiteboardActDescription.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/whiteboard/WhiteboardActDescription.java
@@ -1,0 +1,23 @@
+/*********************************************************************
+* Copyright (c) 2024 Kentyou.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Thomas Calmant (Kentyou) - initial implementation
+**********************************************************************/
+package org.eclipse.sensinact.core.whiteboard;
+
+import java.util.List;
+import java.util.Map.Entry;
+
+public interface WhiteboardActDescription<T> {
+
+    Class<T> getReturnType();
+
+    List<Entry<String, Class<?>>> getNamedParameterTypes();
+}

--- a/core/api/src/main/java/org/eclipse/sensinact/core/whiteboard/WhiteboardConstants.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/whiteboard/WhiteboardConstants.java
@@ -1,0 +1,73 @@
+/*********************************************************************
+* Copyright (c) 2024 Kentyou.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Thomas Calmant (Kentyou) - initial implementation
+**********************************************************************/
+package org.eclipse.sensinact.core.whiteboard;
+
+public interface WhiteboardConstants {
+
+    /**
+     * Property held by whiteboard handler service to indicate the list of providers
+     * it supports to be called for.
+     *
+     * Property can be null, a string or a collection or array of strings.
+     *
+     * If the property is null or an empty collection, the handler accepts all
+     * providers.
+     *
+     * If multiple handlers match the provider, the one with the smallest non-empty
+     * list of providers is preferred
+     */
+    String PROP_PROVIDERS = "sensiNact.provider.name";
+
+    /**
+     * Property held by whiteboard handler service to indicate the model package URI
+     * it supports to be called for.
+     *
+     * Property is a string that can be null, in which case it is computed based on
+     * default package and the given model name
+     */
+    String PROP_MODEL_PACKAGE_URI = "sensiNact.whiteboard.modelPackageUri";
+
+    /**
+     * Property held by whiteboard handler service to indicate the name of the model
+     * it supports to be called for.
+     *
+     * Property is a string that can't be null
+     */
+    String PROP_MODEL = "sensiNact.whiteboard.model";
+
+    /**
+     * Property held by whiteboard handler service to indicate the name of the
+     * service it supports to be called for.
+     *
+     * Property can be null to indicate any service
+     */
+    String PROP_SERVICE = "sensiNact.whiteboard.service";
+
+    /**
+     * Property held by whiteboard handler service to indicate the name of the
+     * resource it supports to be called for.
+     *
+     * Property is a string that can be null to indicate any resource
+     */
+    String PROP_RESOURCE = "sensiNact.whiteboard.resource";
+
+    /**
+     * Property held by whiteboard handler service to indicate that it requires the
+     * whiteboard to create the resource. Value handlers (GET/SET) must implement
+     * {@link WhiteboardResourceDescription} and action handlers must implement
+     * {@link WhiteboardActDescription} to be able to describe their resource.
+     *
+     * Property is a boolean that can be null.
+     */
+    String PROP_AUTO_CREATE = "sensiNact.whiteboard.create";
+}

--- a/core/api/src/main/java/org/eclipse/sensinact/core/whiteboard/WhiteboardConstants.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/whiteboard/WhiteboardConstants.java
@@ -49,7 +49,8 @@ public interface WhiteboardConstants {
      * Property held by whiteboard handler service to indicate the name of the
      * service it supports to be called for.
      *
-     * Property can be null to indicate any service
+     * Property can be null to indicate any service if and only if
+     * {@link #PROP_RESOURCE} is also null
      */
     String PROP_SERVICE = "sensiNact.whiteboard.service";
 

--- a/core/api/src/main/java/org/eclipse/sensinact/core/whiteboard/WhiteboardGet.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/whiteboard/WhiteboardGet.java
@@ -1,0 +1,41 @@
+/*********************************************************************
+* Copyright (c) 2024 Kentyou.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Thomas Calmant (Kentyou) - initial implementation
+**********************************************************************/
+package org.eclipse.sensinact.core.whiteboard;
+
+import org.eclipse.sensinact.core.twin.TimedValue;
+import org.osgi.util.promise.Promise;
+import org.osgi.util.promise.PromiseFactory;
+
+/**
+ * Whiteboard service to handle resource get operations
+ *
+ * @param <T> Resource type
+ */
+public interface WhiteboardGet<T> extends WhiteboardHandler<T> {
+
+    /**
+     * Whiteboard is called to get the resource value as a promise
+     *
+     * @param promiseFactory  Promise factory
+     * @param modelPackageUri Package URI of the provider model
+     * @param model           Provider model name
+     * @param provider        Provider name
+     * @param service         Service name
+     * @param resource        Resource name
+     * @param resourceType    Expected type of the result
+     * @param cachedValue     Previously cached value
+     * @return A promise, created with the promise factory
+     */
+    Promise<TimedValue<T>> pullValue(PromiseFactory promiseFactory, String modelPackageUri, String model,
+            String provider, String service, String resource, Class<T> resourceType, TimedValue<T> cachedValue);
+}

--- a/core/api/src/main/java/org/eclipse/sensinact/core/whiteboard/WhiteboardGet.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/whiteboard/WhiteboardGet.java
@@ -21,7 +21,7 @@ import org.osgi.util.promise.PromiseFactory;
  *
  * @param <T> Resource type
  */
-public interface WhiteboardGet<T> extends WhiteboardHandler<T> {
+public interface WhiteboardGet<T> extends WhiteboardHandler {
 
     /**
      * Whiteboard is called to get the resource value as a promise

--- a/core/api/src/main/java/org/eclipse/sensinact/core/whiteboard/WhiteboardHandler.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/whiteboard/WhiteboardHandler.java
@@ -15,6 +15,6 @@ package org.eclipse.sensinact.core.whiteboard;
 /**
  * Common parent interface for whiteboard handlers
  */
-public interface WhiteboardHandler<T> {
+public interface WhiteboardHandler {
 
 }

--- a/core/api/src/main/java/org/eclipse/sensinact/core/whiteboard/WhiteboardHandler.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/whiteboard/WhiteboardHandler.java
@@ -1,0 +1,20 @@
+/*********************************************************************
+* Copyright (c) 2024 Kentyou.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Thomas Calmant (Kentyou) - initial implementation
+**********************************************************************/
+package org.eclipse.sensinact.core.whiteboard;
+
+/**
+ * Common parent interface for whiteboard handlers
+ */
+public interface WhiteboardHandler<T> {
+
+}

--- a/core/api/src/main/java/org/eclipse/sensinact/core/whiteboard/WhiteboardResourceDescription.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/whiteboard/WhiteboardResourceDescription.java
@@ -14,9 +14,21 @@ package org.eclipse.sensinact.core.whiteboard;
 
 import java.time.Duration;
 
+/**
+ * Interface that an auto-descriptive value resource handler must implement if
+ * it expects the whiteboard to create its resource automatically
+ *
+ * @param <T> Type of resource
+ */
 public interface WhiteboardResourceDescription<T> {
 
+    /**
+     * Returns the type of the resource to create
+     */
     Class<T> getResourceType();
 
+    /**
+     * Returns the duration of the cache to avoid calling the handler too often
+     */
     Duration getCacheDuration();
 }

--- a/core/api/src/main/java/org/eclipse/sensinact/core/whiteboard/WhiteboardResourceDescription.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/whiteboard/WhiteboardResourceDescription.java
@@ -1,0 +1,22 @@
+/*********************************************************************
+* Copyright (c) 2024 Kentyou.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Thomas Calmant (Kentyou) - initial implementation
+**********************************************************************/
+package org.eclipse.sensinact.core.whiteboard;
+
+import java.time.Duration;
+
+public interface WhiteboardResourceDescription<T> {
+
+    Class<T> getResourceType();
+
+    Duration getCacheDuration();
+}

--- a/core/api/src/main/java/org/eclipse/sensinact/core/whiteboard/WhiteboardResourceDescription.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/whiteboard/WhiteboardResourceDescription.java
@@ -20,7 +20,7 @@ import java.time.Duration;
  *
  * @param <T> Type of resource
  */
-public interface WhiteboardResourceDescription<T> {
+public interface WhiteboardResourceDescription<T> extends WhiteboardGet<T> {
 
     /**
      * Returns the type of the resource to create

--- a/core/api/src/main/java/org/eclipse/sensinact/core/whiteboard/WhiteboardSet.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/whiteboard/WhiteboardSet.java
@@ -1,0 +1,44 @@
+/*********************************************************************
+* Copyright (c) 2024 Kentyou.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Thomas Calmant (Kentyou) - initial implementation
+**********************************************************************/
+package org.eclipse.sensinact.core.whiteboard;
+
+import org.eclipse.sensinact.core.twin.TimedValue;
+import org.osgi.util.promise.Promise;
+import org.osgi.util.promise.PromiseFactory;
+
+/**
+ * Whiteboard service to handle resource get/set operations
+ *
+ * @param <T> Resource type
+ */
+public interface WhiteboardSet<T> extends WhiteboardGet<T> {
+
+    /**
+     * Whiteboard is called to set the resource value
+     *
+     *
+     * @param promiseFactory  Promise factory
+     * @param modelPackageUri Package URI of the provider model
+     * @param model           Provider model name
+     * @param provider        Provider name
+     * @param service         Service name
+     * @param resource        Resource name
+     * @param resourceType    Expected type of the result
+     * @param cachedValue     Previously cached value
+     * @param newValue        New value
+     * @return A promise, created with the promise factory
+     */
+    Promise<TimedValue<T>> pushValue(PromiseFactory promiseFactory, String modelPackageUri, String model,
+            String provider, String service, String resource, Class<T> resourceType, TimedValue<T> cachedValue,
+            TimedValue<T> newValue);
+}

--- a/core/api/src/main/java/org/eclipse/sensinact/core/whiteboard/package-info.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/whiteboard/package-info.java
@@ -1,0 +1,14 @@
+/*********************************************************************
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors: Kentyou - initial implementation
+ **********************************************************************/
+@org.osgi.annotation.bundle.Export
+@org.osgi.annotation.versioning.Version("0.2.0")
+package org.eclipse.sensinact.core.whiteboard;

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/command/impl/GatewayThreadImpl.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/command/impl/GatewayThreadImpl.java
@@ -39,6 +39,7 @@ import org.eclipse.sensinact.core.notification.NotificationAccumulator;
 import org.eclipse.sensinact.core.notification.impl.ImmediateNotificationAccumulator;
 import org.eclipse.sensinact.core.notification.impl.NotificationAccumulatorImpl;
 import org.eclipse.sensinact.core.twin.impl.SensinactDigitalTwinImpl;
+import org.eclipse.sensinact.core.whiteboard.WhiteboardHandler;
 import org.eclipse.sensinact.core.whiteboard.impl.SensinactWhiteboard;
 import org.eclipse.sensinact.model.core.provider.ProviderPackage;
 import org.osgi.service.component.AnyService;
@@ -126,6 +127,15 @@ public class GatewayThreadImpl extends Thread implements GatewayThread {
 
     void removeEPackage(EPackage ePackage) {
         nexusImpl.removeEPackage(ePackage);
+    }
+
+    @Reference(service = WhiteboardHandler.class, cardinality = MULTIPLE, policy = DYNAMIC)
+    void addWhiteboardResourceHandler(WhiteboardHandler wbHandler, Map<String, Object> props) {
+        whiteboard.addWhiteboardHandler(wbHandler, props);
+    }
+
+    void removeWhiteboardResourceHandler(WhiteboardHandler wbHandler, Map<String, Object> props) {
+        whiteboard.removeWhiteboardHandler(wbHandler, props);
     }
 
     @Reference(service = AnyService.class, target = "(sensiNact.whiteboard.resource=true)", cardinality = MULTIPLE, policy = DYNAMIC)

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/command/impl/GatewayThreadImpl.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/command/impl/GatewayThreadImpl.java
@@ -130,11 +130,15 @@ public class GatewayThreadImpl extends Thread implements GatewayThread {
     }
 
     @Reference(service = WhiteboardHandler.class, cardinality = MULTIPLE, policy = DYNAMIC)
-    void addWhiteboardResourceHandler(WhiteboardHandler wbHandler, Map<String, Object> props) {
+    void addWhiteboardResourceHandler(WhiteboardHandler<?> wbHandler, Map<String, Object> props) {
         whiteboard.addWhiteboardHandler(wbHandler, props);
     }
 
-    void removeWhiteboardResourceHandler(WhiteboardHandler wbHandler, Map<String, Object> props) {
+    void updatedWhiteboardResourceHandler(WhiteboardHandler<?> wbHandler, Map<String, Object> props) {
+        whiteboard.updatedWhiteboardHandler(wbHandler, props);
+    }
+
+    void removeWhiteboardResourceHandler(WhiteboardHandler<?> wbHandler, Map<String, Object> props) {
         whiteboard.removeWhiteboardHandler(wbHandler, props);
     }
 

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/command/impl/GatewayThreadImpl.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/command/impl/GatewayThreadImpl.java
@@ -130,15 +130,15 @@ public class GatewayThreadImpl extends Thread implements GatewayThread {
     }
 
     @Reference(service = WhiteboardHandler.class, cardinality = MULTIPLE, policy = DYNAMIC)
-    void addWhiteboardResourceHandler(WhiteboardHandler<?> wbHandler, Map<String, Object> props) {
+    void addWhiteboardResourceHandler(WhiteboardHandler wbHandler, Map<String, Object> props) {
         whiteboard.addWhiteboardHandler(wbHandler, props);
     }
 
-    void updatedWhiteboardResourceHandler(WhiteboardHandler<?> wbHandler, Map<String, Object> props) {
+    void updatedWhiteboardResourceHandler(WhiteboardHandler wbHandler, Map<String, Object> props) {
         whiteboard.updatedWhiteboardHandler(wbHandler, props);
     }
 
-    void removeWhiteboardResourceHandler(WhiteboardHandler<?> wbHandler, Map<String, Object> props) {
+    void removeWhiteboardResourceHandler(WhiteboardHandler wbHandler, Map<String, Object> props) {
         whiteboard.removeWhiteboardHandler(wbHandler, props);
     }
 

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/whiteboard/impl/AbstractResourceMethod.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/whiteboard/impl/AbstractResourceMethod.java
@@ -29,11 +29,12 @@ import java.util.function.Function;
 import org.eclipse.sensinact.core.annotation.verb.ActParam;
 import org.eclipse.sensinact.core.annotation.verb.UriParam;
 import org.eclipse.sensinact.core.model.nexus.emf.EMFUtil;
+import org.eclipse.sensinact.core.whiteboard.WhiteboardHandler;
 
 /**
  * Share code between ACT and GET methods
  */
-abstract class AbstractResourceMethod {
+abstract class AbstractResourceMethod implements WhiteboardHandler<Object> {
 
     /**
      * Invoked method

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/whiteboard/impl/AbstractResourceMethod.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/whiteboard/impl/AbstractResourceMethod.java
@@ -34,7 +34,7 @@ import org.eclipse.sensinact.core.whiteboard.WhiteboardHandler;
 /**
  * Share code between ACT and GET methods
  */
-abstract class AbstractResourceMethod implements WhiteboardHandler<Object> {
+abstract class AbstractResourceMethod implements WhiteboardHandler {
 
     /**
      * Invoked method

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/whiteboard/impl/ActMethod.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/whiteboard/impl/ActMethod.java
@@ -16,16 +16,26 @@ import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.Set;
 
-class ActMethod extends AbstractResourceMethod {
+import org.eclipse.sensinact.core.whiteboard.WhiteboardAct;
+import org.osgi.util.promise.Promise;
+import org.osgi.util.promise.PromiseFactory;
+
+class ActMethod extends AbstractResourceMethod implements WhiteboardAct<Object> {
 
     public ActMethod(Method method, Object instance, Long serviceId, Set<String> providers) {
         super(method, instance, serviceId, providers);
     }
 
-    public Object invoke(String modelPackageUri,String model, String provider, String service, String resource, Map<String, Object> params)
-            throws Exception {
+    @Override
+    public Promise<Object> act(PromiseFactory promiseFactory, String modelPackageUri, String model, String provider,
+            String service, String resource, Map<String, Object> arguments) {
         @SuppressWarnings({ "unchecked", "rawtypes" })
-        final Map<Object, Object> rawParam = (Map) params;
-        return super.invoke(modelPackageUri, model, provider, service, resource, rawParam, null, null);
+        final Map<Object, Object> rawParam = (Map) arguments;
+        try {
+            return promiseFactory
+                    .resolved(super.invoke(modelPackageUri, model, provider, service, resource, rawParam, null, null));
+        } catch (Exception e) {
+            return promiseFactory.failed(e);
+        }
     }
 }

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/whiteboard/impl/SensinactWhiteboard.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/whiteboard/impl/SensinactWhiteboard.java
@@ -158,7 +158,7 @@ public class SensinactWhiteboard {
      * @param handler The whiteboard handler service
      * @param props   The handler service properties
      */
-    public void addWhiteboardHandler(WhiteboardHandler<?> handler, Map<String, Object> props) {
+    public void addWhiteboardHandler(WhiteboardHandler handler, Map<String, Object> props) {
         final Long serviceId = (Long) props.get(Constants.SERVICE_ID);
         final Set<String> providers = toSet(props.get(WhiteboardConstants.PROP_PROVIDERS));
         final RegistryKey key = keyFromServiceProperties(props);
@@ -224,7 +224,7 @@ public class SensinactWhiteboard {
         }
     }
 
-    public void updatedWhiteboardHandler(WhiteboardHandler<?> handler, Map<String, Object> props) {
+    public void updatedWhiteboardHandler(WhiteboardHandler handler, Map<String, Object> props) {
         Long serviceId = (Long) props.get(Constants.SERVICE_ID);
         Set<String> providers = toSet(props.get(WhiteboardConstants.PROP_PROVIDERS));
 
@@ -233,7 +233,7 @@ public class SensinactWhiteboard {
         updateServiceReferences("set", serviceId, providers, serviceIdToSetMethods, setMethodRegistry);
     }
 
-    public void removeWhiteboardHandler(WhiteboardHandler<?> handler, Map<String, Object> props) {
+    public void removeWhiteboardHandler(WhiteboardHandler handler, Map<String, Object> props) {
         final Long serviceId = (Long) props.get(Constants.SERVICE_ID);
         clearServiceReferences(serviceId, serviceIdToActMethods, actMethodRegistry);
         clearServiceReferences(serviceId, serviceIdToGetMethods, getMethodRegistry);
@@ -249,7 +249,7 @@ public class SensinactWhiteboard {
      * @param keyRegistry    Service ID to registry keys map
      * @param methodRegistry Registry key to handlers contexts map
      */
-    private <T extends WhiteboardHandler<?>> void storeWhiteboardHandler(WhiteboardContext<T> ctx, RegistryKey key,
+    private <T extends WhiteboardHandler> void storeWhiteboardHandler(WhiteboardContext<T> ctx, RegistryKey key,
             Map<Long, List<RegistryKey>> keyRegistry, Map<RegistryKey, List<WhiteboardContext<T>>> methodRegistry) {
         synchronized (keyRegistry) {
             keyRegistry.merge(ctx.serviceId, List.of(key), (a, b) -> concat(a.stream(), b.stream()).collect(toList()));
@@ -310,7 +310,7 @@ public class SensinactWhiteboard {
      * @param methodRegistry    Registry associating handled resources to the
      *                          handling method
      */
-    private <T extends WhiteboardHandler<?>> void updateServiceReferences(final String kind, final Long serviceId,
+    private <T extends WhiteboardHandler> void updateServiceReferences(final String kind, final Long serviceId,
             final Set<String> providers, final Map<Long, List<RegistryKey>> serviceKeysHolder,
             final Map<RegistryKey, List<WhiteboardContext<T>>> methodRegistry) {
         for (RegistryKey key : serviceKeysHolder.getOrDefault(serviceId, List.of())) {
@@ -366,7 +366,7 @@ public class SensinactWhiteboard {
      * @param methodRegistry    Registry associating handled resources to the
      *                          handling method
      */
-    private <T extends WhiteboardHandler<?>> void clearServiceReferences(final Long serviceId,
+    private <T extends WhiteboardHandler> void clearServiceReferences(final Long serviceId,
             final Map<Long, List<RegistryKey>> serviceKeysHolder,
             final Map<RegistryKey, List<WhiteboardContext<T>>> methodRegistry) {
         final List<RegistryKey> keys = serviceKeysHolder.remove(serviceId);
@@ -516,7 +516,7 @@ public class SensinactWhiteboard {
     }
 
     @SuppressWarnings("unchecked")
-    private <M extends AbstractResourceMethod, T extends WhiteboardHandler<?>> void processAnnotatedMethod(
+    private <M extends AbstractResourceMethod, T extends WhiteboardHandler> void processAnnotatedMethod(
             final RegistryKey key, final Predicate<ResourceType> validateResourceType,
             final Consumer<ResourceBuilder<?, Object>> builderCaller, WhiteboardContext<M> ctx,
             Map<RegistryKey, List<WhiteboardContext<T>>> methodsRegistry,
@@ -669,7 +669,7 @@ public class SensinactWhiteboard {
         return d.getPromise().onResolve(() -> overallTimer.close());
     }
 
-    private <T extends WhiteboardHandler<?>> Optional<WhiteboardContext<T>> lookupContext(final RegistryKey key,
+    private <T extends WhiteboardHandler> Optional<WhiteboardContext<T>> lookupContext(final RegistryKey key,
             final String provider, final Map<RegistryKey, List<WhiteboardContext<T>>> registry) {
         Optional<WhiteboardContext<T>> opt = Optional.empty();
         RegistryKey lookupKey = key;

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/whiteboard/impl/SensinactWhiteboard.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/whiteboard/impl/SensinactWhiteboard.java
@@ -62,6 +62,7 @@ import org.eclipse.sensinact.core.twin.SensinactDigitalTwin;
 import org.eclipse.sensinact.core.twin.TimedValue;
 import org.eclipse.sensinact.core.whiteboard.WhiteboardAct;
 import org.eclipse.sensinact.core.whiteboard.WhiteboardActDescription;
+import org.eclipse.sensinact.core.whiteboard.WhiteboardConstants;
 import org.eclipse.sensinact.core.whiteboard.WhiteboardGet;
 import org.eclipse.sensinact.core.whiteboard.WhiteboardHandler;
 import org.eclipse.sensinact.core.whiteboard.WhiteboardResourceDescription;
@@ -138,6 +139,19 @@ public class SensinactWhiteboard {
     }
 
     /**
+     * Create a registry key from service properties
+     *
+     * @param props Service properties
+     * @return A new registry key
+     */
+    private RegistryKey keyFromServiceProperties(Map<String, Object> props) {
+        return new RegistryKey((String) props.get(WhiteboardConstants.PROP_MODEL_PACKAGE_URI),
+                (String) props.get(WhiteboardConstants.PROP_MODEL),
+                (String) props.get(WhiteboardConstants.PROP_SERVICE),
+                (String) props.get(WhiteboardConstants.PROP_RESOURCE));
+    }
+
+    /**
      * Register a whiteboard handler service. The handler must provider either
      * {@link WhiteboardAct} or {@link WhiteboardGet} and/or {@link WhiteboardSet}
      *
@@ -146,21 +160,19 @@ public class SensinactWhiteboard {
      */
     public void addWhiteboardHandler(WhiteboardHandler<?> handler, Map<String, Object> props) {
         final Long serviceId = (Long) props.get(Constants.SERVICE_ID);
-        Set<String> providers = toSet(props.get("sensiNact.whiteboard.providers"));
-        RegistryKey key = new RegistryKey((String) props.get("sensiNact.whiteboard.modelPackageUri"),
-                (String) props.get("sensiNact.whiteboard.model"), (String) props.get("sensiNact.whiteboard.service"),
-                (String) props.get("sensiNact.whiteboard.resource"));
+        final Set<String> providers = toSet(props.get(WhiteboardConstants.PROP_PROVIDERS));
+        final RegistryKey key = keyFromServiceProperties(props);
 
-        boolean isGet = handler instanceof WhiteboardGet;
-        boolean isSet = handler instanceof WhiteboardSet;
-        boolean isValue = isGet || isSet;
-        boolean isAct = handler instanceof WhiteboardAct;
+        final boolean isGet = handler instanceof WhiteboardGet;
+        final boolean isSet = handler instanceof WhiteboardSet;
+        final boolean isValue = isGet || isSet;
+        final boolean isAct = handler instanceof WhiteboardAct;
         if (!isAct && !isValue) {
             LOG.error("Whiteboard handler service {} for {} doesn't provider meaningful interfaces", serviceId, key);
             return;
         }
 
-        final Boolean createResource = (Boolean) props.get("sensiNact.whiteboard.create");
+        final Boolean createResource = (Boolean) props.get(WhiteboardConstants.PROP_AUTO_CREATE);
         if (createResource != null && createResource.booleanValue()) {
             if (isAct && isValue) {
                 LOG.error("Can't create a resource if its handler is both made for action and value resources");
@@ -214,7 +226,7 @@ public class SensinactWhiteboard {
 
     public void updatedWhiteboardHandler(WhiteboardHandler<?> handler, Map<String, Object> props) {
         Long serviceId = (Long) props.get(Constants.SERVICE_ID);
-        Set<String> providers = toSet(props.get("sensiNact.provider.name"));
+        Set<String> providers = toSet(props.get(WhiteboardConstants.PROP_PROVIDERS));
 
         updateServiceReferences("act", serviceId, providers, serviceIdToActMethods, actMethodRegistry);
         updateServiceReferences("get", serviceId, providers, serviceIdToGetMethods, getMethodRegistry);
@@ -259,7 +271,7 @@ public class SensinactWhiteboard {
     public void addWhiteboardService(Object service, Map<String, Object> props) {
         Long serviceId = (Long) props.get(Constants.SERVICE_ID);
 
-        Set<String> providers = toSet(props.get("sensiNact.provider.name"));
+        Set<String> providers = toSet(props.get(WhiteboardConstants.PROP_PROVIDERS));
 
         Class<?> clz = service.getClass();
 
@@ -337,7 +349,7 @@ public class SensinactWhiteboard {
      */
     public void updatedWhiteboardService(Object service, Map<String, Object> props) {
         Long serviceId = (Long) props.get(Constants.SERVICE_ID);
-        Set<String> providers = toSet(props.get("sensiNact.provider.name"));
+        Set<String> providers = toSet(props.get(WhiteboardConstants.PROP_PROVIDERS));
 
         updateServiceReferences("act", serviceId, providers, serviceIdToActMethods, actMethodRegistry);
         updateServiceReferences("get", serviceId, providers, serviceIdToGetMethods, getMethodRegistry);

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/whiteboard/impl/SensinactWhiteboard.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/whiteboard/impl/SensinactWhiteboard.java
@@ -213,7 +213,16 @@ public class SensinactWhiteboard {
         }
     }
 
-    public <T> void removeWhiteboardHandler(WhiteboardHandler<?> handler, Map<String, Object> props) {
+    public void updatedWhiteboardHandler(WhiteboardHandler<?> handler, Map<String, Object> props) {
+        Long serviceId = (Long) props.get(Constants.SERVICE_ID);
+        Set<String> providers = toSet(props.get("sensiNact.provider.name"));
+
+        updateServiceReferences("act", serviceId, providers, serviceIdToActMethods, actMethodRegistry);
+        updateServiceReferences("get", serviceId, providers, serviceIdToGetMethods, getMethodRegistry);
+        updateServiceReferences("set", serviceId, providers, serviceIdToSetMethods, setMethodRegistry);
+    }
+
+    public void removeWhiteboardHandler(WhiteboardHandler<?> handler, Map<String, Object> props) {
         final Long serviceId = (Long) props.get(Constants.SERVICE_ID);
         clearServiceReferences(serviceId, serviceIdToActMethods, actMethodRegistry);
         clearServiceReferences(serviceId, serviceIdToGetMethods, getMethodRegistry);

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/whiteboard/impl/WhiteboardContext.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/whiteboard/impl/WhiteboardContext.java
@@ -17,7 +17,7 @@ import java.util.Set;
 
 import org.eclipse.sensinact.core.whiteboard.WhiteboardHandler;
 
-class WhiteboardContext<T extends WhiteboardHandler<?>> {
+class WhiteboardContext<T extends WhiteboardHandler> {
 
     /**
      * The underlying handler

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/whiteboard/impl/WhiteboardContext.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/whiteboard/impl/WhiteboardContext.java
@@ -1,0 +1,56 @@
+/*********************************************************************
+* Copyright (c) 2024 Kentyou.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Thomas Calmant (Kentyou) - initial implementation
+**********************************************************************/
+package org.eclipse.sensinact.core.whiteboard.impl;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.sensinact.core.whiteboard.WhiteboardHandler;
+
+class WhiteboardContext<T extends WhiteboardHandler<?>> {
+
+    /**
+     * The underlying handler
+     */
+    public final T handler;
+
+    /**
+     * The set of providers the handler was registered for
+     */
+    public final Set<String> providers = new HashSet<>();
+
+    /**
+     * The ID of the handler service
+     */
+    public final Long serviceId;
+
+    public WhiteboardContext(Long svcId, T handler) {
+        this.serviceId = svcId;
+        this.handler = handler;
+    }
+
+    public WhiteboardContext(Long svcId, T handler, Set<String> providers) {
+        this(svcId, handler);
+        this.providers.addAll(providers);
+    }
+
+    @SuppressWarnings("unchecked")
+    public Class<T> getType() {
+        return (Class<T>) this.handler.getClass();
+    }
+
+    @Override
+    public String toString() {
+        return handler.getClass().getSimpleName() + "[serviceId=" + serviceId + ", providers=" + providers + "]";
+    }
+}

--- a/core/impl/src/test/java/org/eclipse/sensinact/core/command/impl/WhiteboardImplTest.java
+++ b/core/impl/src/test/java/org/eclipse/sensinact/core/command/impl/WhiteboardImplTest.java
@@ -70,6 +70,7 @@ import org.eclipse.sensinact.core.whiteboard.AbstractDescriptiveAct;
 import org.eclipse.sensinact.core.whiteboard.AbstractDescriptiveReadOnly;
 import org.eclipse.sensinact.core.whiteboard.AbstractDescriptiveReadWrite;
 import org.eclipse.sensinact.core.whiteboard.WhiteboardAct;
+import org.eclipse.sensinact.core.whiteboard.WhiteboardConstants;
 import org.eclipse.sensinact.core.whiteboard.WhiteboardGet;
 import org.eclipse.sensinact.core.whiteboard.WhiteboardSet;
 import org.eclipse.sensinact.model.core.provider.ProviderPackage;
@@ -758,9 +759,9 @@ public class WhiteboardImplTest {
     class WhiteboardHandlerAutoCreateTest {
 
         Map<String, Object> makeProps(String model, String service, String resource) {
-            return Map.of(Constants.SERVICE_ID, 42L, "sensiNact.whiteboard.model", model,
-                    "sensiNact.whiteboard.service", service, "sensiNact.whiteboard.resource", resource,
-                    "sensiNact.whiteboard.create", true);
+            return Map.of(Constants.SERVICE_ID, 42L, WhiteboardConstants.PROP_MODEL, model,
+                    WhiteboardConstants.PROP_SERVICE, service, WhiteboardConstants.PROP_RESOURCE, resource,
+                    WhiteboardConstants.PROP_AUTO_CREATE, true);
         }
 
         @Test
@@ -921,8 +922,8 @@ public class WhiteboardImplTest {
     class WhiteboardHandlerTest {
 
         Map<String, Object> makeProps(String model, String service, String resource) {
-            return Map.of(Constants.SERVICE_ID, 42L, "sensiNact.whiteboard.model", model,
-                    "sensiNact.whiteboard.service", service, "sensiNact.whiteboard.resource", resource);
+            return Map.of(Constants.SERVICE_ID, 42L, WhiteboardConstants.PROP_MODEL, model,
+                    WhiteboardConstants.PROP_SERVICE, service, WhiteboardConstants.PROP_RESOURCE, resource);
         }
 
         void makeResource(final String modelName, final String serviceName, final String resourceName,
@@ -1118,10 +1119,10 @@ public class WhiteboardImplTest {
         Map<String, Object> makeProps(long svcId, String model, String service, String resource, String... providers) {
             Map<String, Object> props = new HashMap<>();
             props.put(Constants.SERVICE_ID, svcId);
-            props.put("sensiNact.whiteboard.model", model);
-            props.put("sensiNact.whiteboard.service", service);
-            props.put("sensiNact.whiteboard.resource", resource);
-            props.put("sensiNact.whiteboard.providers", providers.length == 0 ? null : providers);
+            props.put(WhiteboardConstants.PROP_MODEL, model);
+            props.put(WhiteboardConstants.PROP_SERVICE, service);
+            props.put(WhiteboardConstants.PROP_RESOURCE, resource);
+            props.put(WhiteboardConstants.PROP_PROVIDERS, providers.length == 0 ? null : providers);
             return props;
         }
 

--- a/core/impl/src/test/java/org/eclipse/sensinact/core/command/impl/WhiteboardImplTest.java
+++ b/core/impl/src/test/java/org/eclipse/sensinact/core/command/impl/WhiteboardImplTest.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.NoSuchElementException;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -787,8 +788,8 @@ public class WhiteboardImplTest {
             assertNotNull(result.getTimestamp(), "No timestamp");
             assertEquals(42, result.getValue());
 
-            // FIXME: Change exception type
-            assertThrows(Exception.class,
+            // Ensure an exception is thrown
+            assertThrows(NoSuchElementException.class,
                     () -> setValue(PROVIDER_A, svcName, "rc", (r) -> r.setValue(1234, Instant.now())));
         }
 
@@ -996,8 +997,8 @@ public class WhiteboardImplTest {
             assertNotNull(result.getTimestamp(), "No timestamp");
             assertEquals(42, result.getValue());
 
-            // FIXME: Change exception type
-            assertThrows(Exception.class,
+            // Ensure an exception is thrown
+            assertThrows(NoSuchElementException.class,
                     () -> setValue(PROVIDER_A, svcName, rcName, (r) -> r.setValue(1234, Instant.now())));
         }
 

--- a/core/impl/src/test/java/org/eclipse/sensinact/core/command/impl/WhiteboardImplTest.java
+++ b/core/impl/src/test/java/org/eclipse/sensinact/core/command/impl/WhiteboardImplTest.java
@@ -29,6 +29,8 @@ import java.time.temporal.ChronoUnit;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.eclipse.emf.ecore.resource.ResourceSet;
@@ -43,27 +45,40 @@ import org.eclipse.sensinact.core.annotation.verb.SetParam;
 import org.eclipse.sensinact.core.annotation.verb.SetParam.SetSegment;
 import org.eclipse.sensinact.core.annotation.verb.UriParam;
 import org.eclipse.sensinact.core.annotation.verb.UriParam.UriSegment;
+import org.eclipse.sensinact.core.command.AbstractSensinactCommand;
 import org.eclipse.sensinact.core.command.AbstractTwinCommand;
 import org.eclipse.sensinact.core.command.GetLevel;
 import org.eclipse.sensinact.core.command.ResourceCommand;
+import org.eclipse.sensinact.core.emf.util.EMFTestUtil;
 import org.eclipse.sensinact.core.metrics.IMetricCounter;
 import org.eclipse.sensinact.core.metrics.IMetricTimer;
 import org.eclipse.sensinact.core.metrics.IMetricsHistogram;
 import org.eclipse.sensinact.core.metrics.IMetricsManager;
+import org.eclipse.sensinact.core.model.Model;
+import org.eclipse.sensinact.core.model.Resource;
+import org.eclipse.sensinact.core.model.ResourceBuilder;
+import org.eclipse.sensinact.core.model.SensinactModelManager;
+import org.eclipse.sensinact.core.model.Service;
 import org.eclipse.sensinact.core.twin.SensinactDigitalTwin;
 import org.eclipse.sensinact.core.twin.SensinactProvider;
 import org.eclipse.sensinact.core.twin.SensinactResource;
 import org.eclipse.sensinact.core.twin.SensinactService;
 import org.eclipse.sensinact.core.twin.TimedValue;
-import org.eclipse.sensinact.model.core.provider.ProviderPackage;
-import org.eclipse.sensinact.core.emf.util.EMFTestUtil;
 import org.eclipse.sensinact.core.twin.impl.TimedValueImpl;
+import org.eclipse.sensinact.core.whiteboard.AbstractDescriptiveAct;
+import org.eclipse.sensinact.core.whiteboard.AbstractDescriptiveReadOnly;
+import org.eclipse.sensinact.core.whiteboard.AbstractDescriptiveReadWrite;
+import org.eclipse.sensinact.core.whiteboard.WhiteboardAct;
+import org.eclipse.sensinact.core.whiteboard.WhiteboardGet;
+import org.eclipse.sensinact.core.whiteboard.WhiteboardSet;
+import org.eclipse.sensinact.model.core.provider.ProviderPackage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.osgi.framework.Constants;
 import org.osgi.service.typedevent.TypedEventBus;
 import org.osgi.util.promise.Promise;
 import org.osgi.util.promise.PromiseFactory;
@@ -334,7 +349,7 @@ public class WhiteboardImplTest {
                 @GetParam(GetSegment.CACHED_VALUE) TimedValue<?> cached) {
             switch (resource) {
             case "b":
-                if(bReturnNull)
+                if (bReturnNull)
                     return null;
             case "a":
                 if (cached.getValue() != null) {
@@ -394,7 +409,6 @@ public class WhiteboardImplTest {
             Instant secondTimestamp = result.getTimestamp();
             assertTrue(secondTimestamp.isAfter(initialTimestamp),
                     secondTimestamp + " should be after " + initialTimestamp);
-
 
             // Now try for resource b
             runRcCommand(PROVIDER_A, svc, "b", (r) -> {
@@ -736,6 +750,365 @@ public class WhiteboardImplTest {
             assertNotNull(result2.getValue(), "No value");
             assertNotNull(result2.getTimestamp(), "No timestamp");
             assertEquals(42, result2.getValue());
+        }
+    }
+
+    @Nested
+    class WhiteboardHandlerAutoCreateTest {
+
+        Map<String, Object> makeProps(String model, String service, String resource) {
+            return Map.of(Constants.SERVICE_ID, 42L, "sensiNact.whiteboard.model", model,
+                    "sensiNact.whiteboard.service", service, "sensiNact.whiteboard.resource", resource,
+                    "sensiNact.whiteboard.create", true);
+        }
+
+        @Test
+        void testReadOnly() throws Throwable {
+            AbstractDescriptiveReadOnly<Integer> getHandler = new AbstractDescriptiveReadOnly<>() {
+                @Override
+                public Promise<TimedValue<Integer>> doPullValue(PromiseFactory pf, String modelPackageUri, String model,
+                        String provider, String service, String resource, TimedValue<Integer> cachedValue) {
+                    return pf.resolved(new TimedValueImpl<>(42));
+                }
+            };
+
+            assertEquals(Integer.class, getHandler.getResourceType());
+
+            final String modelName = "wbHandlerROTest";
+            final String svcName = "svc";
+            thread.addWhiteboardResourceHandler(getHandler, makeProps(modelName, svcName, "rc"));
+
+            createProviders(modelName, svcName);
+
+            TimedValue<Integer> result = getValue(PROVIDER_A, svcName, "rc", Integer.class);
+            assertNotNull(result.getValue(), "No value");
+            assertNotNull(result.getTimestamp(), "No timestamp");
+            assertEquals(42, result.getValue());
+
+            // FIXME: Change exception type
+            assertThrows(Exception.class,
+                    () -> setValue(PROVIDER_A, svcName, "rc", (r) -> r.setValue(1234, Instant.now())));
+        }
+
+        @Test
+        void testReadWrite() throws Throwable {
+            AbstractDescriptiveReadWrite<Long> rcHandler = new AbstractDescriptiveReadWrite<>() {
+                Long value = 42L;
+
+                @Override
+                public Promise<TimedValue<Long>> doPullValue(PromiseFactory pf, String modelPackageUri, String model,
+                        String provider, String service, String resource, TimedValue<Long> cachedValue) {
+                    return pf.resolved(new TimedValueImpl<Long>(value));
+                }
+
+                @Override
+                public Promise<TimedValue<Long>> doPushValue(PromiseFactory pf, String modelPackageUri, String model,
+                        String provider, String service, String resource, TimedValue<Long> cachedValue,
+                        TimedValue<Long> newValue) {
+                    this.value = newValue.getValue();
+                    return pf.resolved(new TimedValueImpl<Long>(value));
+                }
+            };
+
+            assertEquals(Long.class, rcHandler.getResourceType());
+
+            final String modelName = "wbHandlerRWTest";
+            final String svcName = "svc";
+            thread.addWhiteboardResourceHandler(rcHandler, makeProps(modelName, svcName, "rc"));
+
+            createProviders(modelName, svcName);
+
+            TimedValue<Long> result = getValue(PROVIDER_A, svcName, "rc", Long.class);
+            assertNotNull(result.getValue(), "No value");
+            assertNotNull(result.getTimestamp(), "No timestamp");
+            assertEquals(42L, result.getValue());
+
+            setValue(PROVIDER_A, svcName, "rc", (r) -> r.setValue(1234L, Instant.now()));
+            result = getValue(PROVIDER_A, svcName, "rc", Long.class);
+            assertNotNull(result.getValue(), "No value");
+            assertNotNull(result.getTimestamp(), "No timestamp");
+            assertEquals(1234L, result.getValue());
+
+            setValue(PROVIDER_A, svcName, "rc", (r) -> r.setValue(null, Instant.now()));
+            result = getValue(PROVIDER_A, svcName, "rc", Long.class);
+            assertNull(result.getValue(), "Value still there");
+            assertNotNull(result.getTimestamp(), "No timestamp");
+        }
+
+        @Test
+        void testActEcho() throws Throwable {
+            AbstractDescriptiveAct<String> providerEchoHandler = new AbstractDescriptiveAct<>() {
+                @Override
+                public List<Entry<String, Class<?>>> getNamedParameterTypes() {
+                    return List.of();
+                }
+
+                @Override
+                protected Promise<String> doAct(PromiseFactory promiseFactory, String modelPackageUri, String model,
+                        String provider, String service, String resource, Map<String, Object> arguments) {
+                    return promiseFactory.resolved(provider);
+                }
+            };
+
+            assertEquals(String.class, providerEchoHandler.getReturnType());
+
+            final String modelName = "wbHandlerActTest";
+            final String svcName = "svc";
+            thread.addWhiteboardResourceHandler(providerEchoHandler, makeProps(modelName, svcName, "rc"));
+
+            createProviders(modelName, svcName);
+
+            // Test action
+            assertEquals(PROVIDER_A, act(PROVIDER_A, svcName, "rc", Map.of()));
+            assertEquals(PROVIDER_B, act(PROVIDER_B, svcName, "rc", Map.of()));
+
+            // Other kinds of access must fail
+            assertThrows(IllegalArgumentException.class, () -> getValue(PROVIDER_A, svcName, "rc", String.class));
+            assertThrows(IllegalArgumentException.class,
+                    () -> setValue(PROVIDER_A, svcName, "rc", (r) -> r.setValue(1234, Instant.now())));
+        }
+
+        @Test
+        void testActArgs() throws Throwable {
+            AbstractDescriptiveAct<Integer> providerEchoHandler = new AbstractDescriptiveAct<>() {
+                @Override
+                public List<Entry<String, Class<?>>> getNamedParameterTypes() {
+                    return List.of(Map.entry("value", String.class), Map.entry("radix", Integer.class));
+                }
+
+                @Override
+                public Promise<Integer> doAct(PromiseFactory pf, String modelPackageUri, String model, String provider,
+                        String service, String resource, Map<String, Object> arguments) {
+
+                    String value = (String) arguments.get("value");
+                    if (value == null) {
+                        return pf.failed(new NullPointerException("No value given"));
+                    }
+
+                    Integer radix = (Integer) arguments.get("radix");
+                    if (radix == null) {
+                        radix = 10;
+                    }
+                    return pf.resolved(Integer.parseInt(value, radix));
+                }
+            };
+
+            final String modelName = "wbHandlerActTest2";
+            final String svcName = "svc";
+            thread.addWhiteboardResourceHandler(providerEchoHandler, makeProps(modelName, svcName, "rc"));
+
+            createProviders(modelName, svcName);
+
+            // Test action
+            assertEquals(10, act(PROVIDER_A, svcName, "rc", Map.of("value", "10")));
+            assertEquals(10, act(PROVIDER_A, svcName, "rc", Map.of("value", "10", "radix", 10)));
+            assertEquals(2, act(PROVIDER_A, svcName, "rc", Map.of("value", "10", "radix", 2)));
+            assertEquals(255, act(PROVIDER_A, svcName, "rc", Map.of("value", "FF", "radix", 16)));
+
+            // Test errors
+            assertThrows(NullPointerException.class, () -> act(PROVIDER_A, svcName, "rc", Map.of()));
+            assertThrows(NullPointerException.class, () -> act(PROVIDER_A, svcName, "rc", Map.of("value", null)));
+
+            // Other kinds of access must fail
+            assertThrows(IllegalArgumentException.class, () -> getValue(PROVIDER_A, svcName, "rc", String.class));
+            assertThrows(IllegalArgumentException.class,
+                    () -> setValue(PROVIDER_A, svcName, "rc", (r) -> r.setValue(1234, Instant.now())));
+        }
+    }
+
+    @Nested
+    class WhiteboardHandlerTest {
+
+        Map<String, Object> makeProps(String model, String service, String resource) {
+            return Map.of(Constants.SERVICE_ID, 42L, "sensiNact.whiteboard.model", model,
+                    "sensiNact.whiteboard.service", service, "sensiNact.whiteboard.resource", resource);
+        }
+
+        void makeResource(final String modelName, final String serviceName, final String resourceName,
+                final Consumer<ResourceBuilder<?, Object>> builderCaller) {
+            thread.execute(new AbstractSensinactCommand<Void>() {
+                @Override
+                protected Promise<Void> call(SensinactDigitalTwin twin, SensinactModelManager modelMgr,
+                        PromiseFactory promiseFactory) {
+                    ResourceBuilder<?, Object> builder = null;
+                    Resource resource = null;
+
+                    Model model = modelMgr.getModel(modelName);
+                    if (model == null) {
+                        builder = modelMgr.createModel(null, modelName).withService(serviceName)
+                                .withResource(resourceName);
+                    } else {
+                        Service service = model.getServices().get(serviceName);
+                        if (service == null) {
+                            builder = model.createService(serviceName).withResource(resourceName);
+                        } else {
+                            resource = service.getResources().get(resourceName);
+                            if (resource == null) {
+                                builder = service.createResource(resourceName);
+                            }
+                        }
+                    }
+
+                    if (builder != null) {
+                        // Construct the resource
+                        builderCaller.accept(builder);
+                    }
+
+                    return promiseFactory.resolved(null);
+                }
+            });
+        }
+
+        void makeValueResource(final String modelName, final String serviceName, final String resourceName,
+                Class<?> type) {
+            makeResource(modelName, serviceName, resourceName,
+                    b -> b.withType(type).withGetter().withSetter().withGetterCache(Duration.ZERO).buildAll());
+        }
+
+        void makeActionResource(final String modelName, final String serviceName, final String resourceName,
+                Class<?> resultType, List<Entry<String, Class<?>>> params) {
+            makeResource(modelName, serviceName, resourceName,
+                    b -> b.withAction(params).withType(resultType).buildAll());
+        }
+
+        @Test
+        void testReadOnly() throws Throwable {
+            WhiteboardGet<Integer> getHandler = (pf, modelPackageUri, model, provider, service, resource, resourceType,
+                    cachedValue) -> pf.resolved(new TimedValueImpl<>(42));
+
+            final String modelName = "wbHandlerROTest";
+            final String svcName = "svc";
+            final String rcName = "rc";
+
+            // Register handler
+            thread.addWhiteboardResourceHandler(getHandler, makeProps(modelName, svcName, rcName));
+
+            // Create model
+            makeValueResource(modelName, svcName, rcName, Integer.class);
+
+            // Create providers
+            createProviders(modelName, svcName);
+
+            TimedValue<Integer> result = getValue(PROVIDER_A, svcName, rcName, Integer.class);
+            assertNotNull(result.getValue(), "No value");
+            assertNotNull(result.getTimestamp(), "No timestamp");
+            assertEquals(42, result.getValue());
+
+            // FIXME: Change exception type
+            assertThrows(Exception.class,
+                    () -> setValue(PROVIDER_A, svcName, rcName, (r) -> r.setValue(1234, Instant.now())));
+        }
+
+        @Test
+        void testReadWrite() throws Throwable {
+            WhiteboardSet<Long> rcHandler = new WhiteboardSet<>() {
+                Long value = 42L;
+
+                @Override
+                public Promise<TimedValue<Long>> pullValue(PromiseFactory pf, String modelPackageUri, String model,
+                        String provider, String service, String resource, Class<Long> resourceType,
+                        TimedValue<Long> cachedValue) {
+                    return pf.resolved(new TimedValueImpl<Long>(value));
+                }
+
+                @Override
+                public Promise<TimedValue<Long>> pushValue(PromiseFactory pf, String modelPackageUri, String model,
+                        String provider, String service, String resource, Class<Long> resourceType,
+                        TimedValue<Long> cachedValue, TimedValue<Long> newValue) {
+                    this.value = newValue.getValue();
+                    return pf.resolved(new TimedValueImpl<Long>(value));
+                }
+            };
+
+            final String modelName = "wbHandlerRWTest";
+            final String svcName = "svc";
+            final String rcName = "rc";
+
+            // This time, prepare the provider before registering the handler
+            makeValueResource(modelName, svcName, rcName, Long.class);
+            createProviders(modelName, svcName);
+
+            thread.addWhiteboardResourceHandler(rcHandler, makeProps(modelName, svcName, rcName));
+
+            TimedValue<Long> result = getValue(PROVIDER_A, svcName, rcName, Long.class);
+            assertNotNull(result.getValue(), "No value");
+            assertNotNull(result.getTimestamp(), "No timestamp");
+            assertEquals(42L, result.getValue());
+
+            setValue(PROVIDER_A, svcName, rcName, (r) -> r.setValue(1234L, Instant.now()));
+            result = getValue(PROVIDER_A, svcName, rcName, Long.class);
+            assertNotNull(result.getValue(), "No value");
+            assertNotNull(result.getTimestamp(), "No timestamp");
+            assertEquals(1234L, result.getValue());
+
+            setValue(PROVIDER_A, svcName, rcName, (r) -> r.setValue(null, Instant.now()));
+            result = getValue(PROVIDER_A, svcName, rcName, Long.class);
+            assertNull(result.getValue(), "Value still there");
+            assertNotNull(result.getTimestamp(), "No timestamp");
+        }
+
+        @Test
+        void testActEcho() throws Throwable {
+            WhiteboardAct<String> providerEchoHandler = (promiseFactory, modelPackageUri, model, provider, service,
+                    resource, arguments) -> promiseFactory.resolved(provider);
+
+            final String modelName = "wbHandlerActTest";
+            final String svcName = "svc";
+            final String rcName = "rc";
+            thread.addWhiteboardResourceHandler(providerEchoHandler, makeProps(modelName, svcName, rcName));
+
+            makeActionResource(modelName, svcName, rcName, String.class, List.of());
+            createProviders(modelName, svcName);
+
+            // Test action
+            assertEquals(PROVIDER_A, act(PROVIDER_A, svcName, rcName, Map.of()));
+            assertEquals(PROVIDER_B, act(PROVIDER_B, svcName, rcName, Map.of()));
+
+            // Other kinds of access must fail
+            assertThrows(IllegalArgumentException.class, () -> getValue(PROVIDER_A, svcName, rcName, String.class));
+            assertThrows(IllegalArgumentException.class,
+                    () -> setValue(PROVIDER_A, svcName, rcName, (r) -> r.setValue(1234, Instant.now())));
+        }
+
+        @Test
+        void testActArgs() throws Throwable {
+            WhiteboardAct<Integer> providerEchoHandler = (pf, modelPackageUri, model, provider, service, resource,
+                    arguments) -> {
+                String value = (String) arguments.get("value");
+                if (value == null) {
+                    return pf.failed(new NullPointerException("No value given"));
+                }
+
+                Integer radix = (Integer) arguments.get("radix");
+                if (radix == null) {
+                    radix = 10;
+                }
+                return pf.resolved(Integer.parseInt(value, radix));
+            };
+
+            final String modelName = "wbHandlerActTest2";
+            final String svcName = "svc";
+            final String rcName = "rc";
+            thread.addWhiteboardResourceHandler(providerEchoHandler, makeProps(modelName, svcName, rcName));
+
+            makeActionResource(modelName, svcName, rcName, Integer.class,
+                    List.of(Map.entry("value", String.class), Map.entry("radix", Integer.class)));
+            createProviders(modelName, svcName);
+
+            // Test action
+            assertEquals(10, act(PROVIDER_A, svcName, rcName, Map.of("value", "10")));
+            assertEquals(10, act(PROVIDER_A, svcName, rcName, Map.of("value", "10", "radix", 10)));
+            assertEquals(2, act(PROVIDER_A, svcName, rcName, Map.of("value", "10", "radix", 2)));
+            assertEquals(255, act(PROVIDER_A, svcName, rcName, Map.of("value", "FF", "radix", 16)));
+
+            // Test errors
+            assertThrows(NullPointerException.class, () -> act(PROVIDER_A, svcName, rcName, Map.of()));
+            assertThrows(NullPointerException.class, () -> act(PROVIDER_A, svcName, rcName, Map.of("value", null)));
+
+            // Other kinds of access must fail
+            assertThrows(IllegalArgumentException.class, () -> getValue(PROVIDER_A, svcName, rcName, String.class));
+            assertThrows(IllegalArgumentException.class,
+                    () -> setValue(PROVIDER_A, svcName, rcName, (r) -> r.setValue(1234, Instant.now())));
         }
     }
 }


### PR DESCRIPTION
This PR adds support for new resources handling whiteboard services that doesn't rely on method annotations.
This eases the creation of resources and handlers on-the-go.

The existing whiteboard API with annotated methods hasn't been modified.