### PR TITLE
Added option to include metadata when getting resource value

### DIFF
--- a/northbound/query-handler/src/main/java/org/eclipse/sensinact/northbound/query/dto/query/QueryGetDTO.java
+++ b/northbound/query-handler/src/main/java/org/eclipse/sensinact/northbound/query/dto/query/QueryGetDTO.java
@@ -20,6 +20,11 @@ import org.eclipse.sensinact.northbound.query.api.EQueryType;
  */
 public class QueryGetDTO extends AbstractQueryDTO {
 
+    /**
+     * If set, include metadata in the result
+     */
+    public boolean includeMetadata = false;
+
     public QueryGetDTO() {
         super(EQueryType.GET);
     }

--- a/northbound/query-handler/src/main/java/org/eclipse/sensinact/northbound/query/dto/result/ResponseGetDTO.java
+++ b/northbound/query-handler/src/main/java/org/eclipse/sensinact/northbound/query/dto/result/ResponseGetDTO.java
@@ -12,6 +12,11 @@
 **********************************************************************/
 package org.eclipse.sensinact.northbound.query.dto.result;
 
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
 /**
  * Resource/metadata GET response
  */
@@ -36,4 +41,10 @@ public class ResponseGetDTO implements SubResult {
      * Resource value
      */
     public Object value;
+
+    /**
+     * Resource metadata, if requested
+     */
+    @JsonInclude(Include.NON_NULL)
+    public List<MetadataDTO> attributes;
 }

--- a/northbound/query-handler/src/main/java/org/eclipse/sensinact/northbound/query/impl/QueryHandler.java
+++ b/northbound/query-handler/src/main/java/org/eclipse/sensinact/northbound/query/impl/QueryHandler.java
@@ -270,6 +270,10 @@ public class QueryHandler implements IQueryHandler {
             result.response.type = rcDesc.value.getClass().getName();
         }
 
+        if (dto.includeMetadata) {
+            result.response.attributes = generateMetadataDescriptions(rcDesc.metadata);
+        }
+
         if (rcDesc.timestamp != null) {
             result.statusCode = 200;
             result.response.value = rcDesc.value;

--- a/northbound/rest/src/main/java/org/eclipse/sensinact/northbound/rest/api/IRestNorthbound.java
+++ b/northbound/rest/src/main/java/org/eclipse/sensinact/northbound/rest/api/IRestNorthbound.java
@@ -17,11 +17,13 @@ import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import org.eclipse.sensinact.northbound.query.api.AbstractResultDTO;
 import org.eclipse.sensinact.northbound.query.dto.query.WrappedAccessMethodCallParametersDTO;
 
+import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.sse.SseEventSink;
@@ -64,7 +66,8 @@ public interface IRestNorthbound {
     @Path("providers/{providerId}/services/{serviceName}/resources/{rcName}/GET")
     @GET
     AbstractResultDTO resourceGet(@PathParam("providerId") String providerId,
-            @PathParam("serviceName") String serviceName, @PathParam("rcName") String rcName);
+            @PathParam("serviceName") String serviceName, @PathParam("rcName") String rcName,
+            @QueryParam("metadata") @DefaultValue("false") boolean includeMetadata);
 
     @Path("providers/{providerId}/services/{serviceName}/resources/{rcName}/SET")
     @POST

--- a/northbound/rest/src/main/java/org/eclipse/sensinact/northbound/rest/impl/RestNorthbound.java
+++ b/northbound/rest/src/main/java/org/eclipse/sensinact/northbound/rest/impl/RestNorthbound.java
@@ -185,9 +185,11 @@ public class RestNorthbound implements IRestNorthbound {
     }
 
     @Override
-    public AbstractResultDTO resourceGet(final String providerId, final String serviceName, final String rcName) {
+    public AbstractResultDTO resourceGet(final String providerId, final String serviceName, final String rcName,
+            final boolean includeMetadata) {
         final QueryGetDTO query = new QueryGetDTO();
         query.uri = new SensinactPath(providerId, serviceName, rcName);
+        query.includeMetadata = includeMetadata;
         return handleQuery(query);
     }
 


### PR DESCRIPTION
Query handler QueryGetDTO now has an `includeMetadata` field, false by default, to include metadata with the resource value.
Metadata are provided like in the resource description, as a list in an `attributes` entry.
The `attributes` entry is null and doesn't appear in JSON serizalization if the metadata weren't requested.

Follows #431 