### PR TITLE
Allow data and metadata update de-duplication

### DIFF
--- a/core/annotation/src/main/java/org/eclipse/sensinact/core/annotation/dto/Data.java
+++ b/core/annotation/src/main/java/org/eclipse/sensinact/core/annotation/dto/Data.java
@@ -46,4 +46,12 @@ public @interface Data {
      * @return
      */
     NullAction onNull() default NullAction.IGNORE;
+
+    /**
+     * The action to take if the current value is the same as the new value.
+     * The default is to always update, even if the value has not changed.
+     *
+     * @return
+     */
+    DuplicateAction onDuplicate() default DuplicateAction.UPDATE_ALWAYS;
 }

--- a/core/annotation/src/main/java/org/eclipse/sensinact/core/annotation/dto/DuplicateAction.java
+++ b/core/annotation/src/main/java/org/eclipse/sensinact/core/annotation/dto/DuplicateAction.java
@@ -1,0 +1,32 @@
+/*********************************************************************
+* Copyright (c) 2024 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Kentyou - initial implementation
+**********************************************************************/
+package org.eclipse.sensinact.core.annotation.dto;
+
+/**
+ * This enum defines the rules for handling duplicate values
+ */
+public enum DuplicateAction {
+    /**
+     * Update the value (or metadata value) even if the new value
+     * is the same as the old value. This will cause the timestamp
+     * associated with the value to be updated.
+     */
+    UPDATE_ALWAYS,
+    /**
+     * Update the value (or metadata value) only if the new value
+     * is different from the old value, determined by equality.
+     * If the new value is the same as the old value then no
+     * update will be made and no timestamp change will occur.
+     */
+    UPDATE_IF_DIFFERENT
+}

--- a/core/annotation/src/main/java/org/eclipse/sensinact/core/annotation/dto/Metadata.java
+++ b/core/annotation/src/main/java/org/eclipse/sensinact/core/annotation/dto/Metadata.java
@@ -54,4 +54,12 @@ public @interface Metadata {
      * @return
      */
     MapAction[] onMap() default {};
+
+    /**
+     * The action to take if the current value is the same as the new value.
+     * The default is to only update if the value has changed
+     *
+     * @return
+     */
+    DuplicateAction onDuplicate() default DuplicateAction.UPDATE_IF_DIFFERENT;
 }

--- a/core/annotation/src/main/java/org/eclipse/sensinact/core/annotation/dto/Provider.java
+++ b/core/annotation/src/main/java/org/eclipse/sensinact/core/annotation/dto/Provider.java
@@ -13,6 +13,7 @@
 package org.eclipse.sensinact.core.annotation.dto;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -46,6 +47,7 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.TYPE, ElementType.FIELD })
+@Inherited
 public @interface Provider {
     /**
      * The name of the provider

--- a/core/annotation/src/main/java/org/eclipse/sensinact/core/annotation/dto/Resource.java
+++ b/core/annotation/src/main/java/org/eclipse/sensinact/core/annotation/dto/Resource.java
@@ -13,6 +13,7 @@
 package org.eclipse.sensinact.core.annotation.dto;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -47,6 +48,7 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.TYPE, ElementType.FIELD })
+@Inherited
 public @interface Resource {
     String value() default AnnotationConstants.NOT_SET;
 }

--- a/core/annotation/src/main/java/org/eclipse/sensinact/core/annotation/dto/Service.java
+++ b/core/annotation/src/main/java/org/eclipse/sensinact/core/annotation/dto/Service.java
@@ -13,6 +13,7 @@
 package org.eclipse.sensinact.core.annotation.dto;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -45,6 +46,7 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.TYPE, ElementType.FIELD })
+@Inherited
 public @interface Service {
     /**
      * The name of the service

--- a/core/annotation/src/main/java/org/eclipse/sensinact/core/annotation/dto/Timestamp.java
+++ b/core/annotation/src/main/java/org/eclipse/sensinact/core/annotation/dto/Timestamp.java
@@ -16,15 +16,18 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
+import java.time.temporal.Temporal;
 
 /**
- * Marks a field as containing a timestamp. The field must be convertible to a
- * long, and will be interpreted based on the epoch.
- *
- * If the annotated field is <code>null</code> then the current system time will
- * be used when setting the data
- *
+ * Marks a field as containing a timestamp. The field must either be:
+ * <ul>
+ *  <li>A {@link Number} convertible to a long, which will be interpreted based on the epoch and {@link #value()}</li>
+ *  <li>A {@link Temporal} type indicating a Date/Time, assumed to be UTC if no offset is provided</li>
+ *  <li>A {@link String} parseable to a long, or with {@link DateTimeFormatter#ISO_DATE_TIME}.</li>
+ *  <li><code>null</code> meaning that the current system time will be used when setting the data</li>
+ * </ul>
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)

--- a/core/api/src/main/java/org/eclipse/sensinact/core/push/dto/GenericDto.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/push/dto/GenericDto.java
@@ -14,6 +14,7 @@ package org.eclipse.sensinact.core.push.dto;
 
 import java.time.Instant;
 
+import org.eclipse.sensinact.core.annotation.dto.DuplicateAction;
 import org.eclipse.sensinact.core.annotation.dto.NullAction;
 
 /**
@@ -38,4 +39,14 @@ public final class GenericDto extends BaseValueDto {
      * Action to apply if value is null
      */
     public NullAction nullAction = NullAction.IGNORE;
+
+    /**
+     * Action to apply if value is the same as the current resource value
+     */
+    public DuplicateAction duplicateDataAction = DuplicateAction.UPDATE_ALWAYS;
+
+    /**
+     * Action to apply if a metadata value is the same as the current metadata value
+     */
+    public DuplicateAction duplicateMetadataAction = DuplicateAction.UPDATE_IF_DIFFERENT;
 }

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/dto/impl/AbstractUpdateDto.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/dto/impl/AbstractUpdateDto.java
@@ -16,6 +16,7 @@ import java.time.Instant;
 
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EReference;
+import org.eclipse.sensinact.core.annotation.dto.DuplicateAction;
 import org.eclipse.sensinact.core.annotation.dto.NullAction;
 import org.eclipse.sensinact.model.core.provider.Provider;
 
@@ -73,4 +74,9 @@ public abstract class AbstractUpdateDto {
      * The action to take on a null update
      */
     public NullAction actionOnNull;
+
+    /**
+     * The action to take when the new value is a duplicate of the old value
+     */
+    public DuplicateAction actionOnDuplicate;
 }

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/extract/impl/AnnotationMapping.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/extract/impl/AnnotationMapping.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.time.temporal.Temporal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -143,6 +144,8 @@ public class AnnotationMapping {
                     return Long.parseLong(t.toString());
                 if (t instanceof Number)
                     return ((Number) t).longValue();
+                if (t instanceof Temporal)
+                    return unit.between(Instant.EPOCH, (Temporal) t);
                 throw new IllegalArgumentException("Unable to read timestamp " + t + " from " + fieldName);
             };
 
@@ -182,6 +185,8 @@ public class AnnotationMapping {
             } else {
                 dto.actionOnNull = data.onNull();
             }
+
+            dto.actionOnDuplicate = data.onDuplicate();
 
             try {
                 dto.modelPackageUri = modelPackageUri.apply(o);
@@ -291,6 +296,8 @@ public class AnnotationMapping {
             } else {
                 dto.actionOnNull = metadata.onNull();
             }
+
+            dto.actionOnDuplicate = metadata.onDuplicate();
 
             String key = NOT_SET.equals(metadata.value()) ? fieldName : metadata.value();
 

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/extract/impl/AnnotationMapping.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/extract/impl/AnnotationMapping.java
@@ -19,6 +19,7 @@ import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.Temporal;
 import java.util.ArrayList;
@@ -141,7 +142,12 @@ public class AnnotationMapping {
                 if (t == null)
                     return null;
                 if (t instanceof String)
-                    return Long.parseLong(t.toString());
+                    try {
+                        return Long.valueOf(t.toString());
+                    } catch (NumberFormatException nfe) {
+                        return unit.between(Instant.EPOCH, Instant.from(
+                                DateTimeFormatter.ISO_DATE_TIME.parse(t.toString())));
+                    }
                 if (t instanceof Number)
                     return ((Number) t).longValue();
                 if (t instanceof Temporal)

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/extract/impl/GenericDtoDataExtractor.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/extract/impl/GenericDtoDataExtractor.java
@@ -62,6 +62,7 @@ public class GenericDtoDataExtractor implements DataExtractor {
             if (dto.type != null)
                 dud.type = dto.type;
             dud.data = dto.value;
+            dud.actionOnDuplicate = dto.duplicateDataAction;
             list.add(dud);
         }
 
@@ -69,6 +70,7 @@ public class GenericDtoDataExtractor implements DataExtractor {
             MetadataUpdateDto dud = copyCommonFields(dto, instant, new MetadataUpdateDto());
             dud.metadata = dto.metadata;
             dud.removeNullValues = true;
+            dud.actionOnDuplicate = dto.duplicateMetadataAction;
             list.add(dud);
         }
 

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/impl/SetMetadataCommand.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/impl/SetMetadataCommand.java
@@ -15,18 +15,26 @@ package org.eclipse.sensinact.core.impl;
 import static java.util.stream.Collectors.toList;
 
 import java.util.List;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
+import org.eclipse.sensinact.core.annotation.dto.DuplicateAction;
+import org.eclipse.sensinact.core.annotation.dto.NullAction;
 import org.eclipse.sensinact.core.command.AbstractSensinactCommand;
 import org.eclipse.sensinact.core.model.SensinactModelManager;
 import org.eclipse.sensinact.core.push.DataUpdateException;
 import org.eclipse.sensinact.core.twin.SensinactDigitalTwin;
 import org.eclipse.sensinact.core.twin.SensinactResource;
+import org.eclipse.sensinact.core.twin.TimedValue;
 import org.eclipse.sensinact.core.dto.impl.MetadataUpdateDto;
 import org.osgi.util.promise.Promise;
 import org.osgi.util.promise.PromiseFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SetMetadataCommand extends AbstractSensinactCommand<Void> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SetValueCommand.class);
 
     private final MetadataUpdateDto metadataUpdateDto;
 
@@ -48,7 +56,7 @@ public class SetMetadataCommand extends AbstractSensinactCommand<Void> {
             stream = Stream.of(promiseFactory.failed(new UnsupportedOperationException("Not yet implemented")));
         } else {
             stream = metadataUpdateDto.metadata.entrySet().stream()
-                    .map(e -> resource.setMetadataValue(e.getKey(), e.getValue(), metadataUpdateDto.timestamp));
+                    .map(e -> updateMetdataValue(resource, e.getKey(), e.getValue(), metadataUpdateDto, promiseFactory));
         }
 
         List<Promise<Void>> updates = stream.map(p -> p.recoverWith(pf -> {
@@ -59,6 +67,44 @@ public class SetMetadataCommand extends AbstractSensinactCommand<Void> {
                 .collect(toList());
 
         return promiseFactory.all(updates).map(x -> null);
+    }
+
+    private Promise<Void> updateMetdataValue(SensinactResource resource, String key, Object value, MetadataUpdateDto metadataUpdateDto,
+            PromiseFactory promiseFactory) {
+
+        Function<TimedValue<Object>, Promise<Void>> cachedValueAction = null;
+        if(value == null && metadataUpdateDto.actionOnNull == NullAction.UPDATE_IF_PRESENT) {
+            cachedValueAction = v -> v.getTimestamp() == null ? promiseFactory.resolved(null) :
+                resource.setMetadataValue(key, value, metadataUpdateDto.timestamp);
+        } else if(metadataUpdateDto.actionOnDuplicate == DuplicateAction.UPDATE_IF_DIFFERENT) {
+            cachedValueAction = v -> {
+                if(v.getValue() == null) {
+                    return value == null ? promiseFactory.resolved(null) :
+                        resource.setMetadataValue(key, value, metadataUpdateDto.timestamp);
+                } else {
+                    return v.getValue().equals(value) ? promiseFactory.resolved(null) :
+                        resource.setMetadataValue(key, value, metadataUpdateDto.timestamp);
+                }
+            };
+        }
+
+        if(cachedValueAction != null) {
+            Promise<TimedValue<Object>> p = resource.getMetadataValue(key).timeout(0);
+            try {
+                Throwable t = p.getFailure();
+                if(t != null) {
+                    LOG.error("Unable to retrieve cached value for {}/{}/{}", metadataUpdateDto.provider,
+                            metadataUpdateDto.service, metadataUpdateDto.resource, t);
+                    return promiseFactory.failed(t);
+                } else {
+                    return cachedValueAction.apply(p.getValue());
+                }
+            } catch (Exception e) {
+                return promiseFactory.failed(e);
+            }
+        } else {
+            return resource.setMetadataValue(key, value, metadataUpdateDto.timestamp);
+        }
     }
 
 }

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/model/nexus/ModelNexus.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/model/nexus/ModelNexus.java
@@ -720,6 +720,10 @@ public class ModelNexus {
                     return new TimedValueImpl<Object>(entry.getValue(), entry.getTimestamp());
                 }
             }
+            // If the resource exists but has no metadata for that key then return an
+            // empty timed value indicating that the resource exists but the metadata
+            // is not set
+            return new TimedValueImpl<Object>(null, null);
         }
         return null;
     }

--- a/core/impl/src/test/java/org/eclipse/sensinact/core/extract/impl/AnnotationBasedDtoExtractorTest.java
+++ b/core/impl/src/test/java/org/eclipse/sensinact/core/extract/impl/AnnotationBasedDtoExtractorTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.sensinact.core.annotation.dto.Data;
+import org.eclipse.sensinact.core.annotation.dto.DuplicateAction;
 import org.eclipse.sensinact.core.annotation.dto.Metadata;
 import org.eclipse.sensinact.core.annotation.dto.Model;
 import org.eclipse.sensinact.core.annotation.dto.ModelPackageUri;
@@ -87,7 +88,7 @@ public class AnnotationBasedDtoExtractorTest {
         @Metadata
         public String units;
 
-        @Metadata(value = METADATA_KEY, onNull = NullAction.UPDATE)
+        @Metadata(value = METADATA_KEY, onNull = NullAction.UPDATE, onDuplicate = DuplicateAction.UPDATE_ALWAYS)
         public String fizzbuzz;
     }
 
@@ -108,7 +109,7 @@ public class AnnotationBasedDtoExtractorTest {
         public Integer foo;
 
         @Resource(RESOURCE_2)
-        @Data
+        @Data(onDuplicate = DuplicateAction.UPDATE_IF_DIFFERENT)
         public String bar;
 
         @Resource(RESOURCE)
@@ -116,7 +117,7 @@ public class AnnotationBasedDtoExtractorTest {
         public String units;
 
         @Resource(RESOURCE_2)
-        @Metadata(METADATA_KEY)
+        @Metadata(value = METADATA_KEY, onDuplicate = DuplicateAction.UPDATE_ALWAYS)
         public String fizzbuzz;
     }
 
@@ -124,7 +125,7 @@ public class AnnotationBasedDtoExtractorTest {
         @Data
         public Integer foo;
 
-        @Data
+        @Data(onDuplicate = DuplicateAction.UPDATE_IF_DIFFERENT)
         public String bar;
     }
 
@@ -200,6 +201,7 @@ public class AnnotationBasedDtoExtractorTest {
 
             assertEquals(VALUE, dud.data);
             assertEquals(Integer.class, dud.type);
+            assertEquals(DuplicateAction.UPDATE_ALWAYS, dud.actionOnDuplicate);
 
             extracted = updates.stream().filter(MetadataUpdateDto.class::isInstance).findFirst().get();
 
@@ -211,6 +213,7 @@ public class AnnotationBasedDtoExtractorTest {
             assertEquals(singletonMap(METADATA_KEY, null), dud2.metadata);
             assertFalse(dud2.removeNullValues, "Null values should be removed");
             assertFalse(dud2.removeMissingValues, "Missing values should be kept");
+            assertEquals(DuplicateAction.UPDATE_ALWAYS, dud2.actionOnDuplicate);
         }
 
         @Test
@@ -235,6 +238,7 @@ public class AnnotationBasedDtoExtractorTest {
 
             assertEquals(VALUE, dud.data);
             assertEquals(Integer.class, dud.type);
+            assertEquals(DuplicateAction.UPDATE_ALWAYS, dud.actionOnDuplicate);
 
             extracted = updates.stream().filter(MetadataUpdateDto.class::isInstance)
                     .filter(d -> ((MetadataUpdateDto) d).metadata.containsKey(METADATA_KEY)).findFirst().get();
@@ -247,6 +251,7 @@ public class AnnotationBasedDtoExtractorTest {
             assertEquals(singletonMap(METADATA_KEY, METADATA_VALUE), dud2.metadata);
             assertFalse(dud2.removeNullValues, "Null values should be removed");
             assertFalse(dud2.removeMissingValues, "Missing values should be kept");
+            assertEquals(DuplicateAction.UPDATE_ALWAYS, dud2.actionOnDuplicate);
 
             extracted = updates.stream().filter(MetadataUpdateDto.class::isInstance)
                     .filter(d -> ((MetadataUpdateDto) d).metadata.containsKey("units")).findFirst().get();
@@ -259,6 +264,7 @@ public class AnnotationBasedDtoExtractorTest {
             assertEquals(singletonMap("units", METADATA_VALUE_2), dud2.metadata);
             assertFalse(dud2.removeNullValues, "Null values should be removed");
             assertFalse(dud2.removeMissingValues, "Missing values should be kept");
+            assertEquals(DuplicateAction.UPDATE_IF_DIFFERENT, dud2.actionOnDuplicate);
         }
     }
 
@@ -293,6 +299,7 @@ public class AnnotationBasedDtoExtractorTest {
 
             assertEquals(VALUE, dud.data);
             assertEquals(Integer.class, dud.type);
+            assertEquals(DuplicateAction.UPDATE_ALWAYS, dud.actionOnDuplicate);
         }
 
         @Test
@@ -324,6 +331,7 @@ public class AnnotationBasedDtoExtractorTest {
 
             assertEquals(VALUE, dud.data);
             assertEquals(Integer.class, dud.type);
+            assertEquals(DuplicateAction.UPDATE_ALWAYS, dud.actionOnDuplicate);
 
             extracted = updates.stream().filter(DataUpdateDto.class::isInstance)
                     .filter(d -> RESOURCE_2.equals(d.resource)).findFirst().get();
@@ -336,6 +344,7 @@ public class AnnotationBasedDtoExtractorTest {
 
             assertEquals(VALUE_2, dud.data);
             assertEquals(String.class, dud.type);
+            assertEquals(DuplicateAction.UPDATE_IF_DIFFERENT, dud.actionOnDuplicate);
 
             extracted = updates.stream().filter(MetadataUpdateDto.class::isInstance)
                     .filter(d -> ((MetadataUpdateDto) d).metadata.containsKey(METADATA_KEY)).findFirst().get();
@@ -348,6 +357,7 @@ public class AnnotationBasedDtoExtractorTest {
             assertEquals(singletonMap(METADATA_KEY, METADATA_VALUE), dud2.metadata);
             assertFalse(dud2.removeNullValues, "Null values should be removed");
             assertFalse(dud2.removeMissingValues, "Missing values should be kept");
+            assertEquals(DuplicateAction.UPDATE_ALWAYS, dud2.actionOnDuplicate);
 
             extracted = updates.stream().filter(MetadataUpdateDto.class::isInstance)
                     .filter(d -> ((MetadataUpdateDto) d).metadata.containsKey("units")).findFirst().get();
@@ -360,6 +370,7 @@ public class AnnotationBasedDtoExtractorTest {
             assertEquals(singletonMap("units", METADATA_VALUE_2), dud2.metadata);
             assertFalse(dud2.removeNullValues, "Null values should be removed");
             assertFalse(dud2.removeMissingValues, "Missing values should be kept");
+            assertEquals(DuplicateAction.UPDATE_IF_DIFFERENT, dud2.actionOnDuplicate);
         }
     }
 
@@ -394,6 +405,7 @@ public class AnnotationBasedDtoExtractorTest {
 
             assertEquals(VALUE, dud.data);
             assertEquals(Integer.class, dud.type);
+            assertEquals(DuplicateAction.UPDATE_ALWAYS, dud.actionOnDuplicate);
         }
 
         @Test
@@ -423,6 +435,7 @@ public class AnnotationBasedDtoExtractorTest {
 
             assertEquals(VALUE, dud.data);
             assertEquals(Integer.class, dud.type);
+            assertEquals(DuplicateAction.UPDATE_ALWAYS, dud.actionOnDuplicate);
 
             extracted = updates.stream().filter(DataUpdateDto.class::isInstance).filter(d -> "bar".equals(d.resource))
                     .findFirst().get();
@@ -435,6 +448,7 @@ public class AnnotationBasedDtoExtractorTest {
 
             assertEquals(VALUE_2, dud.data);
             assertEquals(String.class, dud.type);
+            assertEquals(DuplicateAction.UPDATE_IF_DIFFERENT, dud.actionOnDuplicate);
         }
     }
 

--- a/core/impl/src/test/java/org/eclipse/sensinact/core/extract/impl/CustomBaseValueDtoExtractorTest.java
+++ b/core/impl/src/test/java/org/eclipse/sensinact/core/extract/impl/CustomBaseValueDtoExtractorTest.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.sensinact.core.annotation.dto.Data;
+import org.eclipse.sensinact.core.annotation.dto.DuplicateAction;
 import org.eclipse.sensinact.core.annotation.dto.NullAction;
 import org.eclipse.sensinact.core.annotation.dto.Provider;
 import org.eclipse.sensinact.core.annotation.dto.Resource;
@@ -61,7 +62,7 @@ public class CustomBaseValueDtoExtractorTest {
         @Data
         public String foo;
 
-        @Data
+        @Data(onDuplicate = DuplicateAction.UPDATE_IF_DIFFERENT)
         public Integer bar;
     }
 
@@ -77,7 +78,7 @@ public class CustomBaseValueDtoExtractorTest {
         public Integer bar;
 
         @Resource("null")
-        @Data(onNull = NullAction.UPDATE)
+        @Data(onNull = NullAction.UPDATE, onDuplicate = DuplicateAction.UPDATE_IF_DIFFERENT)
         public String nullable;
         @Resource("null2")
         @Data(onNull = NullAction.UPDATE_IF_PRESENT)
@@ -114,6 +115,7 @@ public class CustomBaseValueDtoExtractorTest {
 
             assertEquals(VALUE_2, dud.data);
             assertEquals(String.class, dud.type);
+            assertEquals(DuplicateAction.UPDATE_ALWAYS, dud.actionOnDuplicate);
 
             extracted = updates.stream().filter(MetadataUpdateDto.class::isInstance).findFirst().get();
 
@@ -125,6 +127,7 @@ public class CustomBaseValueDtoExtractorTest {
             assertEquals(singletonMap(METADATA_KEY, METADATA_VALUE), dud2.metadata);
             assertTrue(dud2.removeNullValues, "Null values should be removed");
             assertFalse(dud2.removeMissingValues, "Missing values should be kept");
+            assertEquals(DuplicateAction.UPDATE_IF_DIFFERENT, dud2.actionOnDuplicate);
         }
     }
 
@@ -154,6 +157,7 @@ public class CustomBaseValueDtoExtractorTest {
 
             assertEquals(VALUE_2, dud.data);
             assertEquals(String.class, dud.type);
+            assertEquals(DuplicateAction.UPDATE_ALWAYS, dud.actionOnDuplicate);
 
             extracted = updates.stream().filter(MetadataUpdateDto.class::isInstance).findFirst().get();
 
@@ -165,6 +169,7 @@ public class CustomBaseValueDtoExtractorTest {
             assertEquals(singletonMap(METADATA_KEY, METADATA_VALUE), dud2.metadata);
             assertTrue(dud2.removeNullValues, "Null values should be removed");
             assertFalse(dud2.removeMissingValues, "Missing values should be kept");
+            assertEquals(DuplicateAction.UPDATE_IF_DIFFERENT, dud2.actionOnDuplicate);
         }
 
         @Test
@@ -188,6 +193,7 @@ public class CustomBaseValueDtoExtractorTest {
 
             assertEquals(VALUE, dud.data);
             assertEquals(Integer.class, dud.type);
+            assertEquals(DuplicateAction.UPDATE_IF_DIFFERENT, dud.actionOnDuplicate);
 
             extracted = updates.stream().filter(MetadataUpdateDto.class::isInstance).findFirst().get();
 
@@ -199,6 +205,7 @@ public class CustomBaseValueDtoExtractorTest {
             assertEquals(singletonMap(METADATA_KEY, METADATA_VALUE), dud2.metadata);
             assertTrue(dud2.removeNullValues, "Null values should be removed");
             assertFalse(dud2.removeMissingValues, "Missing values should be kept");
+            assertEquals(DuplicateAction.UPDATE_IF_DIFFERENT, dud2.actionOnDuplicate);
         }
 
         @Test
@@ -224,6 +231,7 @@ public class CustomBaseValueDtoExtractorTest {
 
             assertEquals(VALUE_2, dud.data);
             assertEquals(String.class, dud.type);
+            assertEquals(DuplicateAction.UPDATE_ALWAYS, dud.actionOnDuplicate);
 
             extracted = updates.stream().filter(DataUpdateDto.class::isInstance)
                     .filter(d -> Integer.class == ((DataUpdateDto) d).type).findFirst().get();
@@ -236,6 +244,7 @@ public class CustomBaseValueDtoExtractorTest {
 
             assertEquals(VALUE, dud.data);
             assertEquals(Integer.class, dud.type);
+            assertEquals(DuplicateAction.UPDATE_IF_DIFFERENT, dud.actionOnDuplicate);
 
             extracted = updates.stream().filter(MetadataUpdateDto.class::isInstance).findFirst().get();
 
@@ -247,6 +256,7 @@ public class CustomBaseValueDtoExtractorTest {
             assertEquals(singletonMap(METADATA_KEY, METADATA_VALUE), dud2.metadata);
             assertTrue(dud2.removeNullValues, "Null values should be removed");
             assertFalse(dud2.removeMissingValues, "Missing values should be kept");
+            assertEquals(DuplicateAction.UPDATE_IF_DIFFERENT, dud2.actionOnDuplicate);
         }
 
     }
@@ -282,6 +292,7 @@ public class CustomBaseValueDtoExtractorTest {
 
             assertEquals(VALUE_2, dud.data);
             assertEquals(String.class, dud.type);
+            assertEquals(DuplicateAction.UPDATE_ALWAYS, dud.actionOnDuplicate);
 
             extracted = updates.stream().filter(DataUpdateDto.class::isInstance)
                     .filter(d -> RESOURCE_2.equals(d.resource)).findFirst().get();
@@ -294,12 +305,14 @@ public class CustomBaseValueDtoExtractorTest {
 
             assertEquals(VALUE, dud.data);
             assertEquals(Long.class, dud.type);
+            assertEquals(DuplicateAction.UPDATE_ALWAYS, dud.actionOnDuplicate);
 
             extracted = updates.stream().filter(DataUpdateDto.class::isInstance).filter(d -> "null".equals(d.resource))
                     .findFirst().get();
 
             checkCommonFields(extracted, "null", time);
             assertEquals(NullAction.UPDATE, extracted.actionOnNull);
+            assertEquals(DuplicateAction.UPDATE_IF_DIFFERENT, extracted.actionOnDuplicate);
 
             assertTrue(extracted instanceof DataUpdateDto, "Not a data update dto " + extracted.getClass());
 
@@ -308,6 +321,7 @@ public class CustomBaseValueDtoExtractorTest {
 
             checkCommonFields(extracted, "null2", time);
             assertEquals(NullAction.UPDATE_IF_PRESENT, extracted.actionOnNull);
+            assertEquals(DuplicateAction.UPDATE_ALWAYS, extracted.actionOnDuplicate);
 
             assertTrue(extracted instanceof DataUpdateDto, "Not a data update dto " + extracted.getClass());
 
@@ -315,6 +329,7 @@ public class CustomBaseValueDtoExtractorTest {
 
             assertNull(dud.data);
             assertEquals(String.class, dud.type);
+            assertEquals(DuplicateAction.UPDATE_ALWAYS, dud.actionOnDuplicate);
 
             extracted = updates.stream().filter(MetadataUpdateDto.class::isInstance).findFirst().get();
 
@@ -326,6 +341,7 @@ public class CustomBaseValueDtoExtractorTest {
             assertEquals(singletonMap(METADATA_KEY, METADATA_VALUE), dud2.metadata);
             assertTrue(dud2.removeNullValues, "Null values should be removed");
             assertFalse(dud2.removeMissingValues, "Missing values should be kept");
+            assertEquals(DuplicateAction.UPDATE_IF_DIFFERENT, dud2.actionOnDuplicate);
 
         }
 

--- a/core/impl/src/test/java/org/eclipse/sensinact/core/extract/impl/GenericDtoExtractorTest.java
+++ b/core/impl/src/test/java/org/eclipse/sensinact/core/extract/impl/GenericDtoExtractorTest.java
@@ -25,6 +25,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.sensinact.core.annotation.dto.DuplicateAction;
 import org.eclipse.sensinact.core.annotation.dto.NullAction;
 import org.eclipse.sensinact.core.dto.impl.AbstractUpdateDto;
 import org.eclipse.sensinact.core.dto.impl.DataUpdateDto;
@@ -127,6 +128,8 @@ public class GenericDtoExtractorTest {
 
             assertEquals(VALUE, dud.data);
             assertNull(dud.type);
+            assertEquals(NullAction.IGNORE, dud.actionOnNull);
+            assertEquals(DuplicateAction.UPDATE_ALWAYS, dud.actionOnDuplicate);
         }
 
         @Test
@@ -147,6 +150,8 @@ public class GenericDtoExtractorTest {
 
             assertEquals(VALUE, dud.data);
             assertNull(dud.type);
+            assertEquals(NullAction.IGNORE, dud.actionOnNull);
+            assertEquals(DuplicateAction.UPDATE_ALWAYS, dud.actionOnDuplicate);
         }
 
         @Test
@@ -166,6 +171,8 @@ public class GenericDtoExtractorTest {
 
             assertEquals(VALUE, dud.data);
             assertEquals(Long.class, dud.type);
+            assertEquals(NullAction.IGNORE, dud.actionOnNull);
+            assertEquals(DuplicateAction.UPDATE_ALWAYS, dud.actionOnDuplicate);
         }
 
         @Test
@@ -185,6 +192,8 @@ public class GenericDtoExtractorTest {
 
             assertEquals(VALUE_2, dud.data);
             assertNull(dud.type);
+            assertEquals(NullAction.IGNORE, dud.actionOnNull);
+            assertEquals(DuplicateAction.UPDATE_ALWAYS, dud.actionOnDuplicate);
         }
 
         @Test
@@ -207,6 +216,29 @@ public class GenericDtoExtractorTest {
             assertEquals(VALUE_2, dud.data);
             assertNull(dud.type);
             assertEquals(NullAction.UPDATE, dud.actionOnNull);
+            assertEquals(DuplicateAction.UPDATE_ALWAYS, dud.actionOnDuplicate);
+        }
+
+        @Test
+        void duplicateAction() {
+            GenericDto testDto = makeTestDto(PROVIDER, SERVICE, RESOURCE, VALUE_2, null, null);
+            testDto.duplicateDataAction = DuplicateAction.UPDATE_IF_DIFFERENT;
+            List<? extends AbstractUpdateDto> updates = extractor()
+                    .getUpdates(testDto);
+
+            assertEquals(1, updates.size(), "Wrong number of updates " + updates.size());
+
+            AbstractUpdateDto extracted = updates.get(0);
+
+            checkCommonFields(extracted);
+
+            assertTrue(extracted instanceof DataUpdateDto, "Not a data update dto " + extracted.getClass());
+
+            DataUpdateDto dud = (DataUpdateDto) extracted;
+
+            assertEquals(VALUE_2, dud.data);
+            assertNull(dud.type);
+            assertEquals(DuplicateAction.UPDATE_IF_DIFFERENT, dud.actionOnDuplicate);
         }
     }
 
@@ -233,6 +265,7 @@ public class GenericDtoExtractorTest {
             assertEquals(singletonMap(METADATA_KEY, METADATA_VALUE), dud.metadata);
             assertTrue(dud.removeNullValues, "Null values should be removed");
             assertFalse(dud.removeMissingValues, "Missing values should be kept");
+            assertEquals(DuplicateAction.UPDATE_IF_DIFFERENT, dud.actionOnDuplicate);
         }
 
         @Test
@@ -253,6 +286,7 @@ public class GenericDtoExtractorTest {
             assertEquals(Map.of(METADATA_KEY, METADATA_VALUE, METADATA_KEY_2, METADATA_VALUE_2), dud.metadata);
             assertTrue(dud.removeNullValues, "Null values should be removed");
             assertFalse(dud.removeMissingValues, "Missing values should be kept");
+            assertEquals(DuplicateAction.UPDATE_IF_DIFFERENT, dud.actionOnDuplicate);
         }
 
         @Test
@@ -280,6 +314,31 @@ public class GenericDtoExtractorTest {
             assertTrue(dud.removeNullValues, "Null values should be removed");
             assertFalse(dud.removeMissingValues, "Missing values should be kept");
             assertEquals(NullAction.UPDATE, dud.actionOnNull);
+            assertEquals(DuplicateAction.UPDATE_IF_DIFFERENT, dud.actionOnDuplicate);
+        }
+
+        @Test
+        void duplicateValue() {
+            GenericDto testDto = makeTestDto(PROVIDER, SERVICE, RESOURCE, null, null, singletonMap(METADATA_KEY, METADATA_VALUE));
+            testDto.duplicateMetadataAction = DuplicateAction.UPDATE_ALWAYS;
+
+            List<? extends AbstractUpdateDto> updates = extractor().getUpdates(
+                    testDto);
+
+            assertEquals(1, updates.size(), "Wrong number of updates " + updates.size());
+
+            AbstractUpdateDto extracted = updates.get(0);
+
+            checkCommonFields(extracted);
+
+            assertTrue(extracted instanceof MetadataUpdateDto, "Not a metadata update dto " + extracted.getClass());
+
+            MetadataUpdateDto dud = (MetadataUpdateDto) extracted;
+
+            assertEquals(singletonMap(METADATA_KEY, METADATA_VALUE), dud.metadata);
+            assertTrue(dud.removeNullValues, "Null values should be removed");
+            assertFalse(dud.removeMissingValues, "Missing values should be kept");
+            assertEquals(DuplicateAction.UPDATE_ALWAYS, dud.actionOnDuplicate);
         }
     }
 
@@ -306,6 +365,7 @@ public class GenericDtoExtractorTest {
 
             assertEquals(VALUE, dud.data);
             assertNull(dud.type);
+            assertEquals(DuplicateAction.UPDATE_ALWAYS, dud.actionOnDuplicate);
 
             extracted = updates.stream().filter(MetadataUpdateDto.class::isInstance).findFirst().get();
 
@@ -317,6 +377,7 @@ public class GenericDtoExtractorTest {
             assertEquals(singletonMap(METADATA_KEY, METADATA_VALUE), dud2.metadata);
             assertTrue(dud2.removeNullValues, "Null values should be removed");
             assertFalse(dud2.removeMissingValues, "Missing values should be kept");
+            assertEquals(DuplicateAction.UPDATE_IF_DIFFERENT, dud2.actionOnDuplicate);
         }
 
         @Test
@@ -336,6 +397,7 @@ public class GenericDtoExtractorTest {
 
             assertEquals(VALUE, dud.data);
             assertNull(dud.type);
+            assertEquals(DuplicateAction.UPDATE_ALWAYS, dud.actionOnDuplicate);
 
             extracted = updates.stream().filter(MetadataUpdateDto.class::isInstance).findFirst().get();
 
@@ -347,6 +409,7 @@ public class GenericDtoExtractorTest {
             assertEquals(singletonMap(METADATA_KEY, METADATA_VALUE), dud2.metadata);
             assertTrue(dud2.removeNullValues, "Null values should be removed");
             assertFalse(dud2.removeMissingValues, "Missing values should be kept");
+            assertEquals(DuplicateAction.UPDATE_IF_DIFFERENT, dud2.actionOnDuplicate);
         }
     }
 
@@ -365,6 +428,9 @@ public class GenericDtoExtractorTest {
                     makeTestDto(PROVIDER_2, SERVICE_2, RESOURCE_2, VALUE_2, null,
                             singletonMap(METADATA_KEY_2, METADATA_VALUE_2)));
 
+            dto.dtos.get(1).duplicateDataAction = DuplicateAction.UPDATE_IF_DIFFERENT;
+            dto.dtos.get(1).duplicateMetadataAction = DuplicateAction.UPDATE_ALWAYS;
+
             List<? extends AbstractUpdateDto> updates = multiExtractor().getUpdates(dto);
 
             assertEquals(4, updates.size(), "Wrong number of updates " + updates.size());
@@ -380,6 +446,7 @@ public class GenericDtoExtractorTest {
 
             assertEquals(VALUE, dud.data);
             assertNull(dud.type);
+            assertEquals(DuplicateAction.UPDATE_ALWAYS, dud.actionOnDuplicate);
 
             extracted = updates.stream().filter(DataUpdateDto.class::isInstance)
                     .filter(d -> PROVIDER_2.equals(d.provider)).findFirst().get();
@@ -392,6 +459,7 @@ public class GenericDtoExtractorTest {
 
             assertEquals(VALUE_2, dud.data);
             assertNull(dud.type);
+            assertEquals(DuplicateAction.UPDATE_IF_DIFFERENT, dud.actionOnDuplicate);
 
             extracted = updates.stream().filter(MetadataUpdateDto.class::isInstance)
                     .filter(d -> PROVIDER.equals(d.provider)).findFirst().get();
@@ -404,6 +472,7 @@ public class GenericDtoExtractorTest {
             assertEquals(singletonMap(METADATA_KEY, METADATA_VALUE), dud2.metadata);
             assertTrue(dud2.removeNullValues, "Null values should be removed");
             assertFalse(dud2.removeMissingValues, "Missing values should be kept");
+            assertEquals(DuplicateAction.UPDATE_IF_DIFFERENT, dud2.actionOnDuplicate);
 
             extracted = updates.stream().filter(MetadataUpdateDto.class::isInstance)
                     .filter(d -> PROVIDER_2.equals(d.provider)).findFirst().get();
@@ -416,6 +485,7 @@ public class GenericDtoExtractorTest {
             assertEquals(singletonMap(METADATA_KEY_2, METADATA_VALUE_2), dud2.metadata);
             assertTrue(dud2.removeNullValues, "Null values should be removed");
             assertFalse(dud2.removeMissingValues, "Missing values should be kept");
+            assertEquals(DuplicateAction.UPDATE_ALWAYS, dud2.actionOnDuplicate);
         }
     }
 


### PR DESCRIPTION
This commit adds a DuplicateAction to the pushed updates, which determines the behaviour when the pushed update contains a duplicate value or metadata value. A duplicate value is determined by object equality, or == if one value is null. The default for resource values is that duplicates updates are applied, updating the timestamp and generating a update event. The default for metadata values is that duplicate updates are ignored, avoiding timestamp updates and update events. The reason for this difference is that repeated data readings can often give the same value, but this is a new reading. In general metadata values do not change, and so duplicates aren't interesting.