### PR TITLE
Fix logging of errors

### DIFF
--- a/docs/source/southbound/history/timescale.md
+++ b/docs/source/southbound/history/timescale.md
@@ -51,7 +51,7 @@ docker run --rm -d --name timescale-db -p 5432:5432 \
 The matching history provider configuration with PID `sensinact.history.timescale` could be:
 ```json
 {
-    "url": "jdbc://localhost:5432/sensinactHistory",
+    "url": "jdbc:postgresql://localhost:5432/sensinactHistory",
     "user": "snaHistory",
     ".password": "test.password",
     "provider": "history"

--- a/southbound/history/timescale-provider/src/main/java/org/eclipse/sensinact/gateway/southbound/history/timescale/TimescaleHistoricalStore.java
+++ b/southbound/history/timescale-provider/src/main/java/org/eclipse/sensinact/gateway/southbound/history/timescale/TimescaleHistoricalStore.java
@@ -97,7 +97,7 @@ public class TimescaleHistoricalStore {
             setupTables();
         } catch (Exception e) {
             if (logger.isWarnEnabled()) {
-                logger.debug("An error occurred setting up database access", e);
+                logger.warn("An error occurred setting up database access", e);
             }
             safeUnregister();
             return;


### PR DESCRIPTION
Errors (e.g. misconfiguration) during startup were only logged in the debug and were therefore not visible.