### PR TITLE
Null check to avoid NPE

### DIFF
--- a/northbound/sensorthings/rest.gateway/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/impl/DtoMapper.java
+++ b/northbound/sensorthings/rest.gateway/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/impl/DtoMapper.java
@@ -503,7 +503,10 @@ public class DtoMapper {
         TimedValue<GeoJsonObject> location = null;
         if (optRS.isPresent()) {
             ResourceSnapshot rs = optRS.get();
-            location = getLocation(mapper, rs.getValue().getValue(), rs.getValue().getTimestamp(), allowNull);
+            TimedValue<?> value = rs.getValue();
+            if(value != null) {
+                location = getLocation(mapper, value.getValue(), rs.getValue().getTimestamp(), allowNull);
+            }
         }
         if (location == null) {
             location = getLocation(provider, mapper, allowNull);


### PR DESCRIPTION
The getValue method of te ResourceSnapshot can return null, so we should handle it.