### PR TITLE
Allow default resource metadata to be set in the model

### DIFF
--- a/core/api/src/main/java/org/eclipse/sensinact/core/model/Resource.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/model/Resource.java
@@ -53,4 +53,10 @@ public interface Resource extends Modelled, CommandScoped {
 
     Service getService();
 
+    /**
+     * The Map of default metadata which is set for all resource instances
+     * @return
+     */
+    Map<String, Object> getDefaultMetadata();
+
 }

--- a/core/api/src/main/java/org/eclipse/sensinact/core/model/ResourceBuilder.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/model/ResourceBuilder.java
@@ -15,6 +15,7 @@ package org.eclipse.sensinact.core.model;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -53,6 +54,13 @@ public interface ResourceBuilder<B, T> {
      * @return
      */
     <U extends T> ResourceBuilder<B, U> withInitialValue(U initialValue, Instant timestamp);
+
+    /**
+     * Default metadata that should be provided by the model for this resource
+     * @param defaultMetadata
+     * @return
+     */
+    ResourceBuilder<B, T> withDefaultMetadata(Map<String, Object> defaultMetadata);
 
     /**
      * The type of the value - must be consistent with the built model, e.g. if

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/impl/snapshot/ResourceSnapshotImpl.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/impl/snapshot/ResourceSnapshotImpl.java
@@ -23,6 +23,7 @@ import org.eclipse.sensinact.core.model.ValueType;
 import org.eclipse.sensinact.core.snapshot.ProviderSnapshot;
 import org.eclipse.sensinact.core.snapshot.ResourceSnapshot;
 import org.eclipse.sensinact.core.twin.TimedValue;
+import org.eclipse.sensinact.model.core.metadata.MetadataFactory;
 import org.eclipse.sensinact.model.core.provider.Metadata;
 import org.eclipse.sensinact.model.core.provider.Service;
 import org.eclipse.sensinact.core.model.impl.ResourceImpl;
@@ -77,15 +78,17 @@ public class ResourceSnapshotImpl extends AbstractSnapshot implements ResourceSn
         this.valueType = ValueType.UPDATABLE;
 
         Service modelService = parent.getModelService();
-        final Metadata rcMetadata = modelService == null ? null : modelService.getMetadata().get(rcFeature);
+        Metadata rcMetadata = modelService == null ? null : modelService.getMetadata().get(rcFeature);
         if (rcMetadata == null) {
-            this.metadata = Map.of();
-        } else {
-            final Map<String, Object> rcMeta = new HashMap<>();
-            rcMeta.putAll(EMFUtil.toMetadataAttributesToMap(rcMetadata, rcFeature));
-            this.metadata = rcMeta;
+            rcMetadata = MetadataFactory.eINSTANCE.createResourceMetadata();
+            if(rcFeature instanceof Metadata) {
+                rcMetadata.getExtra().addAll(((Metadata)rcFeature).getExtra());
+            }
         }
-    }
+        final Map<String, Object> rcMeta = new HashMap<>();
+        rcMeta.putAll(EMFUtil.toMetadataAttributesToMap(rcMetadata, rcFeature));
+        this.metadata = rcMeta;
+}
 
     @Override
     public String toString() {

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/model/impl/ResourceBuilderImpl.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/model/impl/ResourceBuilderImpl.java
@@ -15,6 +15,7 @@ package org.eclipse.sensinact.core.model.impl;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -33,6 +34,7 @@ public class ResourceBuilderImpl<R, T> extends NestableBuilderImpl<R, ServiceImp
     private Class<?> type;
     private Object initialValue;
     private Instant timestamp;
+    private Map<String, Object> defaultMetadata;
     private ResourceType resourceType = null;
     private List<Entry<String, Class<?>>> namedParameterTypes;
     private boolean hasGetter;
@@ -81,6 +83,13 @@ public class ResourceBuilderImpl<R, T> extends NestableBuilderImpl<R, ServiceImp
         this.initialValue = initialValue;
         this.timestamp = timestamp;
         return (ResourceBuilder<R, U>) this;
+    }
+
+    @Override
+    public ResourceBuilder<R, T> withDefaultMetadata(Map<String, Object> defaultMetadata) {
+        checkValid();
+        this.defaultMetadata = Map.copyOf(defaultMetadata);
+        return this;
     }
 
     @Override
@@ -171,11 +180,11 @@ public class ResourceBuilderImpl<R, T> extends NestableBuilderImpl<R, ServiceImp
         switch (resourceType) {
         case ACTION:
             createResource = nexusImpl.createActionResource(builtParent.getServiceEClass(), name, type,
-                    namedParameterTypes);
+                    namedParameterTypes, defaultMetadata);
             break;
         case SENSOR:
             createResource = nexusImpl.createResource(builtParent.getServiceEClass(), name, type, timestamp,
-                    initialValue, hasGetter, getterCacheMs, hasSetter);
+                    initialValue, defaultMetadata, hasGetter, getterCacheMs, hasSetter);
             break;
         case PROPERTY:
         case STATE_VARIABLE:

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/model/impl/ResourceImpl.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/model/impl/ResourceImpl.java
@@ -25,7 +25,10 @@ import org.eclipse.sensinact.core.model.Resource;
 import org.eclipse.sensinact.core.model.ResourceType;
 import org.eclipse.sensinact.core.model.Service;
 import org.eclipse.sensinact.core.model.ValueType;
+import org.eclipse.sensinact.core.model.nexus.emf.EMFUtil;
+import org.eclipse.sensinact.model.core.metadata.NexusMetadata;
 import org.eclipse.sensinact.model.core.metadata.ResourceAttribute;
+import org.eclipse.sensinact.model.core.provider.Metadata;
 
 public class ResourceImpl extends CommandScopedImpl implements Resource {
 
@@ -117,6 +120,14 @@ public class ResourceImpl extends CommandScopedImpl implements Resource {
         // Check the metadata, Sensor if no info
         if (feature instanceof ResourceAttribute) {
             return ValueType.valueOf(((ResourceAttribute) feature).getValueType().getName());
+        }
+        throw new UnsupportedOperationException("Handling of none Sensinact Atributes not implemented yet");
+    }
+
+    @Override
+    public Map<String, Object> getDefaultMetadata() {
+        if(feature instanceof Metadata) {
+            return EMFUtil.toMetadataAttributesToMap((Metadata) feature, feature);
         }
         throw new UnsupportedOperationException("Handling of none Sensinact Atributes not implemented yet");
     }

--- a/core/impl/src/test/java/org/eclipse/sensinact/core/model/impl/ModelBuildingTest.java
+++ b/core/impl/src/test/java/org/eclipse/sensinact/core/model/impl/ModelBuildingTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.AbstractMap.SimpleEntry;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 
 import org.eclipse.emf.ecore.resource.ResourceSet;
@@ -165,6 +166,46 @@ public class ModelBuildingTest {
             assertFalse(nexus.getModel(packageUri, name).isPresent());
 
             assertThrows(IllegalStateException.class, () -> model.getPackageUri());
+        }
+
+        @Test
+        void resourceWithDefaultMetadata() {
+            Model model = manager.createModel(TEST_MODEL).withService(TEST_SERVICE).withResource(TEST_RESOURCE)
+                    .withType(Integer.class).withDefaultMetadata(Map.of("foo", "bar", "foobar", 42)).build().build().build();
+
+            Resource resource = model.getServices().get(TEST_SERVICE).getResources().get(TEST_RESOURCE);
+
+            assertEquals(TEST_RESOURCE, resource.getName());
+            assertEquals(Integer.class, resource.getType());
+            assertEquals(ResourceType.SENSOR, resource.getResourceType());
+
+            Map<String, Object> metadata = resource.getDefaultMetadata();
+
+            assertNotNull(metadata);
+            assertEquals("bar", metadata.get("foo"));
+            assertEquals(42, metadata.get("foobar"));
+        }
+
+        @Test
+        void actionWithDefaultMetadata() {
+            List<Entry<String, Class<?>>> parameters = List.of(new SimpleEntry<>("foo", Double.class),
+                    new SimpleEntry<>("bar", Long.class));
+            Model model = manager.createModel(TEST_MODEL).withService(TEST_SERVICE).withResource(TEST_RESOURCE)
+                    .withType(Integer.class).withAction(parameters)
+                    .withDefaultMetadata(Map.of("foo", "bar", "foobar", 42)).build().build().build();
+
+            Resource resource = model.getServices().get(TEST_SERVICE).getResources().get(TEST_RESOURCE);
+
+            assertEquals(TEST_RESOURCE, resource.getName());
+            assertEquals(Integer.class, resource.getType());
+            assertEquals(ResourceType.ACTION, resource.getResourceType());
+            assertEquals(parameters, resource.getArguments());
+
+            Map<String, Object> metadata = resource.getDefaultMetadata();
+
+            assertNotNull(metadata);
+            assertEquals("bar", metadata.get("foo"));
+            assertEquals(42, metadata.get("foobar"));
         }
     }
 }

--- a/core/models/metadata/src/main/resources/model/metadata.ecore
+++ b/core/models/metadata/src/main/resources/model/metadata.ecore
@@ -5,7 +5,7 @@
   <eAnnotations source="http://www.eclipse.org/OCL/Import">
     <details key="ecore" value="http://www.eclipse.org/emf/2002/Ecore"/>
   </eAnnotations>
-  <eClassifiers xsi:type="ecore:EClass" name="NexusMetadata" abstract="true" eSuperTypes="../../../../../org.eclipse.sensinact.gateway.core.models.provider/src/main/resources/model/sensinact.ecore#//Metadata">
+  <eClassifiers xsi:type="ecore:EClass" name="NexusMetadata" abstract="true" eSuperTypes="../../../../../provider/src/main/resources/model/sensinact.ecore#//Metadata">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="locked" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"
         defaultValueLiteral="false" unsettable="true"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="originalName" lowerBound="1"
@@ -13,9 +13,9 @@
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="AnnotationMetadata" eSuperTypes="#//NexusMetadata"/>
   <eClassifiers xsi:type="ecore:EClass" name="ResourceAttribute" eSuperTypes="http://www.eclipse.org/emf/2002/Ecore#//EAttribute #//NexusMetadata">
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="resourceType" eType="ecore:EEnum ../../../../../org.eclipse.sensinact.gateway.core.models.provider/src/main/resources/model/sensinact.ecore#//ResourceType"
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="resourceType" eType="ecore:EEnum ../../../../../provider/src/main/resources/model/sensinact.ecore#//ResourceType"
         defaultValueLiteral="SENSOR"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="valueType" eType="ecore:EEnum ../../../../../org.eclipse.sensinact.gateway.core.models.provider/src/main/resources/model/sensinact.ecore#//ValueType"
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="valueType" eType="ecore:EEnum ../../../../../provider/src/main/resources/model/sensinact.ecore#//ValueType"
         defaultValueLiteral="MODIFIABLE"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="externalGet" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="externalGetCacheMs" eType="ecore:EDataType ../../../../../org.eclipse.emf.ecore/model/Ecore.ecore#//ELong"
@@ -30,7 +30,7 @@
   <eClassifiers xsi:type="ecore:EClass" name="ServiceReference" eSuperTypes="http://www.eclipse.org/emf/2002/Ecore#//EReference #//NexusMetadata"/>
   <eClassifiers xsi:type="ecore:EClass" name="Action" eSuperTypes="http://www.eclipse.org/emf/2002/Ecore#//EOperation #//NexusMetadata"/>
   <eClassifiers xsi:type="ecore:EClass" name="ActionParameter" eSuperTypes="http://www.eclipse.org/emf/2002/Ecore#//EParameter">
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="timestamp" eType="ecore:EDataType ../../../../../org.eclipse.sensinact.gateway.core.models.provider/src/main/resources/model/sensinact.ecore#//EInstant"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="timestamp" eType="ecore:EDataType ../../../../../provider/src/main/resources/model/sensinact.ecore#//EInstant"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="ResourceMetadata" eSuperTypes="#//NexusMetadata"/>
   <eClassifiers xsi:type="ecore:EClass" name="ActionMetadata" eSuperTypes="#//NexusMetadata"/>

--- a/core/models/metadata/src/main/resources/model/metadata.genmodel
+++ b/core/models/metadata/src/main/resources/model/metadata.genmodel
@@ -4,7 +4,7 @@
     modelDirectory="/org.eclipse.sensinact.core.model/src/main/java" modelPluginID="org.eclipse.sensinact.core.model"
     modelName="sensinact" rootExtendsClass="org.eclipse.emf.ecore.impl.MinimalEObjectImpl$Container$Dynamic$Permissive"
     importerID="org.eclipse.emf.importer.ecore" complianceLevel="11.0" suppressGenModelAnnotations="false"
-    copyrightFields="false" usedGenPackages="../../../../../org.eclipse.emf.ecore/model/Ecore.genmodel#//ecore ../../../../../org.eclipse.sensinact.gateway.core.models.provider/src/main/resources/model/sensinact.genmodel#//provider"
+    copyrightFields="false" usedGenPackages="../../../../../org.eclipse.emf.ecore/model/Ecore.genmodel#//ecore ../../../../../provider/src/main/resources/model/sensinact.genmodel#//provider"
     operationReflection="true" importOrganizing="true" oSGiCompatible="true">
   <foreignModel>metadata.ecore</foreignModel>
   <genPackages prefix="Metadata" basePackage="org.eclipse.sensinact.model.core" disposableProviderFactory="true"


### PR DESCRIPTION
Provider instances have the ability to independently set metadata values, however in most cases metadata is common to all instances of a model and it is relatively static. It therefore makes sense to be able to define default metadata at the resource model level which is applied to the instance when it is first created.

Note that only the Extra metadata is used to populate the defaults. This prevents other data about the resource (e.g. the resource type and value type) from being added and bloating the metadata. To differentiate default metadata values from metadata values which are set later the default metadata values will have no associated timestamp. This is in line with the behaviour for default resource values.